### PR TITLE
[bitnami/openldap] Follow LDAP_LOGLEVEL in setup phase

### DIFF
--- a/bitnami/openldap/2.6/debian-11/rootfs/opt/bitnami/scripts/libopenldap.sh
+++ b/bitnami/openldap/2.6/debian-11/rootfs/opt/bitnami/scripts/libopenldap.sh
@@ -196,12 +196,19 @@ is_ldap_not_running() {
 #   None
 #########################
 ldap_start_bg() {
-    local -a flags=("-h" "ldap://:${LDAP_PORT_NUMBER}/ ldapi:/// " "-F" "${LDAP_CONF_DIR}/slapd.d")
+    local -r retries="${1:-12}"
+    local -r sleep_time="${2:-1}"
+
+    local -a flags=("-h" "ldap://:${LDAP_PORT_NUMBER}/ ldapi:/// " "-F" "${LDAP_CONF_DIR}/slapd.d" "-d" "$LDAP_LOGLEVEL")
     if is_ldap_not_running; then
         info "Starting OpenLDAP server in background"
         ulimit -n "$LDAP_ULIMIT_NOFILES"
         am_i_root && flags=("-u" "$LDAP_DAEMON_USER" "${flags[@]}")
-        debug_execute slapd "${flags[@]}"
+        debug_execute slapd "${flags[@]}"&
+        if ! retry_while is_ldap_running "$retries" "$sleep_time"; then
+            error "OpenLDAP failed to start"
+            return 1
+        fi
     fi
 }
 


### PR DESCRIPTION
### Description of the change

Follow the LDAP_LOGLEVEL environment variable already in the setup phase.
The mechanisms are copied from ldap_stop and run.sh

### Benefits

More logging will be generated on first startup of the slapd daemon. The startup may fail, for example when permissions on the key file do not permit reading by the user running the slapd daemon. Without this patch, it will fail with a generic error and quit.
Using this patch, with BITNAMI_DEBUG set to true, the logs will tell you slapd can't read the key file. The logging can be tuned with the LDAP_LOGLEVEL variable.

### Possible drawbacks

None I see. Output can be tuned with BITNAMI_DEBUG and LDAP_LOGLEVEL

### Applicable issues

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
