### PR TITLE
[bitnami/redis-cluster] Support scenario where IPs are reused

### DIFF
--- a/bitnami/redis-cluster/6.2/debian-11/rootfs/opt/bitnami/scripts/librediscluster.sh
+++ b/bitnami/redis-cluster/6.2/debian-11/rootfs/opt/bitnami/scripts/librediscluster.sh
@@ -215,7 +215,7 @@ redis_cluster_update_ips() {
             fi
             host_2_ip_array["$node"]="$newIP"
         done
-        sed -i "s/<NEWIP>//g" "${REDIS_DATA_DIR}/nodes.conf"
+        replace_in_file "${REDIS_DATA_DIR}/nodes.conf" "<NEWIP>:" ":" false
         declare -p host_2_ip_array >"${REDIS_DATA_DIR}/nodes.sh"
     fi
 }

--- a/bitnami/redis-cluster/6.2/debian-11/rootfs/opt/bitnami/scripts/librediscluster.sh
+++ b/bitnami/redis-cluster/6.2/debian-11/rootfs/opt/bitnami/scripts/librediscluster.sh
@@ -210,11 +210,12 @@ redis_cluster_update_ips() {
             # The node can be new if we are updating the cluster, so catch the unbound variable error
             if [[ ${host_2_ip_array[$node]+true} ]]; then
                 echo "Changing old IP ${host_2_ip_array[$node]} by the new one ${newIP}"
-                nodesFile=$(sed "s/ ${host_2_ip_array[$node]}:/ $newIP:/g" "${REDIS_DATA_DIR}/nodes.conf")
+                nodesFile=$(sed "s/ ${host_2_ip_array[$node]}:/ $newIP<NEWIP>:/g" "${REDIS_DATA_DIR}/nodes.conf")
                 echo "$nodesFile" >"${REDIS_DATA_DIR}/nodes.conf"
             fi
             host_2_ip_array["$node"]="$newIP"
         done
+        sed -i "s/<NEWIP>//g" "${REDIS_DATA_DIR}/nodes.conf"
         declare -p host_2_ip_array >"${REDIS_DATA_DIR}/nodes.sh"
     fi
 }

--- a/bitnami/redis-cluster/7.0/debian-11/rootfs/opt/bitnami/scripts/librediscluster.sh
+++ b/bitnami/redis-cluster/7.0/debian-11/rootfs/opt/bitnami/scripts/librediscluster.sh
@@ -215,7 +215,7 @@ redis_cluster_update_ips() {
             fi
             host_2_ip_array["$node"]="$newIP"
         done
-        sed -i "s/<NEWIP>//g" "${REDIS_DATA_DIR}/nodes.conf"
+        replace_in_file "${REDIS_DATA_DIR}/nodes.conf" "<NEWIP>:" ":" false
         declare -p host_2_ip_array >"${REDIS_DATA_DIR}/nodes.sh"
     fi
 }

--- a/bitnami/redis-cluster/7.0/debian-11/rootfs/opt/bitnami/scripts/librediscluster.sh
+++ b/bitnami/redis-cluster/7.0/debian-11/rootfs/opt/bitnami/scripts/librediscluster.sh
@@ -210,11 +210,12 @@ redis_cluster_update_ips() {
             # The node can be new if we are updating the cluster, so catch the unbound variable error
             if [[ ${host_2_ip_array[$node]+true} ]]; then
                 echo "Changing old IP ${host_2_ip_array[$node]} by the new one ${newIP}"
-                nodesFile=$(sed "s/ ${host_2_ip_array[$node]}:/ $newIP:/g" "${REDIS_DATA_DIR}/nodes.conf")
+                nodesFile=$(sed "s/ ${host_2_ip_array[$node]}:/ $newIP<NEWIP>:/g" "${REDIS_DATA_DIR}/nodes.conf")
                 echo "$nodesFile" >"${REDIS_DATA_DIR}/nodes.conf"
             fi
             host_2_ip_array["$node"]="$newIP"
         done
+        sed -i "s/<NEWIP>//g" "${REDIS_DATA_DIR}/nodes.conf"
         declare -p host_2_ip_array >"${REDIS_DATA_DIR}/nodes.sh"
     fi
 }


### PR DESCRIPTION
### Description of the change

Closes https://github.com/bitnami/charts/issues/11341

### Benefits
There is a bug in that if a redis-cluster is restarted, and the redis node starting is assigned the same IP that was used by one of the shutdown nodes, the existing logic incorrectly updates the IPs.

For example:
Shut down cluster:
```
redis-0   127.0.0.1
redis-1   127.0.0.2
```
new IPs:
```
redis-0   127.0.0.2
redis-2   127.0.0.1
```
The existing logic results in:
a) switch 127.0.0.1 to 127.0.0.2
a) switch 127.0.0.2 to 127.0.0.1 (bug)
```
redis-0   127.0.0.1
redis-1   127.0.0.1
```
The update logic ensures that newly set IPs are not updated again
