### PR TITLE
[bitnami/etcd] Fix libetcd.sh - unbound ETCD_ACTIVE_ENDPOINTS

### DIFF
--- a/bitnami/etcd/3.3/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
+++ b/bitnami/etcd/3.3/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
@@ -392,13 +392,13 @@ is_new_etcd_cluster() {
 }
 
 ########################
-# Setup ETCD_ACTIVE_ENDPOINTS environment variable, will return the number of active endpoints
+# Setup ETCD_ACTIVE_ENDPOINTS environment variable, will return the number of active endpoints, cluster size (including not active member) and the ETCD_ACTIVE_ENDPOINTS (which is also export)
 # Globals:
 #   ETCD_*
 # Arguments:
 #   None
 # Returns:
-#   List of Numbers (active_endpoints, cluster_size)
+#   List of Numbers (active_endpoints, cluster_size, ETCD_ACTIVE_ENDPOINTS)
 ########################
 setup_etcd_active_endpoints() {
     local active_endpoints=0
@@ -424,7 +424,7 @@ setup_etcd_active_endpoints() {
         ETCD_ACTIVE_ENDPOINTS=$(echo "${active_endpoints_array[*]}" | tr ' ' ',')
         export ETCD_ACTIVE_ENDPOINTS
     fi
-    echo "${active_endpoints} ${cluster_size}"
+    echo "${active_endpoints} ${cluster_size} ${ETCD_ACTIVE_ENDPOINTS}"
 }
 
 ########################
@@ -439,7 +439,8 @@ setup_etcd_active_endpoints() {
 is_healthy_etcd_cluster() {
     local return_value=0
     local active_endpoints cluster_size
-    read -r active_endpoints cluster_size <<<"$(setup_etcd_active_endpoints)"
+    read -r active_endpoints cluster_size ETCD_ACTIVE_ENDPOINTS <<<"$(setup_etcd_active_endpoints)"
+    export ETCD_ACTIVE_ENDPOINTS
 
     if is_boolean_yes "$ETCD_DISASTER_RECOVERY"; then
         if [[ -f "/snapshots/.disaster_recovery" ]]; then

--- a/bitnami/etcd/3.4/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
+++ b/bitnami/etcd/3.4/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
@@ -392,13 +392,13 @@ is_new_etcd_cluster() {
 }
 
 ########################
-# Setup ETCD_ACTIVE_ENDPOINTS environment variable, will return the number of active endpoints
+# Setup ETCD_ACTIVE_ENDPOINTS environment variable, will return the number of active endpoints, cluster size (including not active member) and the ETCD_ACTIVE_ENDPOINTS (which is also export)
 # Globals:
 #   ETCD_*
 # Arguments:
 #   None
 # Returns:
-#   List of Numbers (active_endpoints, cluster_size)
+#   List of Numbers (active_endpoints, cluster_size, ETCD_ACTIVE_ENDPOINTS)
 ########################
 setup_etcd_active_endpoints() {
     local active_endpoints=0
@@ -424,7 +424,7 @@ setup_etcd_active_endpoints() {
         ETCD_ACTIVE_ENDPOINTS=$(echo "${active_endpoints_array[*]}" | tr ' ' ',')
         export ETCD_ACTIVE_ENDPOINTS
     fi
-    echo "${active_endpoints} ${cluster_size}"
+    echo "${active_endpoints} ${cluster_size} ${ETCD_ACTIVE_ENDPOINTS}"
 }
 
 ########################
@@ -439,7 +439,8 @@ setup_etcd_active_endpoints() {
 is_healthy_etcd_cluster() {
     local return_value=0
     local active_endpoints cluster_size
-    read -r active_endpoints cluster_size <<<"$(setup_etcd_active_endpoints)"
+    read -r active_endpoints cluster_size ETCD_ACTIVE_ENDPOINTS <<<"$(setup_etcd_active_endpoints)"
+    export ETCD_ACTIVE_ENDPOINTS
 
     if is_boolean_yes "$ETCD_DISASTER_RECOVERY"; then
         if [[ -f "/snapshots/.disaster_recovery" ]]; then

--- a/bitnami/etcd/3.5/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
+++ b/bitnami/etcd/3.5/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
@@ -392,13 +392,13 @@ is_new_etcd_cluster() {
 }
 
 ########################
-# Setup ETCD_ACTIVE_ENDPOINTS environment variable, will return the number of active endpoints
+# Setup ETCD_ACTIVE_ENDPOINTS environment variable, will return the number of active endpoints, cluster size (including not active member) and the ETCD_ACTIVE_ENDPOINTS (which is also export)
 # Globals:
 #   ETCD_*
 # Arguments:
 #   None
 # Returns:
-#   List of Numbers (active_endpoints, cluster_size)
+#   List of Numbers (active_endpoints, cluster_size, ETCD_ACTIVE_ENDPOINTS)
 ########################
 setup_etcd_active_endpoints() {
     local active_endpoints=0
@@ -424,7 +424,7 @@ setup_etcd_active_endpoints() {
         ETCD_ACTIVE_ENDPOINTS=$(echo "${active_endpoints_array[*]}" | tr ' ' ',')
         export ETCD_ACTIVE_ENDPOINTS
     fi
-    echo "${active_endpoints} ${cluster_size}"
+    echo "${active_endpoints} ${cluster_size} ${ETCD_ACTIVE_ENDPOINTS}"
 }
 
 ########################
@@ -439,7 +439,8 @@ setup_etcd_active_endpoints() {
 is_healthy_etcd_cluster() {
     local return_value=0
     local active_endpoints cluster_size
-    read -r active_endpoints cluster_size <<<"$(setup_etcd_active_endpoints)"
+    read -r active_endpoints cluster_size ETCD_ACTIVE_ENDPOINTS <<<"$(setup_etcd_active_endpoints)"
+    export ETCD_ACTIVE_ENDPOINTS
 
     if is_boolean_yes "$ETCD_DISASTER_RECOVERY"; then
         if [[ -f "/snapshots/.disaster_recovery" ]]; then


### PR DESCRIPTION
Signed-off-by: Lucas GRANET <lucas.granet@ovhcloud.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Correct a script to fix an issue when a new ETCD member is added (no member id found) when deployed in a K8S cluster.
The script (`libetcd.sh`) is currently not able to add a new member in an existing ETCD cluster.

Following code don't export the `ETCD_ACTIVE_ENDPOINTS` variable (subshell function call in `is_healthy_etcd_cluster` function) as we need it to self-add the new member in the cluster.
```bash
is_healthy_etcd_cluster() {
    local return_value=0
    local active_endpoints cluster_size
    read -r active_endpoints cluster_size <<<"$(setup_etcd_active_endpoints)" # <- Subshell call don't export value in current context
...
add_self_to_cluster() {
    local -a extra_flags
    read -r -a extra_flags <<<"$(etcdctl_auth_flags)"
    # is_healthy_etcd_cluster will also set ETCD_ACTIVE_ENDPOINTS <- wrong
    while ! is_healthy_etcd_cluster; do
        warn "Cluster not healthy, not adding self to cluster for now, keeping trying..."
        sleep 10
    done
```

### Benefits

Fix ETCD scale up, reset ETCD member in a Kubernetes cluster (using Bitnami Helm chart)

### Possible drawbacks

<!-- Describe any known limitations with your change -->
N/A

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes new etcd member join
```
INFO  ==> ** Starting etcd setup **
INFO  ==> Validating settings in ETCD_* env vars..
INFO  ==> Initializing etcd
INFO  ==> Generating etcd config file using env variables
INFO  ==> There is no data from previous deployments
INFO  ==> Adding new member to existing cluster
DEBUG ==> patroni-etcd-0.patroni-etcd-headless.etcd.svc.cluster.local:2379 endpoint is active
DEBUG ==> patroni-etcd-1.patroni-etcd-headless.etcd.svc.cluster.local:2379 endpoint is active
/opt/bitnami/scripts/libetcd.sh: line 732: ETCD_ACTIVE_ENDPOINTS: unbound variable
```

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
N/A