### PR TITLE
[containers/*] Fix sync issue in redis-cluster

### DIFF
--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -62,7 +62,7 @@ findCommitsToSync() {
     local -r last_commit_date="${last_commit_date_message%----*}"
     local -r last_commit_message="${last_commit_date_message#*----}"
     # Search on the container origin repo the ID for the latest commit we have locally in the container folder
-    local -r last_synced_commit_id="$(git rev-list "$origin_name"/master --since="${last_commit_date}" --grep="${last_commit_message}" | head -1)"
+    local -r last_synced_commit_id="$(git rev-list "$origin_name"/master --since="${last_commit_date}" --grep="${last_commit_message}" --no-merges --date-order --reverse | head -1)"
     local commits_to_sync=""
     local max=100 # If we need to sync more than 100 commits there must be something wrong since we run the job on a daily basis
     # Get all commits IDs on the origin


### PR DESCRIPTION
Signed-off-by: Fran Mulero <fmulero@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Get pending commits in the right order avoiding merge commits (they are not synced)

**Applicable issues**

It fix current issue with merge commits in redis-cluster