### PR TITLE
[bitnami/*] Remove condition in ci-pipeline workflow

### DIFF
--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -72,7 +72,7 @@ jobs:
   vib-verify:
     runs-on: ubuntu-latest
     needs: get-containers
-    if: ${{ needs.get-containers.outputs.result == 'ok' && contains(github.event.pull_request.labels.*.name, 'verify') }}
+    if: ${{ needs.get-containers.outputs.result == 'ok' }}
     name: VIB Verify
     continue-on-error: false
     strategy:


### PR DESCRIPTION
Signed-off-by: Fran Mulero <fmulero@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This a #4766 follow up. In this change we are fixing a broken condition, `vib-verify` job needs a concrete output from `get-container`, the check about `verify` label is not required 

### Possible drawbacks

None indentified

### Applicable issues
It unblocks automated PRs like:
  - #4991

