### PR TITLE
[bitnami/*] Use bitnami-bot to enable auto-merge in automated PRs

### DIFF
--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -35,7 +35,7 @@ jobs:
         run: |
           curl --request POST \
           --url https://api.github.com/graphql \
-          --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+          --header 'authorization: Bearer ${{ secrets.BITNAMI_BOT_TOKEN }}' \
           --data '{
             "query": "mutation { enablePullRequestAutoMerge(input: {pullRequestId: \"${{ github.event.pull_request.node_id }}\", mergeMethod: SQUASH}) { clientMutationId }}"
             }' \

--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -172,7 +172,7 @@ jobs:
         run: |
           curl --request POST \
           --url https://api.github.com/graphql \
-          --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+          --header 'authorization: Bearer ${{ secrets.BITNAMI_BOT_TOKEN }}' \
           --data '{
             "query": "mutation { disablePullRequestAutoMerge(input: {pullRequestId: \"${{ github.event.pull_request.node_id }}\"}) { clientMutationId }}"
             }' \


### PR DESCRIPTION
Signed-off-by: FraPazGal <fdepaz@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

We need to use the `BITNAMI_BOT_TOKEN` to enable the auto-merge feature for automated PRs, as the user that enables it is the one that appears as the one that merges the PR:

- Before https://github.com/bitnami/containers/pull/339: https://github.com/bitnami/containers/pull/778
- After  https://github.com/bitnami/containers/pull/339: https://github.com/bitnami/containers/pull/920

The user `github-actions` can't be the one that merges the PR's because tasks performed by `GITHUB_TOKEN` [won't trigger new actions.](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow) It seems GH understands the merged commit is pushed to `main` by `GITHUB_TOKEN` and thus is not triggering the `CD Pipeline` workflow.
