### PR TITLE
[bitnami/wordpress-nginx] see #1051: fix wp-config.php path

### DIFF
--- a/bitnami/wordpress-nginx/6/debian-11/rootfs/opt/bitnami/scripts/libwordpress.sh
+++ b/bitnami/wordpress-nginx/6/debian-11/rootfs/opt/bitnami/scripts/libwordpress.sh
@@ -228,7 +228,7 @@ wordpress_initialize() {
 
     # Check if WordPress has already been initialized and persisted in a previous run
     local -r app_name="wordpress"
-    if ! is_app_initialized "$app_name" || [[ ! -f "$WORDPRESS_CONF_FILE" ]]; then
+    if ! is_app_initialized "$app_name" || [[ ! -f "${BITNAMI_VOLUME_DIR}/${app_name}/wp-config.php" ]]; then
         # Ensure WordPress persisted directories exist (i.e. when a volume has been mounted to /bitnami)
         info "Ensuring WordPress directories exist"
         ensure_dir_exists "$WORDPRESS_VOLUME_DIR"


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Fix the wp-config.php path.

### Benefits

The script will be able to correctly detect whether WordPress is already installed or not.

### Possible drawbacks

None.

### Applicable issues

  - fixes #1051 

### Additional information

https://github.com/bitnami/bitnami-docker-wordpress-nginx/pull/88
