### PR TITLE
[bitnami/moodle] Fix MOODLE_SSLPROXY and MOODLE_REVERSEPROXY

### DIFF
--- a/bitnami/moodle/3/debian-11/rootfs/opt/bitnami/scripts/libmoodle.sh
+++ b/bitnami/moodle/3/debian-11/rootfs/opt/bitnami/scripts/libmoodle.sh
@@ -410,9 +410,9 @@ if (isset(\$_SERVER['HTTPS']) \&\& \$_SERVER['HTTPS'] == 'on') {\\
 #########################
 moodle_configure_reverseproxy() {
     # Checking the reverseproxy setting values
-    is_boolean_yes "$MOODLE_REVERSEPROXY" && echo "\$CFG->reverseproxy = true;" >>"$MOODLE_CONF_FILE"
+    is_boolean_yes "$MOODLE_REVERSEPROXY" && sed -i '/^require/i $CFG->reverseproxy = true;' "$MOODLE_CONF_FILE"
     # Checking the sslproxy setting values
-    is_boolean_yes "$MOODLE_SSLPROXY" && echo "\$CFG->sslproxy = true;" >>"$MOODLE_CONF_FILE"
+    is_boolean_yes "$MOODLE_SSLPROXY" && sed -i '/^require/i $CFG->sslproxy = true;' "$MOODLE_CONF_FILE"
 
     true
 }

--- a/bitnami/moodle/4/debian-11/rootfs/opt/bitnami/scripts/libmoodle.sh
+++ b/bitnami/moodle/4/debian-11/rootfs/opt/bitnami/scripts/libmoodle.sh
@@ -410,9 +410,9 @@ if (isset(\$_SERVER['HTTPS']) \&\& \$_SERVER['HTTPS'] == 'on') {\\
 #########################
 moodle_configure_reverseproxy() {
     # Checking the reverseproxy setting values
-    is_boolean_yes "$MOODLE_REVERSEPROXY" && echo "\$CFG->reverseproxy = true;" >>"$MOODLE_CONF_FILE"
+    is_boolean_yes "$MOODLE_REVERSEPROXY" && sed -i '/^require/i $CFG->reverseproxy = true;' "$MOODLE_CONF_FILE"
     # Checking the sslproxy setting values
-    is_boolean_yes "$MOODLE_SSLPROXY" && echo "\$CFG->sslproxy = true;" >>"$MOODLE_CONF_FILE"
+    is_boolean_yes "$MOODLE_SSLPROXY" && sed -i '/^require/i $CFG->sslproxy = true;' "$MOODLE_CONF_FILE"
 
     true
 }


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This pull request changes the `moodle_configure_reverseproxy` function in `libmoodle.sh` that modifies `/bitnami/moodle/config.php` based on the `MOODLE_SSLPROXY` and `MOODLE_REVERSEPROXY` environment variables. These variables had no effect before as described in #6534.

### Benefits

`$CFG->sslproxy = true;` (and `reverseproxy`) now gets put to a different place in `config.php` where it is actualy taken into account.

### Possible drawbacks

`moodle_configure_reverseproxy` now depends on the existence of a specific line in `config.php` (starting with `require`) to know where to put the options. If the structure of `config.php` changes significantly in the future, this code will need to be updated with a better heuristic.

### Applicable issues

  - fixes #6534

### Additional information

Tested on `bitnami/moodle:4.0.4-debian-11-r2`.
