### PR TITLE
[bitnami/sonarqube] Add ARM64 support for Sonarqube

### DIFF
--- a/.vib/sonarqube/vib-publish.json
+++ b/.vib/sonarqube/vib-publish.json
@@ -18,7 +18,8 @@
               }
             },
             "architectures": [
-              "linux/amd64"
+              "linux/amd64",
+              "linux/arm64"
             ]
           }
         },


### PR DESCRIPTION
### Description of the change

Add `linux/arm64` architecture to the VIB publish pipeline.