### PR TITLE
[bitnami/mongodb] Fix hardcoded root username for metrics user creation

### DIFF
--- a/bitnami/mongodb/5.0/debian-11/rootfs/opt/bitnami/scripts/libmongodb.sh
+++ b/bitnami/mongodb/5.0/debian-11/rootfs/opt/bitnami/scripts/libmongodb.sh
@@ -714,7 +714,7 @@ EOF
 
     if [[ -n "$MONGODB_METRICS_USERNAME" ]] && [[ -n "$MONGODB_METRICS_PASSWORD" ]]; then
         info "Creating '$MONGODB_METRICS_USERNAME' user..."
-        mongodb_execute 'root' "$MONGODB_ROOT_PASSWORD" "" "127.0.0.1" <<EOF
+        mongodb_execute "$MONGODB_ROOT_USER" "$MONGODB_ROOT_PASSWORD" "" "127.0.0.1" <<EOF
 db.getSiblingDB('admin').createUser({ user: '$MONGODB_METRICS_USERNAME', pwd: '$MONGODB_METRICS_PASSWORD', roles: [{role: 'clusterMonitor', db: 'admin'},{ role: 'read', db: 'local' }] })
 EOF
     fi

--- a/bitnami/mongodb/6.0/debian-11/rootfs/opt/bitnami/scripts/libmongodb.sh
+++ b/bitnami/mongodb/6.0/debian-11/rootfs/opt/bitnami/scripts/libmongodb.sh
@@ -714,7 +714,7 @@ EOF
 
     if [[ -n "$MONGODB_METRICS_USERNAME" ]] && [[ -n "$MONGODB_METRICS_PASSWORD" ]]; then
         info "Creating '$MONGODB_METRICS_USERNAME' user..."
-        mongodb_execute 'root' "$MONGODB_ROOT_PASSWORD" "" "127.0.0.1" <<EOF
+        mongodb_execute "$MONGODB_ROOT_USER" "$MONGODB_ROOT_PASSWORD" "" "127.0.0.1" <<EOF
 db.getSiblingDB('admin').createUser({ user: '$MONGODB_METRICS_USERNAME', pwd: '$MONGODB_METRICS_PASSWORD', roles: [{role: 'clusterMonitor', db: 'admin'},{ role: 'read', db: 'local' }] })
 EOF
     fi


### PR DESCRIPTION
### Description of the change

Hardcoded root username `'root'` is used during *MONGODB_METRICS_USERNAME* user creation, so it is impossible to create a metric user when the root username is different. This PR changes this behaviour.

### Benefits

From now it is possible to create a metric user when there is a different root username than `'root'`.
 
### Possible drawbacks

n/a
