### PR TITLE
Fix sync process

### DIFF
--- a/.github/workflows/vib-scheduled-verify.yaml
+++ b/.github/workflows/vib-scheduled-verify.yaml
@@ -45,6 +45,8 @@ jobs:
       matrix:
         flavor:  ${{ fromJSON(needs.get-container.outputs.flavors) }}
     steps:
+      - name: Install dependencies
+        run: pip install git-filter-repo==2.34.0
       - uses: actions/checkout@v2
         name: Checkout Repository
         with:


### PR DESCRIPTION
Signed-off-by: Fran Mulero <fmulero@vmware.com>

**Description of the change**

`bitnami/containers` repository contains all commits from each container in a plain structure (it doesn't have merge commits) Getting the list of commits in topological order helps to plain the tree ignoring the merge commits.

**Benefits**

Current sync errors with pgbouncer will be fixed

**Possible drawbacks**

Not found
