### PR TITLE
Avoid assigning reviewers for the bitnami-bot PRs

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -38,6 +38,7 @@ jobs:
           # creating env variable "on the fly"
           echo "TRIAGE_TEAM_STRING=$TRIAGE_TEAM_STRING" >> $GITHUB_ENV
       - name: Assign to a person to work on it
+        if: ${{ github.actor != 'bitnami-bot'  }}
         uses: pozil/auto-assign-issue@v1.7.3
         with:
           numOfAssignee: 1


### PR DESCRIPTION
Signed-off-by: Alejandro Gómez <morona@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Avoid assigning reviewers for the bitnami-bot PRs

### Benefits

Automated PRs will not have reviewers by default.

### Possible drawbacks

If _bitnami-bot_ opens a non automated PR, will not have a reviewer assigned.