### PR TITLE
[bitnami/apache] Allow to know when setup is done bitnami/charts#11770

### DIFF
--- a/bitnami/apache/2.4/debian-11/rootfs/opt/bitnami/scripts/apache/setup.sh
+++ b/bitnami/apache/2.4/debian-11/rootfs/opt/bitnami/scripts/apache/setup.sh
@@ -61,3 +61,6 @@ fi
 
 # Fix logging issue when running as root
 ! am_i_root || chmod o+w "$(readlink /dev/stdout)" "$(readlink /dev/stderr)"
+
+# Allow to know when setup is done (used by startupProbe)
+date > /tmp/bitnami-setup-done


### PR DESCRIPTION
### Description of the change

Creates a file in /tmp directory to allow to know other applications when the setup is done.

### Benefits

Allow to set a better startupProbe when using kubernetes. Or create a docker [healthCheck](https://docs.docker.com/engine/reference/builder/#healthcheck)

### Possible drawbacks

Users with a mounted /tmp directory with custom permissions?

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes bitnami/charts#11770

### Additional information

Related: bitnami/charts#12144
