### PR TITLE
[bitnami/cassandra] honor for broadcast-address in nodetool-output

### DIFF
--- a/bitnami/cassandra/4.0/debian-11/rootfs/opt/bitnami/scripts/libcassandra.sh
+++ b/bitnami/cassandra/4.0/debian-11/rootfs/opt/bitnami/scripts/libcassandra.sh
@@ -839,7 +839,7 @@ wait_for_nodetool_up() {
         # https://community.datastax.com/questions/13764/java-version-for-cassandra-3113.html
         local -r check_cmd=("${CASSANDRA_BIN_DIR}/nodetool" "-Dcom.sun.jndi.rmiURLParsing=legacy")
         local -r check_args=("status" "--port" "$CASSANDRA_JMX_PORT_NUMBER")
-        local -r machine_ip="$(dns_lookup "$CASSANDRA_HOST" "v4")"
+        local -r machine_ip="$(dns_lookup "${CASSANDRA_BROADCAST_ADDRESS:-$CASSANDRA_HOST}" "v4")"
         local -r check_regex="UN\s*(${CASSANDRA_HOST}|${machine_ip}|127.0.0.1)"
 
         local output="/dev/null"
@@ -855,7 +855,7 @@ wait_for_nodetool_up() {
         # https://community.datastax.com/questions/13764/java-version-for-cassandra-3113.html
         local -r check_cmd=("${CASSANDRA_BIN_DIR}/nodetool" "-Dcom.sun.jndi.rmiURLParsing=legacy")
         local -r check_args=("status" "--port" "$CASSANDRA_JMX_PORT_NUMBER")
-        local -r machine_ip="$(dns_lookup "$CASSANDRA_HOST" "v4")"
+        local -r machine_ip="$(dns_lookup "${CASSANDRA_BROADCAST_ADDRESS:-$CASSANDRA_HOST}" "v4")"
         local -r check_regex="UN\s*"
         read -r -a host_list <<<"$(tr ',;' ' ' <<<"$CASSANDRA_NODES")"
         local -r expected_node_count="${#host_list[@]}"


### PR DESCRIPTION

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

If CASSANDRA_BROADCAST_ADDRESS was set, nodetool reports that address only. Thus wait_for_nodetool_up() must grep for broadcast-ip else container startup hangs.

### Benefits

You can use config-option CASSANDRA_BROADCAST_ADDRESS

### Possible drawbacks

None (if CASSANDRA_BROADCAST_ADDRESS is unset, behavior will not change)

