### PR TITLE
[bitnami/*] Follow up #6637, Fix moving-cards workflow

### DIFF
--- a/.github/workflows/moving-cards.yml
+++ b/.github/workflows/moving-cards.yml
@@ -110,7 +110,7 @@ jobs:
     needs:
       - get-issue
     # The job shouldn't run for new PRs created by bitnami-bot
-    if: ${{ github.event.action != 'created' || needs.get-issue.outputs.author != 'bitnami-bot' || needs.get-issue.outputs.issue != 'pull_request'}}
+    if: ${{ github.event.action != 'created' || needs.get-issue.outputs.author != 'bitnami-bot' || needs.get-issue.outputs.type != 'pull_request'}}
     steps:
       - name: Repo checkout
         uses: actions/checkout@v3

--- a/.github/workflows/moving-cards.yml
+++ b/.github/workflows/moving-cards.yml
@@ -56,13 +56,13 @@ jobs:
         if: ${{ github.event.project_card.column_id == env.TRIAGE_COLUMN_ID }}
         uses: andymckay/labeler@1.0.4
         with:
-          add-labels: ${{ (needs.get-issue.outputs.author == 'bitnami-bot' && needs.get-issue.outputs.type != 'issue') && 'automated, auto-merge' || 'triage' }}
+          add-labels: triage
           remove-labels: on-hold, in-progress, solved
       - name: From Bitnami labeling
         if: ${{ github.event.project_card.column_id == env.BITNAMI_COLUMN_ID }}
         uses: andymckay/labeler@1.0.4
         with:
-          add-labels: bitnami
+          add-labels: ${{ (needs.get-issue.outputs.author == 'bitnami-bot' && needs.get-issue.outputs.type == 'pull_request') && 'automated, auto-merge' || 'bitnami' }}
           remove-labels: on-hold, in-progress, triage, solved
       - name: Verify labeling
         # Only if moved into bitnami column and the PR is ready for review


### PR DESCRIPTION
Signed-off-by: Fran Mulero <fmulero@vmware.com>

### Description of the change

Follow up #6637. Labels for automated PRs and the condition to assign a user are wrong.

### Benefits

Enable automation properly for PRs as #6677
