### PR TITLE
[bitnami/keycloak] append --auto-build to arguments in production mode

### DIFF
--- a/bitnami/keycloak/18/debian-11/rootfs/opt/bitnami/scripts/keycloak/run.sh
+++ b/bitnami/keycloak/18/debian-11/rootfs/opt/bitnami/scripts/keycloak/run.sh
@@ -19,9 +19,13 @@ info "** Starting keycloak **"
 # Use only basename
 conf_file="${KEYCLOAK_CONF_DIR}/${KEYCLOAK_CONF_FILE}"
 
-is_boolean_yes "$KEYCLOAK_PRODUCTION" && start_param="start" || start_param="start-dev"
+start_command=("${KEYCLOAK_BIN_DIR}/kc.sh" "-cf" "$conf_file")
 
-start_command=("${KEYCLOAK_BIN_DIR}/kc.sh" "-cf" "$conf_file" "$start_param")
+if is_boolean_yes "$KEYCLOAK_PRODUCTION"; then
+    start_command+=("start" "--auto-build")
+else
+    start_command+=("start-dev")
+fi
 
 # Add extra args
 if [[ -n "$KEYCLOAK_EXTRA_ARGS" ]]; then

--- a/bitnami/keycloak/19/debian-11/rootfs/opt/bitnami/scripts/keycloak/run.sh
+++ b/bitnami/keycloak/19/debian-11/rootfs/opt/bitnami/scripts/keycloak/run.sh
@@ -19,9 +19,13 @@ info "** Starting keycloak **"
 # Use only basename
 conf_file="${KEYCLOAK_CONF_DIR}/${KEYCLOAK_CONF_FILE}"
 
-is_boolean_yes "$KEYCLOAK_PRODUCTION" && start_param="start" || start_param="start-dev"
+start_command=("${KEYCLOAK_BIN_DIR}/kc.sh" "-cf" "$conf_file")
 
-start_command=("${KEYCLOAK_BIN_DIR}/kc.sh" "-cf" "$conf_file" "$start_param")
+if is_boolean_yes "$KEYCLOAK_PRODUCTION"; then
+    start_command+=("start" "--auto-build")
+else
+    start_command+=("start-dev")
+fi
 
 # Add extra args
 if [[ -n "$KEYCLOAK_EXTRA_ARGS" ]]; then


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

Fixes "No suitable driver found" when the server starts with `KEYCLOAK_PRODUCTION=true`.


### Benefits

<!-- What benefits will be realized by the code change? -->
I should be able to enable `KEYCLOAK_PRODUCTION=true` without digging into this image's entrypoint scripts.

### Possible drawbacks

<!-- Describe any known limitations with your change -->
Users who have already adopted the workaround of adding `KEYCLOAK_EXTRA_ARGS=--autobuild` to their environment will see the following error

```
Unknown option: '--auto-build'
```

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #983 (currently closed due to staleness)

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

Since this will likely cause people's pods to stop working, a less disruptive option might be to make a mention that consumers are expected to pass "KEYCLOAK_EXTRA_ARGS=--auto-build" starting from 18.0.2 in the "Notable Changes" section of the README.