### PR TITLE
[bitnami/*]Use github token to reduce the number of labeled events

### DIFF
--- a/.github/workflows/clossing-issues.yml
+++ b/.github/workflows/clossing-issues.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   issues: write
   repository-projects: write
+  pull-requests: write
 
 jobs:
   stale:

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -6,6 +6,7 @@ on:
 permissions:
   repository-projects: write
   issues: write
+  pull-requests: write
 
 # To fix the concurrency when for example more than one label is added
 concurrency:

--- a/.github/workflows/move-closed-issues.yml
+++ b/.github/workflows/move-closed-issues.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   issues: write
   repository-projects: write
+  pull-requests: write
 
 # To fix the concurrency when for example more than one label is added
 concurrency:

--- a/.github/workflows/moving-cards.yml
+++ b/.github/workflows/moving-cards.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   repository-projects: read
   issues: write
+  pull-requests: write
 
 # To fix the concurrency when for example more than one label is added
 concurrency:

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -12,6 +12,7 @@ on:
 permissions:
   repository-projects: write
   issues: write
+  pull-requests: write
 
 # To fix the concurrency when for example more than one label is added
 concurrency:


### PR DESCRIPTION
Signed-off-by: Fran Mulero <fmulero@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Follow up #4452. Add explicitly write permissions on PR for support workflows.

### Benefits

Avoid [hidden 403 errors](https://github.com/bitnami/containers/runs/8076184162?check_suite_focus=true)

### Possible drawbacks

None
