### PR TITLE
[bitnami/*] Disable CI on closed PRs

### DIFF
--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -20,7 +20,7 @@ jobs:
     if: |
       github.event.pull_request.state != 'closed' &&
       (
-        (github.event.action == 'labeled' && github.event.label.name == 'verify) ||
+        (github.event.action == 'labeled' && github.event.label.name == 'verify') ||
         (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'verify'))
       )
     outputs:

--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -17,6 +17,12 @@ jobs:
   get-container:
     runs-on: ubuntu-latest
     name: Get modified containers
+    if: |
+      github.event.pull_request.state != 'closed' &&
+      (
+        (github.event.action == 'labeled' && github.event.label.name == 'verify) ||
+        (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'verify'))
+      )
     outputs:
       container: ${{ steps.get-container.outputs.container }}
       result: ${{ steps.get-container.outputs.result }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Disable CI in closed PRs. Also on 'labeled' events we take care only about 'verify' label

### Benefits

Don't run CI on unexpected events
