### PR TITLE
[bitnami/*] Fix skipped CDs for automated PRs when pusher != bitnami-bot

### DIFF
--- a/.github/workflows/cd-pipeline.yaml
+++ b/.github/workflows/cd-pipeline.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Get modified containers path
     if: |
-      github.event.pusher.name == 'bitnami-bot' &&
+      github.event.head_commit.author.name == 'Bitnami Bot' &&
       github.event.forced == false
     outputs:
       result: ${{ steps.get-containers.outputs.result }}

--- a/.github/workflows/cd-pipeline.yaml
+++ b/.github/workflows/cd-pipeline.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Get modified containers path
     if: |
-      github.event.head_commit.author.name == 'Bitnami Bot' &&
+      github.event.head_commit.author.username == 'bitnami-bot' &&
       github.event.forced == false
     outputs:
       result: ${{ steps.get-containers.outputs.result }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

As we were using the condition `event.pusher.name == 'bitnami-bot'` to launch the CD, when an automated PR required manual intervention and was merged by a user, the CD was skipped. The condition has now been updated so the commit's author is checked. 

This condition does not clash with those PRs (and squashed commits) co-authored by `bitnami-bot` and a user and the CD will be launched as expected.

### Benefits

CD pipelines for automated PRs are no longer skipped.

### Possible drawbacks

None

### Additional information

Tested in fork:

- PR co-authored and pushed by user: [PR](https://github.com/FraPazGal/containers/pull/7) and [commit](https://github.com/FraPazGal/containers/commit/30429d0d9344f712616c9da77db79fec522ba59e) --> Not skipped
- PR approved and pushed by user: [PR](https://github.com/FraPazGal/containers/pull/6) and [commit](https://github.com/FraPazGal/containers/commit/25ec716e485040f401ff2c9bdac4c18e716125a5) --> Not skipped
- Commit authored only by user: [link](https://github.com/FraPazGal/containers/commit/390c24eea9b185a5f3284cbb31dcbfb10133ff25) --> Skipped