### PR TITLE
[bitnami/*] Disable ARM support for Intel specific images

### DIFF
--- a/.vib/haproxy-intel/vib-publish.json
+++ b/.vib/haproxy-intel/vib-publish.json
@@ -18,8 +18,7 @@
               }
             },
             "architectures": [
-              "linux/amd64",
-              "linux/arm64"
+              "linux/amd64"
             ]
           }
         },

--- a/.vib/wordpress-intel/vib-publish.json
+++ b/.vib/wordpress-intel/vib-publish.json
@@ -18,8 +18,7 @@
               }
             },
             "architectures": [
-              "linux/amd64",
-              "linux/arm64"
+              "linux/amd64"
             ]
           }
         },


### PR DESCRIPTION
Signed-off-by: Alejandro Ruiz <alejandroruiz@vmware.com>

The `arm64` was added by mistake, as it does not make much sense to add it for Intel-specific images.