### PR TITLE
[bitnami/discourse] refactor: bump postgresql client version

### DIFF
--- a/bitnami/discourse/2/debian-11/Dockerfile
+++ b/bitnami/discourse/2/debian-11/Dockerfile
@@ -44,13 +44,13 @@ RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ && \
     tar -zxf ruby-2.7.6-153-linux-${OS_ARCH}-debian-11.tar.gz -C /opt/bitnami --strip-components=2 --no-same-owner --wildcards '*/files' && \
     rm -rf ruby-2.7.6-153-linux-${OS_ARCH}-debian-11.tar.gz ruby-2.7.6-153-linux-${OS_ARCH}-debian-11.tar.gz.sha256
 RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ && \
-    if [ ! -f postgresql-client-13.8.0-1-linux-${OS_ARCH}-debian-11.tar.gz ]; then \
-      curl -SsLf https://downloads.bitnami.com/files/stacksmith/postgresql-client-13.8.0-1-linux-${OS_ARCH}-debian-11.tar.gz -O ; \
-      curl -SsLf https://downloads.bitnami.com/files/stacksmith/postgresql-client-13.8.0-1-linux-${OS_ARCH}-debian-11.tar.gz.sha256 -O ; \
+    if [ ! -f postgresql-client-14.5.0-1-linux-${OS_ARCH}-debian-11.tar.gz ]; then \
+      curl -SsLf https://downloads.bitnami.com/files/stacksmith/postgresql-client-14.5.0-1-linux-${OS_ARCH}-debian-11.tar.gz -O ; \
+      curl -SsLf https://downloads.bitnami.com/files/stacksmith/postgresql-client-14.5.0-1-linux-${OS_ARCH}-debian-11.tar.gz.sha256 -O ; \
     fi && \
-    sha256sum -c postgresql-client-13.8.0-1-linux-${OS_ARCH}-debian-11.tar.gz.sha256 && \
-    tar -zxf postgresql-client-13.8.0-1-linux-${OS_ARCH}-debian-11.tar.gz -C /opt/bitnami --strip-components=2 --no-same-owner --wildcards '*/files' && \
-    rm -rf postgresql-client-13.8.0-1-linux-${OS_ARCH}-debian-11.tar.gz postgresql-client-13.8.0-1-linux-${OS_ARCH}-debian-11.tar.gz.sha256
+    sha256sum -c postgresql-client-14.5.0-1-linux-${OS_ARCH}-debian-11.tar.gz.sha256 && \
+    tar -zxf postgresql-client-14.5.0-1-linux-${OS_ARCH}-debian-11.tar.gz -C /opt/bitnami --strip-components=2 --no-same-owner --wildcards '*/files' && \
+    rm -rf postgresql-client-14.5.0-1-linux-${OS_ARCH}-debian-11.tar.gz postgresql-client-14.5.0-1-linux-${OS_ARCH}-debian-11.tar.gz.sha256
 RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ && \
     if [ ! -f node-14.20.0-3-linux-${OS_ARCH}-debian-11.tar.gz ]; then \
       curl -SsLf https://downloads.bitnami.com/files/stacksmith/node-14.20.0-3-linux-${OS_ARCH}-debian-11.tar.gz -O ; \


### PR DESCRIPTION
### Description of the change

This commit bumps the Discourse image's postgresql-client package version from 13.8.x to 14.5.x.

### Benefits

In the case of managed databases, like what DigitalOcean offers, the Postgres server is patched and updated regularly. This can result in major version mismatch of the client and server that ends up in exceptions in Discourse like the following:

```
...
[2022-09-20 03:37:55] Dumping the public schema of the database...
[2022-09-20 03:37:55] pg_dump: error: server version: 14.5; pg_dump version: 13.7
[2022-09-20 03:37:55] pg_dump: error: aborting because of server version mismatch
[2022-09-20 03:37:55] EXCEPTION: pg_dump failed
...
```

### Possible drawbacks

This is somewhat a breaking change if the client is not backward compatible. Since I have no information about the compatibility, I would says that a potential drawback is:

If someone using the updated image with an older postgres server version, it can end up in the same situation as using a newer server version with an old client, aka. cannot do `pg_dump`.

### Applicable issues

No opened issues.

### Additional information

N/A
