### PR TITLE
[bitnami/*] Move failed automated PRs into Support Dashboard

### DIFF
--- a/.github/workflows/ci-automated-pipeline.yaml
+++ b/.github/workflows/ci-automated-pipeline.yaml
@@ -140,4 +140,11 @@ jobs:
           numOfAssignee: 1
           removePreviousAssignees: true
           teams: build-maintainers
-          repo-token: "${{ secrets.BITNAMI_BOT_TOKEN }}"
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Move into In Progress
+        uses: peter-evans/create-or-update-project-card@v2
+        if: ${{ needs.vib-verify.result != 'success' }}
+        with:
+          project-name: Support
+          column-name: From Bitnami
+          token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/ci-automated-pipeline.yaml
+++ b/.github/workflows/ci-automated-pipeline.yaml
@@ -140,8 +140,8 @@ jobs:
           numOfAssignee: 1
           removePreviousAssignees: true
           teams: build-maintainers
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Move into In Progress
+          repo-token: "${{ secrets.BITNAMI_BOT_TOKEN }}"
+      - name: Move into From Bitnami
         uses: peter-evans/create-or-update-project-card@v2
         if: ${{ needs.vib-verify.result != 'success' }}
         with:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Move the non verified automated PRs into the support Dashboard. Currently they are assigned to a member of `build-maintainers` team, but the PRs don't appear in the Support Dashboard, creating some confusion.

### Benefits

We will have all pending PRs (automated or non automated) in the Support Dashboard.

### Possible drawbacks

None
