### PR TITLE
[bitnami/*]Avoid (re)assignment of closed cards

### DIFF
--- a/.github/workflows/moving-cards.yml
+++ b/.github/workflows/moving-cards.yml
@@ -109,8 +109,10 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - get-issue
-    # The job shouldn't run for new PRs created by bitnami-bot
-    if: ${{ github.event.action != 'created' || needs.get-issue.outputs.author != 'bitnami-bot' || needs.get-issue.outputs.type != 'pull_request'}}
+    # The job shouldn't run for solved cards or new PRs created by bitnami-bot
+    if: |
+      github.event.project_card.column_id != env.SOLVED_COLUMN_ID &&
+      (github.event.action != 'created' || needs.get-issue.outputs.type != 'pull_request' || needs.get-issue.outputs.author != 'bitnami-bot')
     steps:
       - name: Repo checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Signed-off-by: Fran Mulero <fmulero@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Avoid assignment or reassigment of closed cards

### Benefits

Assigment of closed task is not needed and creates a lot of noise

### Additional information

Follow up #6637
