### PR TITLE
[bitnami/discourse] Use unicorn instead of passenger

### DIFF
--- a/bitnami/discourse/2/debian-11/Dockerfile
+++ b/bitnami/discourse/2/debian-11/Dockerfile
@@ -17,7 +17,7 @@ RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "node" "14.20.0-1
 RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "git" "2.37.1-1" --checksum 39ea3040baa552b4760c1100a3713f86493620c0a74121c1ceba50fe17341878
 RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "brotli" "1.0.9-151" --checksum ba4c4d26d232f8d91d1143078a633ba7c5ae33f5c4182684400ffb7bbc0ed262
 RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "discourse" "2.8.7-1" --checksum bd120eab1a7403e691f608f57b574a9782391fe1c4a46ce40752cfa560f922c2
-RUN apt-get update && apt-get upgrade -y && \
+RUN apt-get update && apt-get upgrade -y && apt-get install sudo runit -y && \
     rm -r /var/lib/apt/lists /var/cache/apt/archives
 RUN chmod g+rwX /opt/bitnami
 RUN /opt/bitnami/ruby/bin/gem install --force bundler -v '< 2'

--- a/bitnami/discourse/2/debian-11/rootfs/opt/bitnami/scripts/discourse-env.sh
+++ b/bitnami/discourse/2/debian-11/rootfs/opt/bitnami/scripts/discourse-env.sh
@@ -22,6 +22,7 @@ export BITNAMI_DEBUG="${BITNAMI_DEBUG:-false}"
 # By setting an environment variable matching *_FILE to a file path, the prefixed environment
 # variable will be overridden with the value specified in that file
 discourse_env_vars=(
+    DISCOURSE_SERVE_STATIC_ASSETS
     DISCOURSE_DATA_TO_PERSIST
     DISCOURSE_ENABLE_HTTPS
     DISCOURSE_EXTERNAL_HTTP_PORT_NUMBER
@@ -92,6 +93,8 @@ export DISCOURSE_CONF_FILE="${DISCOURSE_BASE_DIR}/config/discourse.conf"
 export PATH="${BITNAMI_ROOT_DIR}/common/bin:${BITNAMI_ROOT_DIR}/brotli/bin:${BITNAMI_ROOT_DIR}/git/bin:${PATH}"
 
 # Discourse persistence configuration
+DISCOURSE_SERVE_STATIC_ASSETS="${DISCOURSE_SERVE_STATIC_ASSETS:-true}"
+export DISCOURSE_SERVE_STATIC_ASSETS="${DISCOURSE_SERVE_STATIC_ASSETS:-true}"
 export DISCOURSE_VOLUME_DIR="${BITNAMI_VOLUME_DIR}/discourse"
 export DISCOURSE_DATA_TO_PERSIST="${DISCOURSE_DATA_TO_PERSIST:-plugins public/backups public/uploads}"
 

--- a/bitnami/discourse/2/debian-11/rootfs/opt/bitnami/scripts/discourse/run.sh
+++ b/bitnami/discourse/2/debian-11/rootfs/opt/bitnami/scripts/discourse/run.sh
@@ -18,11 +18,10 @@ set -o pipefail
 cd "$DISCOURSE_BASE_DIR"
 
 declare -a cmd=(
-    "bundle" "exec" "passenger" "start"
-    "--user" "$DISCOURSE_DAEMON_USER"
-    "-e" "$DISCOURSE_ENV"
+    chpst -u "$DISCOURSE_DAEMON_USER" -U "$DISCOURSE_DAEMON_USER" "bundle" "exec" "config/unicorn_launcher"
+    "-E" "$DISCOURSE_ENV"
     "-p" "$DISCOURSE_PORT_NUMBER"
-    "--spawn-method" "$DISCOURSE_PASSENGER_SPAWN_METHOD"
+    "-c" "config/unicorn.conf.rb"
 )
 
 # Append extra flags specified via environment variables
@@ -33,4 +32,4 @@ if [[ -n "$DISCOURSE_PASSENGER_EXTRA_FLAGS" ]]; then
 fi
 
 info "** Starting Discourse **"
-exec "${cmd[@]}" "$@"
+USER=$DISCOURSE_DAEMON_USER exec "${cmd[@]}" "$@"

--- a/bitnami/discourse/2/debian-11/rootfs/opt/bitnami/scripts/libdiscourse.sh
+++ b/bitnami/discourse/2/debian-11/rootfs/opt/bitnami/scripts/libdiscourse.sh
@@ -259,6 +259,11 @@ discourse_create_conf_file() {
         discourse_conf_set "smtp_enable_start_tls" "$([[ "$DISCOURSE_SMTP_PROTOCOL" = "tls" ]] && echo "true" || echo "false")"
         discourse_conf_set "smtp_authentication" "$DISCOURSE_SMTP_AUTH"
     fi
+
+    if ! is_empty_value "$DISCOURSE_SERVE_STATIC_ASSETS"; then
+        discourse_conf_set "serve_static_assets" "$DISCOURSE_SERVE_STATIC_ASSETS"
+    fi
+
     # Extra configuration
     ! is_empty_value "$DISCOURSE_EXTRA_CONF_CONTENT" && echo "$DISCOURSE_EXTRA_CONF_CONTENT" >> "$DISCOURSE_CONF_FILE"
 }


### PR DESCRIPTION
Original https://github.com/bitnami/bitnami-docker-discourse/pull/234

discourse lately removed the setting from the UI, this image doesn't really work properly without disabling this option currently.

Signed-off-by: Tobias Gurtzick magic@wizardtales.com


---

right now requires to set serve_static_assets = true

---

important info from previous ticket:

the docker-compose seems to be outdated and deviates from the helm chart.
The helm chart sets already

```
  - DISCOURSE_PORT_NUMBER=8080
  - DISCOURSE_EXTERNAL_HTTP_PORT_NUMBER=80
```

These two variables, and adding those to the docker-compose lets it run just fine.