### PR TITLE
[bitnami/moodle] Always set `$CFG->wwwroot` to HTTPS if `MOODLE_SSLPROXY` set

### DIFF
--- a/bitnami/moodle/3/debian-11/rootfs/opt/bitnami/scripts/libmoodle.sh
+++ b/bitnami/moodle/3/debian-11/rootfs/opt/bitnami/scripts/libmoodle.sh
@@ -388,14 +388,20 @@ moodle_configure_wwwroot() {
     # sed replacement notes:
     # - The ampersand ('&') is escaped due to sed replacing any non-escaped ampersand characters with the matched string
     # - For the replacement text to be multi-line, an \ needs to be specified to escape the newline character
-    local -r conf_to_replace="if (empty(\$_SERVER['HTTP_HOST'])) {\\
+    local conf_to_replace="if (empty(\$_SERVER['HTTP_HOST'])) {\\
   \$_SERVER['HTTP_HOST'] = '127.0.0.1:${http_port}';\\
-}\\
+}"
+    if is_boolean_yes "$MOODLE_SSLPROXY"; then
+        conf_to_replace="$conf_to_replace\\
+\$CFG->wwwroot   = 'https://' . ${host};"
+    else
+        conf_to_replace="$conf_to_replace\\
 if (isset(\$_SERVER['HTTPS']) \&\& \$_SERVER['HTTPS'] == 'on') {\\
   \$CFG->wwwroot   = 'https://' . ${host};\\
 } else {\\
   \$CFG->wwwroot   = 'http://' . ${host};\\
 }"
+    fi
     replace_in_file "$MOODLE_CONF_FILE" "\\\$CFG->wwwroot\s*=.*" "$conf_to_replace"
 }
 

--- a/bitnami/moodle/4/debian-11/rootfs/opt/bitnami/scripts/libmoodle.sh
+++ b/bitnami/moodle/4/debian-11/rootfs/opt/bitnami/scripts/libmoodle.sh
@@ -388,14 +388,20 @@ moodle_configure_wwwroot() {
     # sed replacement notes:
     # - The ampersand ('&') is escaped due to sed replacing any non-escaped ampersand characters with the matched string
     # - For the replacement text to be multi-line, an \ needs to be specified to escape the newline character
-    local -r conf_to_replace="if (empty(\$_SERVER['HTTP_HOST'])) {\\
+    local conf_to_replace="if (empty(\$_SERVER['HTTP_HOST'])) {\\
   \$_SERVER['HTTP_HOST'] = '127.0.0.1:${http_port}';\\
-}\\
+}"
+    if is_boolean_yes "$MOODLE_SSLPROXY"; then
+        conf_to_replace="$conf_to_replace\\
+\$CFG->wwwroot   = 'https://' . ${host};"
+    else
+        conf_to_replace="$conf_to_replace\\
 if (isset(\$_SERVER['HTTPS']) \&\& \$_SERVER['HTTPS'] == 'on') {\\
   \$CFG->wwwroot   = 'https://' . ${host};\\
 } else {\\
   \$CFG->wwwroot   = 'http://' . ${host};\\
 }"
+    fi
     replace_in_file "$MOODLE_CONF_FILE" "\\\$CFG->wwwroot\s*=.*" "$conf_to_replace"
 }
 


### PR DESCRIPTION
### Description of the change

When `$CFG->sslproxy` is set (set by `MOODLE_SSLPROXY`, although see #6534) , `$CFG->wwwroot` is required to start with `https`, otherwise Moodle refuses to serve any content except an error message. Previously, the logic generated by the `moodle_configure_wwwroot` function in `libmoodle.sh` used to determine the scheme of `$CFG->wwwroot` dynamically at run time based on the request.

This pull request enhances the behavior of `moodle_configure_wwwroot` to disable this logic when the `MOODLE_SSLPROXY` environment variable is set. In such case, `$CFG->wwwroot` is set statically to HTTPS.

### Benefits

`/bitnami/moodle/config.php` does not need to be fixed manually after creating a new container.

### Applicable issues

  - fixes #6535

### Additional information

Tested on `bitnami/moodle:4.0.4-debian-11-r2`.
