### PR TITLE
[bitnami/matomo] Proxy host headers

### DIFF
--- a/bitnami/matomo/4/debian-11/rootfs/opt/bitnami/scripts/libmatomo.sh
+++ b/bitnami/matomo/4/debian-11/rootfs/opt/bitnami/scripts/libmatomo.sh
@@ -159,6 +159,11 @@ EOF
         info "Configuring Matomo to check proxy_client_headers for client IP"
             ini-file set -s "General" -k "proxy_client_headers[]" -v "$MATOMO_PROXY_CLIENT_HEADER" "$MATOMO_CONF_FILE"
         fi
+        
+        if ! is_empty_value "$MATOMO_PROXY_HOST_HEADER"; then
+        info "Configuring Matomo to check proxy_host_headers for client IP"
+            ini-file set -s "General" -k "proxy_host_headers[]" -v "$MATOMO_PROXY_HOST_HEADER" "$MATOMO_CONF_FILE"
+        fi        
 
         if is_boolean_yes "$MATOMO_ENABLE_ASSUME_SECURE_PROTOCOL"; then
             info "Configuring Matomo to always assume secure protocol"

--- a/bitnami/matomo/README.md
+++ b/bitnami/matomo/README.md
@@ -292,6 +292,7 @@ If you are connecting through a reverse proxy (https-to-http) and Matomo is not 
  - `MATOMO_ENABLE_ASSUME_SECURE_PROTOCOL`: Enable 'assume_secure_protocol' in Matomo configuration file. Default: **no**
  - `MATOMO_ENABLE_FORCE_SSL`: Enable 'force_ssl' in Matomo configuration file. Default: **no**
  - `MATOMO_PROXY_CLIENT_HEADER`: Specify the the client IP HTTP Header. Usually 'HTTP_X_FORWARDED_FOR'. No defaults.
+ - `MATOMO_PROXY_HOST_HEADER`: Specify the the host IP HTTP Header. Usually 'HTTP_X_FORWARDED_HOST'. No defaults.
 
 ##### Example
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

It adds the option to set the proxy_host_headers option in Matomo's option.ini.php configuration file by setting the MATOMO_PROXY_HOST_HEADER environment variable.

### Benefits

This [setting is necessary when Matomo is behind a proxy](https://matomo.org/faq/how-to-install/faq_98/). It could be that it was not needed in the past. But in my setup it was not possible to login to Matomo when it was behind a proxy due to a [origin/nonce-check](https://github.com/matomo-org/matomo/blob/b183ce903f3e24c97ad929c77aff99e1ef93ab11/core/Nonce.php#L136) during login (The error message is about `form security failed`). Without this setting Matomo can not know what the original origin/host is, so the check fails.

### Possible drawbacks

Can not think of any.
