### PR TITLE
[bitnami/*] Fix label issue when verify is already set

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -21,7 +21,7 @@ jobs:
     if: |
       github.event.pull_request.state != 'closed' &&
       (
-        contains(github.event.pull_request.labels.*.name, 'verify') || (github.event.action == 'labeled' && (github.event.label.name == 'verify'))
+        contains(github.event.pull_request.labels.*.name, 'verify') || (github.event.action == 'labeled' && github.event.label.name == 'verify')
       )
     outputs:
       result: ${{ steps.get-containers.outputs.result }}

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -21,8 +21,7 @@ jobs:
     if: |
       github.event.pull_request.state != 'closed' &&
       (
-        (github.event.action == 'labeled' && github.event.label.name == 'verify') ||
-        (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'verify'))
+        contains(github.event.pull_request.labels.*.name, 'verify') || (github.event.action == 'labeled' && (github.event.label.name == 'verify'))
       )
     outputs:
       result: ${{ steps.get-containers.outputs.result }}


### PR DESCRIPTION
Signed-off-by: Fran Mulero <fmulero@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Triggers `get-containers` action on any label event with `verify` or when `verify` is already set

### Benefits

Avoid CI error with label events when verify is already set

### Possible drawbacks

VIB verify could be triggered several times if we set several labels at the same time and `verify` is already set.

