### PR TITLE
[bitnami/moodle] Add support for auroramysql driver

### DIFF
--- a/bitnami/moodle/3/debian-11/rootfs/opt/bitnami/scripts/libmoodle.sh
+++ b/bitnami/moodle/3/debian-11/rootfs/opt/bitnami/scripts/libmoodle.sh
@@ -87,7 +87,7 @@ moodle_validate() {
     fi
 
     # Support for MySQL and MariaDB
-    check_multi_value "MOODLE_DATABASE_TYPE" "mysqli mariadb pgsql"
+    check_multi_value "MOODLE_DATABASE_TYPE" "mysqli mariadb pgsql auroramysql"
 
     # Check that the web server is properly set up
     web_server_validate || print_validation_error "Web server validation failed"
@@ -145,7 +145,7 @@ moodle_initialize() {
         db_name="$MOODLE_DATABASE_NAME"
         db_user="$MOODLE_DATABASE_USER"
         db_pass="$MOODLE_DATABASE_PASSWORD"
-        [[ "$db_type" = "mariadb" || "$db_type" = "mysqli" ]] && moodle_wait_for_mysql_connection "$db_host" "$db_port" "$db_name" "$db_user" "$db_pass"
+        [[ "$db_type" = "mariadb" || "$db_type" = "mysqli" || "$db_type" = "auroramysql" ]] && moodle_wait_for_mysql_connection "$db_host" "$db_port" "$db_name" "$db_user" "$db_pass"
         [[ "$db_type" = "pgsql" ]] && moodle_wait_for_postgresql_connection "$db_host" "$db_port" "$db_name" "$db_user" "$db_pass"
 
         # Create Moodle install argument list, allowing to pass custom options via 'MOODLE_INSTALL_EXTRA_ARGS'
@@ -204,7 +204,7 @@ EOF
         db_name="$(moodle_conf_get "\$CFG->dbname")"
         db_user="$(moodle_conf_get "\$CFG->dbuser")"
         db_pass="$(moodle_conf_get "\$CFG->dbpass")"
-        [[ "$db_type" = "mariadb" || "$db_type" = "mysqli" ]] && moodle_wait_for_mysql_connection "$db_host" "$db_port" "$db_name" "$db_user" "$db_pass"
+        [[ "$db_type" = "mariadb" || "$db_type" = "mysqli" || "$db_type" = "auroramysql" ]] && moodle_wait_for_mysql_connection "$db_host" "$db_port" "$db_name" "$db_user" "$db_pass"
         [[ "$db_type" = "pgsql" ]] && moodle_wait_for_postgresql_connection "$db_host" "$db_port" "$db_name" "$db_user" "$db_pass"
 
         # Perform Moodle database schema upgrade

--- a/bitnami/moodle/4/debian-11/rootfs/opt/bitnami/scripts/libmoodle.sh
+++ b/bitnami/moodle/4/debian-11/rootfs/opt/bitnami/scripts/libmoodle.sh
@@ -87,7 +87,7 @@ moodle_validate() {
     fi
 
     # Support for MySQL and MariaDB
-    check_multi_value "MOODLE_DATABASE_TYPE" "mysqli mariadb pgsql"
+    check_multi_value "MOODLE_DATABASE_TYPE" "mysqli mariadb pgsql auroramysql"
 
     # Check that the web server is properly set up
     web_server_validate || print_validation_error "Web server validation failed"
@@ -145,7 +145,7 @@ moodle_initialize() {
         db_name="$MOODLE_DATABASE_NAME"
         db_user="$MOODLE_DATABASE_USER"
         db_pass="$MOODLE_DATABASE_PASSWORD"
-        [[ "$db_type" = "mariadb" || "$db_type" = "mysqli" ]] && moodle_wait_for_mysql_connection "$db_host" "$db_port" "$db_name" "$db_user" "$db_pass"
+        [[ "$db_type" = "mariadb" || "$db_type" = "mysqli" || "$db_type" = "auroramysql" ]] && moodle_wait_for_mysql_connection "$db_host" "$db_port" "$db_name" "$db_user" "$db_pass"
         [[ "$db_type" = "pgsql" ]] && moodle_wait_for_postgresql_connection "$db_host" "$db_port" "$db_name" "$db_user" "$db_pass"
 
         # Create Moodle install argument list, allowing to pass custom options via 'MOODLE_INSTALL_EXTRA_ARGS'
@@ -204,7 +204,7 @@ EOF
         db_name="$(moodle_conf_get "\$CFG->dbname")"
         db_user="$(moodle_conf_get "\$CFG->dbuser")"
         db_pass="$(moodle_conf_get "\$CFG->dbpass")"
-        [[ "$db_type" = "mariadb" || "$db_type" = "mysqli" ]] && moodle_wait_for_mysql_connection "$db_host" "$db_port" "$db_name" "$db_user" "$db_pass"
+        [[ "$db_type" = "mariadb" || "$db_type" = "mysqli" || "$db_type" = "auroramysql" ]] && moodle_wait_for_mysql_connection "$db_host" "$db_port" "$db_name" "$db_user" "$db_pass"
         [[ "$db_type" = "pgsql" ]] && moodle_wait_for_postgresql_connection "$db_host" "$db_port" "$db_name" "$db_user" "$db_pass"
 
         # Perform Moodle database schema upgrade

--- a/bitnami/moodle/README.md
+++ b/bitnami/moodle/README.md
@@ -228,7 +228,7 @@ Available environment variables:
 
 ##### Use an existing database
 
-- `MOODLE_DATABASE_TYPE`: Database type. Valid values: *mariadb*, *mysqli*, *pgsql*. Default: **mariadb**
+- `MOODLE_DATABASE_TYPE`: Database type. Valid values: *mariadb*, *mysqli*, *pgsql*, *auroramysql*. Default: **mariadb**
 - `MOODLE_DATABASE_HOST`: Hostname for database server. Default: **mariadb**
 - `MOODLE_DATABASE_PORT_NUMBER`: Port used by database server. Default: **3306**
 - `MOODLE_DATABASE_NAME`: Database name that Moodle will use to connect with the database. Default: **bitnami_moodle**


### PR DESCRIPTION
Signed-off-by: Chris Grycki <christopher-grycki@uiowa.edu>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
This PR adds support for Moodle's Amazon Aurora MySQL database driver. The environment variable "MOODLE_DATABASE_TYPE" should be set to "auroramysql" to use the Aurora driver.

### Benefits

<!-- What benefits will be realized by the code change? -->
Adds support for Amazon Aurora MySQL databases.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #1636 
