### PR TITLE
[bitnami/harbor-portal] Fix broken link on README.md

### DIFF
--- a/bitnami/harbor-portal/README.md
+++ b/bitnami/harbor-portal/README.md
@@ -12,7 +12,7 @@
 
 ```console
 $ curl -LO https://raw.githubusercontent.com/bitnami/containers/main/bitnami/harbor-portal/docker-compose.yml
-$ curl -L https://github.com/bitnami/containers/blob/main/bitnami/harbor-portal/archive/master.tar.gz | tar xz --strip=1 --wildcards '*-master/config'
+$ curl -L https://github.com/bitnami/containers/archive/main.tar.gz | tar xz --strip=1 --wildcards '*-main/bitnami/harbor-portal/config' && mv bitnami/harbor-portal/config . && rm -rf bitnami
 $ docker-compose up
 ```
 


### PR DESCRIPTION
### Description of the change

Fix a broken link produced by the `bitnami/bitnami-docker-*` to `bitnami/containers` migration

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #3049 