### PR TITLE
[bitnami/*] Add CD step to retrieve registry credentials

### DIFF
--- a/.github/workflows/cd-pipeline.yaml
+++ b/.github/workflows/cd-pipeline.yaml
@@ -91,8 +91,8 @@ jobs:
         run: |
           csp_auth_token=$(curl -s -H 'Content-Type: application/x-www-form-urlencoded' -X POST -d "grant_type=refresh_token&api_token=${{ secrets.STAGING_MARKETPLACE_API_TOKEN }}" https://console.cloud.vmware.com/csp/gateway/am/api/auth/api-tokens/authorize | jq -r .access_token)
           repo_info=$(curl -s -X POST -H "Content-Type: application/json" -H "csp-auth-token:$csp_auth_token" -d '{"withCredentials":true, "storageType":"OCI"}' https://gtwstg.market.csp.vmware.com/api/v1/repositories/transient)
-          marketplace_user=$(echo "$repo_info" | jq -r .response.repodetails.username)
-          marketplace_passwd=$(echo "$repo_info" | jq -r .response.repodetails.token)
+          marketplace_user=$(echo "$repo_info" | jq -re .response.repodetails.username)
+          marketplace_passwd=$(echo "$repo_info" | jq -re .response.repodetails.token)
           echo "::add-mask::${marketplace_user}"
           echo "::add-mask::${marketplace_passwd}"
           echo "::set-output name=marketplace_user::${marketplace_user}"

--- a/.github/workflows/cd-pipeline.yaml
+++ b/.github/workflows/cd-pipeline.yaml
@@ -89,7 +89,7 @@ jobs:
       - id: get-registry-credentials
         name: Get staging marketplace's registry credentials
         run: |
-          csp_auth_token=$(curl -s -H 'Content-Type: application/x-www-form-urlencoded' -X POST -d "grant_type=refresh_token&api_token=${{ secrets.STAGING_MARKETPLACE_API_TOKEN }}" https://console.cloud.vmware.com/csp/gateway/am/api/auth/api-tokens/authorize | jq -r .access_token)
+          csp_auth_token=$(curl -s -H 'Content-Type: application/x-www-form-urlencoded' -X POST -d "grant_type=refresh_token&api_token=${{ secrets.STAGING_MARKETPLACE_API_TOKEN }}" https://console.cloud.vmware.com/csp/gateway/am/api/auth/api-tokens/authorize | jq -re .access_token)
           repo_info=$(curl -s -X POST -H "Content-Type: application/json" -H "csp-auth-token:$csp_auth_token" -d '{"withCredentials":true, "storageType":"OCI"}' https://gtwstg.market.csp.vmware.com/api/v1/repositories/transient)
           marketplace_user=$(echo "$repo_info" | jq -re .response.repodetails.username)
           marketplace_passwd=$(echo "$repo_info" | jq -re .response.repodetails.token)

--- a/.github/workflows/cd-pipeline.yaml
+++ b/.github/workflows/cd-pipeline.yaml
@@ -86,6 +86,17 @@ jobs:
             # Container folder doesn't exists we are assuming a deprecation
             echo "::set-output name=result::skip"
           fi
+      - id: get-registry-credentials
+        name: Get staging marketplace's registry credentials
+        run: |
+          csp_auth_token=$(curl -s -H 'Content-Type: application/x-www-form-urlencoded' -X POST -d "grant_type=refresh_token&api_token=${{ secrets.STAGING_MARKETPLACE_API_TOKEN }}" https://console.cloud.vmware.com/csp/gateway/am/api/auth/api-tokens/authorize | jq -r .access_token)
+          repo_info=$(curl -s -X POST -H "Content-Type: application/json" -H "csp-auth-token:$csp_auth_token" -d '{"withCredentials":true, "storageType":"OCI"}' https://gtwstg.market.csp.vmware.com/api/v1/repositories/transient)
+          marketplace_user=$(echo "$repo_info" | jq -r .response.repodetails.username)
+          marketplace_passwd=$(echo "$repo_info" | jq -r .response.repodetails.token)
+          echo "::add-mask::${marketplace_user}"
+          echo "::add-mask::${marketplace_passwd}"
+          echo "::set-output name=marketplace_user::${marketplace_user}"
+          echo "::set-output name=marketplace_passwd::${marketplace_passwd}"
       - uses: vmware-labs/vmware-image-builder-action@main
         name: 'Publish ${{ steps.get-container-metadata.outputs.name }}: ${{ steps.get-container-metadata.outputs.tag }}'
         if: ${{ steps.get-container-metadata.outputs.result == 'ok' }}
@@ -98,5 +109,5 @@ jobs:
           VIB_ENV_CONTAINER: ${{ steps.get-container-metadata.outputs.name }}
           VIB_ENV_TAG: ${{ steps.get-container-metadata.outputs.tag }}
           VIB_ENV_REGISTRY_URL: ${{ secrets.STAGING_MARKETPLACE_REGISTRY_URL }}
-          VIB_ENV_REGISTRY_USERNAME: ${{ secrets.STAGING_MARKETPLACE_USER }}
-          VIB_ENV_REGISTRY_PASSWORD:  ${{ secrets.STAGING_MARKETPLACE_PASSWORD }}
+          VIB_ENV_REGISTRY_USERNAME: ${{ steps.get-registry-credentials.outputs.marketplace_user }}
+          VIB_ENV_REGISTRY_PASSWORD: ${{ steps.get-registry-credentials.outputs.marketplace_passwd }}


### PR DESCRIPTION
Signed-off-by: FraPazGal <fdepaz@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This is a follow-up of https://github.com/bitnami/containers/pull/5477 to retrieve the registry credentials in each CD execution given the password's transient nature. We also decided to retrieve the `username` this way to avoid potential issues in the future.

### Benefits

CD pipelines failing with auth issues will now work as expected.

### Possible drawbacks

None

### Additional information

Tested in fork: https://github.com/FraPazGal/containers/runs/8245071416?check_suite_focus=true