### PR TITLE
[bitnami/*] Fix wrong tag in CD pipeline

### DIFF
--- a/.github/workflows/cd-pipeline.yaml
+++ b/.github/workflows/cd-pipeline.yaml
@@ -84,7 +84,7 @@ jobs:
         name: Get image tag and container name
         run: |
           # Now EAM commits has the following format "[bitnami/<container>] Release <tag>"
-          tag="$(git log --pretty=tformat:"%s" -n 1 --grep="[R|r]elease" --author bitnami-bot@vmware.com --author containers@bitnami.com --author containers-bot@bitnami.com -- ${{ matrix.container }} | sed "s|\[.*\]||" | sed "s|\(.*\)||" | sed "s|[R|r]elease||" | awk '{print $1}')"
+          tag="$(git log --pretty=tformat:"%s" -n 1 --grep="[R|r]elease" --author bitnami-bot@vmware.com --author containers@bitnami.com --author containers-bot@bitnami.com -- ${{ matrix.container }} | sed "s|\[.*\]||" | sed "s|[R|r]elease||" | awk '{print $1}')"
           if [[ -z "${tag}" ]]; then
             echo "No tag found for: ${{ matrix.container }}"
             exit 1

--- a/.github/workflows/cd-pipeline.yaml
+++ b/.github/workflows/cd-pipeline.yaml
@@ -84,15 +84,14 @@ jobs:
         name: Get image tag and container name
         run: |
           # Now EAM commits has the following format "[bitnami/<container>] Release <tag>"
-          tag="$(git log --pretty=tformat:"%s" -n 1 --grep="[R|r]elease" --author bitnami-bot@vmware.com --author containers@bitnami.com --author containers-bot@bitnami.com -- ${{ matrix.container }} | sed "s|\[.*\]||" | sed "s|[R|r]elease||" | sed "s|[[:space:]]*||")"
+          tag="$(git log --pretty=tformat:"%s" -n 1 --grep="[R|r]elease" --author bitnami-bot@vmware.com --author containers@bitnami.com --author containers-bot@bitnami.com -- ${{ matrix.container }} | sed "s|\[.*\]||" | sed "s|\(.*\)||" | sed "s|[R|r]elease||" | awk '{print $1}')"
           if [[ -z "${tag}" ]]; then
-            echo "No tag found for: ${{ needs.get-container.outputs.path }}"
+            echo "No tag found for: ${{ matrix.container }}"
             exit 1
           else
             name="$(echo "${{ matrix.container }}" | awk -F '/' '{print $2}')"
             echo "::set-output name=tag::${tag}"
             echo "::set-output name=name::${name}"
-            echo "::set-output name=tag::${tag}"
           fi
       - uses: vmware-labs/vmware-image-builder-action@main
         name: "Publish ${{ steps.get-container-metadata.outputs.name }}: ${{ steps.get-container-metadata.outputs.tag }}"

--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -96,7 +96,7 @@ jobs:
         name: Get latest image tag
         run: |
           # Now EAM commits has the following format "[bitnami/<container>] Release <tag>"
-          tag="$(git log --pretty=tformat:"%s" -n 1 --grep="[R|r]elease" --author bitnami-bot@vmware.com --author containers@bitnami.com --author containers-bot@bitnami.com -- ${{ needs.get-container.outputs.path }} | sed "s|\[.*\]||" | sed "s|[R|r]elease||" | sed "s|[[:space:]]*||")"
+          tag="$(git log --pretty=tformat:"%s" -n 1 --grep="[R|r]elease" --author bitnami-bot@vmware.com --author containers@bitnami.com --author containers-bot@bitnami.com -- ${{ needs.get-container.outputs.path }} | sed "s|\[.*\]||" | sed "s|[R|r]elease||" | awk '{print $1}')"
           if [[ -z "${tag}" ]]; then
             echo "No tag found for: ${{ needs.get-container.outputs.path }}"
             exit 1


### PR DESCRIPTION
Signed-off-by: Fran Mulero <fmulero@vmware.com>

### Description of the change

Merge commits have the number of the PR at the end. This is causing a failure in CD pipeline because the package tag has this format `<app-version>-<os>-<release> (<PR number>)`

### Benefits

### Possible drawbacks

### Applicable issues

 https://github.com/bitnami/containers/runs/7499788374?check_suite_focus=true#step:4:33

