### PR TITLE
[containers/*] Set linter threshold to error

### DIFF
--- a/.vib/vib-verify.json
+++ b/.vib/vib-verify.json
@@ -22,7 +22,7 @@
         {
           "action_id": "container-image-lint",
           "params": {
-            "threshold": "warning"
+            "threshold": "error"
           }
         }
       ]


### PR DESCRIPTION
Signed-off-by: Fran Mulero <fmulero@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Set linter threshold to error

**Benefits**

Most of the failures comes from warnings in the linter action.Increasing the threshold to ERROR in the linter action will allow us put the focus in real errors and will avoid skipping trivy actions when linter finish with a warning
