### PR TITLE
[bitnami/kibana] Fix is_kibana_running function

### DIFF
--- a/bitnami/kibana/7/debian-11/rootfs/opt/bitnami/scripts/libkibana.sh
+++ b/bitnami/kibana/7/debian-11/rootfs/opt/bitnami/scripts/libkibana.sh
@@ -310,9 +310,9 @@ is_kibana_ready() {
     # Therefore, we must check the value is not 'true'
     [[ ! "$rewriteBasePath" = "false" ]] && basePath=$(kibana_conf_get "server.basePath")
     if is_kibana_running; then
-        local -r status="$(yq eval ".status.overall" - <<<"$(curl -s "127.0.0.1:${KIBANA_PORT_NUMBER}${basePath:-}/api/status")")"
-        [[ $(echo $status | yq eval ".state") = "green" ]] && return # Kibana 7
-        [[ $(echo $status | yq eval ".level") = "available" ]] && return # Kibana 8
+        # Kibana 7 expects .status.overall.state to be 'green', while 8 expects .status.overall.level to be 'available'
+        local -r status="$(yq eval '.status.overall | pick(["state", "level"]) | .[]' - <<<"$(curl -s "127.0.0.1:${KIBANA_PORT_NUMBER}${basePath:-}/api/status")")"
+        [[ "$status" = "green" || "$status" = "available" ]] && return
     else
         false
     fi

--- a/bitnami/kibana/7/debian-11/rootfs/opt/bitnami/scripts/libkibana.sh
+++ b/bitnami/kibana/7/debian-11/rootfs/opt/bitnami/scripts/libkibana.sh
@@ -310,8 +310,9 @@ is_kibana_ready() {
     # Therefore, we must check the value is not 'true'
     [[ ! "$rewriteBasePath" = "false" ]] && basePath=$(kibana_conf_get "server.basePath")
     if is_kibana_running; then
-        local -r state="$(yq eval ".status.overall.state" - <<<"$(curl -s "127.0.0.1:${KIBANA_PORT_NUMBER}${basePath:-}/api/status")")"
-        [[ "$state" = "green" ]]
+        local -r status="$(yq eval ".status.overall" - <<<"$(curl -s "127.0.0.1:${KIBANA_PORT_NUMBER}${basePath:-}/api/status")")"
+        [[ $(echo $status | yq eval ".state") = "green" ]] && return # Kibana 7
+        [[ $(echo $status | yq eval ".level") = "available" ]] && return # Kibana 8
     else
         false
     fi

--- a/bitnami/kibana/8/debian-11/rootfs/opt/bitnami/scripts/libkibana.sh
+++ b/bitnami/kibana/8/debian-11/rootfs/opt/bitnami/scripts/libkibana.sh
@@ -310,9 +310,9 @@ is_kibana_ready() {
     # Therefore, we must check the value is not 'true'
     [[ ! "$rewriteBasePath" = "false" ]] && basePath=$(kibana_conf_get "server.basePath")
     if is_kibana_running; then
-        local -r status="$(yq eval ".status.overall" - <<<"$(curl -s "127.0.0.1:${KIBANA_PORT_NUMBER}${basePath:-}/api/status")")"
-        [[ $(echo $status | yq eval ".state") = "green" ]] && return # Kibana 7
-        [[ $(echo $status | yq eval ".level") = "available" ]] && return # Kibana 8
+        # Kibana 7 expects .status.overall.state to be 'green', while 8 expects .status.overall.level to be 'available'
+        local -r status="$(yq eval '.status.overall | pick(["state", "level"]) | .[]' - <<<"$(curl -s "127.0.0.1:${KIBANA_PORT_NUMBER}${basePath:-}/api/status")")"
+        [[ "$status" = "green" || "$status" = "available" ]] && return
     else
         false
     fi

--- a/bitnami/kibana/8/debian-11/rootfs/opt/bitnami/scripts/libkibana.sh
+++ b/bitnami/kibana/8/debian-11/rootfs/opt/bitnami/scripts/libkibana.sh
@@ -310,8 +310,9 @@ is_kibana_ready() {
     # Therefore, we must check the value is not 'true'
     [[ ! "$rewriteBasePath" = "false" ]] && basePath=$(kibana_conf_get "server.basePath")
     if is_kibana_running; then
-        local -r level="$(yq eval ".status.overall.level" - <<<"$(curl -s "127.0.0.1:${KIBANA_PORT_NUMBER}${basePath:-}/api/status")")"
-        [[ "$level" = "available" ]]
+        local -r status="$(yq eval ".status.overall" - <<<"$(curl -s "127.0.0.1:${KIBANA_PORT_NUMBER}${basePath:-}/api/status")")"
+        [[ $(echo $status | yq eval ".state") = "green" ]] && return # Kibana 7
+        [[ $(echo $status | yq eval ".level") = "available" ]] && return # Kibana 8
     else
         false
     fi

--- a/bitnami/kibana/8/debian-11/rootfs/opt/bitnami/scripts/libkibana.sh
+++ b/bitnami/kibana/8/debian-11/rootfs/opt/bitnami/scripts/libkibana.sh
@@ -310,8 +310,8 @@ is_kibana_ready() {
     # Therefore, we must check the value is not 'true'
     [[ ! "$rewriteBasePath" = "false" ]] && basePath=$(kibana_conf_get "server.basePath")
     if is_kibana_running; then
-        local -r state="$(yq eval ".status.overall.state" - <<<"$(curl -s "127.0.0.1:${KIBANA_PORT_NUMBER}${basePath:-}/api/status")")"
-        [[ "$state" = "green" ]]
+        local -r level="$(yq eval ".status.overall.level" - <<<"$(curl -s "127.0.0.1:${KIBANA_PORT_NUMBER}${basePath:-}/api/status")")"
+        [[ "$level" = "available" ]]
     else
         false
     fi


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Fix the `is_kibana_running` function used to check kibana status when running in background mode.
The previous check (`.status.overall.state`) works in Kibana 7.x, but the json structure looks to have changed in 8.x. 
I cannot find the `/api/status` endpoint documented to confirm/reference.

### Benefits

The container no longer hangs when running in background mode.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
