### PR TITLE
[bitnami/*]Use github token to reduce the number of labeled events

### DIFF
--- a/.github/workflows/ci-automated-pipeline.yaml
+++ b/.github/workflows/ci-automated-pipeline.yaml
@@ -25,7 +25,6 @@ jobs:
         name: Label PR
         uses: andymckay/labeler@1.0.4
         with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
           add-labels: "verify, auto-merge"
       - id: auto-merge
         name: Enable auto-merge

--- a/.github/workflows/moving-cards.yml
+++ b/.github/workflows/moving-cards.yml
@@ -33,7 +33,6 @@ jobs:
         if: ${{ github.event.project_card.column_id == env.ON_HOLD_COLUMN_ID  }}
         uses: andymckay/labeler@1.0.4
         with:
-          repo-token: "${{ secrets.BITNAMI_BOT_TOKEN }}"
           add-labels: "on-hold"
           remove-labels: "triage"
       - name: In progress labeling
@@ -41,7 +40,6 @@ jobs:
         if: ${{ github.event.project_card.column_id == env.IN_PROGRESS_COLUMN_ID  }}
         uses: andymckay/labeler@1.0.4
         with:
-          repo-token: "${{ secrets.BITNAMI_BOT_TOKEN }}"
           add-labels: "in-progress"
           remove-labels: "on-hold, triage"
       - name: Solved labeling
@@ -49,7 +47,6 @@ jobs:
         if: ${{ github.event.project_card.column_id == env.SOLVED_COLUMN_ID  }}
         uses: andymckay/labeler@1.0.4
         with:
-          repo-token: "${{ secrets.BITNAMI_BOT_TOKEN }}"
           add-labels: "solved"
           remove-labels: "in-progress, on-hold, triage"
   assign-assignee-if-needed:

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -51,7 +51,6 @@ jobs:
         # Only if moved into Solved
         uses: andymckay/labeler@1.0.4
         with:
-          repo-token: "${{ secrets.BITNAMI_BOT_TOKEN }}"
           add-labels: ${{ (!contains(fromJson(env.BITNAMI_TEAM), github.actor)) && 'triage' || 'bitnami' }}
           # For reopened issues
           remove-labels: "solved"


### PR DESCRIPTION
Signed-off-by: Fran Mulero <fmulero@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Use github token (user github-actions) to label the issues and PRs in the support workflows.

### Benefits

CI/CD workflows are listening for any label change in the PRs. This change should reduce the number of events triggered due to movements in the support dashboard.

### Possible drawbacks

None identified
