### PR TITLE
[bitnami/*] Move failed automated PRs into Support Dashboard

### DIFF
--- a/.github/workflows/ci-automated-pipeline.yaml
+++ b/.github/workflows/ci-automated-pipeline.yaml
@@ -148,5 +148,5 @@ jobs:
           project-name: Support
           column-name: From Bitnami
           token: "${{ secrets.GITHUB_TOKEN }}"
-          # The action by default uses github.event.issue.number and PRs don't have that field
+          # The action by default uses github.event.issue.number but PRs don't have that field
           issue-number: ${{ github.event.number }}

--- a/.github/workflows/ci-automated-pipeline.yaml
+++ b/.github/workflows/ci-automated-pipeline.yaml
@@ -148,3 +148,5 @@ jobs:
           project-name: Support
           column-name: From Bitnami
           token: "${{ secrets.GITHUB_TOKEN }}"
+          # The action by default uses github.event.issue.number and PRs don't have that field
+          issue-number: ${{ github.event.number }}


### PR DESCRIPTION
Signed-off-by: Fran Mulero <fmulero@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Set explicitly the issue-number. # The action uses by default `github.event.issue.number` but PRs don't have that field

### Benefits

Failed/cancelled PRs are not correctly added to the support dahboard. For instance, this [one](https://github.com/bitnami/containers/runs/8115156491?check_suite_focus=true)

### Possible drawbacks

None

### Additional information

Follow up #4450 
