### PR TITLE
[bitnami/jasperreports] Fix SMTP settings for Jasperreports

### DIFF
--- a/bitnami/jasperreports/8/debian-11/rootfs/opt/bitnami/scripts/jasperreports-env.sh
+++ b/bitnami/jasperreports/8/debian-11/rootfs/opt/bitnami/scripts/jasperreports-env.sh
@@ -102,7 +102,7 @@ export JASPERREPORTS_SMTP_USER="${JASPERREPORTS_SMTP_USER:-}" # only used during
 JASPERREPORTS_SMTP_PASSWORD="${JASPERREPORTS_SMTP_PASSWORD:-"${SMTP_PASSWORD:-}"}"
 export JASPERREPORTS_SMTP_PASSWORD="${JASPERREPORTS_SMTP_PASSWORD:-}" # only used during the first initialization
 JASPERREPORTS_SMTP_PROTOCOL="${JASPERREPORTS_SMTP_PROTOCOL:-"${SMTP_PROTOCOL:-}"}"
-export JASPERREPORTS_SMTP_PROTOCOL="${JASPERREPORTS_SMTP_PROTOCOL:-}" # only used during the first initialization
+export JASPERREPORTS_SMTP_PROTOCOL="${JASPERREPORTS_SMTP_PROTOCOL:-smtp}" # only used during the first initialization
 
 # Database configuration
 export JASPERREPORTS_DATABASE_TYPE="${JASPERREPORTS_DATABASE_TYPE:-mariadb}" # only used during the first initialization

--- a/bitnami/jasperreports/8/debian-11/rootfs/opt/bitnami/scripts/libjasperreports.sh
+++ b/bitnami/jasperreports/8/debian-11/rootfs/opt/bitnami/scripts/libjasperreports.sh
@@ -98,7 +98,7 @@ jasperreports_validate() {
         done
         is_empty_value "$JASPERREPORTS_SMTP_PORT_NUMBER" && print_validation_error "The JASPERREPORTS_SMTP_PORT_NUMBER environment variable is empty or not set."
         ! is_empty_value "$JASPERREPORTS_SMTP_PORT_NUMBER" && check_valid_port "JASPERREPORTS_SMTP_PORT_NUMBER"
-        ! is_empty_value "$JASPERREPORTS_SMTP_PROTOCOL" && check_multi_value "JASPERREPORTS_SMTP_PROTOCOL" "smtp ssl tls"
+        ! is_empty_value "$JASPERREPORTS_SMTP_PROTOCOL" && check_multi_value "JASPERREPORTS_SMTP_PROTOCOL" "smtp smtps ssl tls"
     fi
 
     return "$error_code"

--- a/bitnami/jasperreports/8/debian-11/rootfs/opt/bitnami/scripts/libjasperreports.sh
+++ b/bitnami/jasperreports/8/debian-11/rootfs/opt/bitnami/scripts/libjasperreports.sh
@@ -98,7 +98,7 @@ jasperreports_validate() {
         done
         is_empty_value "$JASPERREPORTS_SMTP_PORT_NUMBER" && print_validation_error "The JASPERREPORTS_SMTP_PORT_NUMBER environment variable is empty or not set."
         ! is_empty_value "$JASPERREPORTS_SMTP_PORT_NUMBER" && check_valid_port "JASPERREPORTS_SMTP_PORT_NUMBER"
-        ! is_empty_value "$JASPERREPORTS_SMTP_PROTOCOL" && check_multi_value "JASPERREPORTS_SMTP_PROTOCOL" "ssl tls"
+        ! is_empty_value "$JASPERREPORTS_SMTP_PROTOCOL" && check_multi_value "JASPERREPORTS_SMTP_PROTOCOL" "smtp ssl tls"
     fi
 
     return "$error_code"

--- a/bitnami/jasperreports/README.md
+++ b/bitnami/jasperreports/README.md
@@ -284,7 +284,7 @@ To configure JasperReports to send email using SMTP you can set the following en
 - `JASPERREPORTS_SMTP_PORT_NUMBER`: SMTP port.
 - `JASPERREPORTS_SMTP_USER`: SMTP account user.
 - `JASPERREPORTS_SMTP_PASSWORD`: SMTP account password.
-- `JASPERREPORTS_SMTP_PROTOCOL`: If specified, SMTP protocol to use. Allowed values: *tls*, *ssl*. No default.
+- `JASPERREPORTS_SMTP_PROTOCOL`: If specified, SMTP protocol to use. Allowed values: *smtp*, *tls*, *ssl*. Default: **smtp**.
 
 ##### JasperReports base URL configuration
 

--- a/bitnami/jasperreports/README.md
+++ b/bitnami/jasperreports/README.md
@@ -284,7 +284,7 @@ To configure JasperReports to send email using SMTP you can set the following en
 - `JASPERREPORTS_SMTP_PORT_NUMBER`: SMTP port.
 - `JASPERREPORTS_SMTP_USER`: SMTP account user.
 - `JASPERREPORTS_SMTP_PASSWORD`: SMTP account password.
-- `JASPERREPORTS_SMTP_PROTOCOL`: If specified, SMTP protocol to use. Allowed values: *smtp*, *tls*, *ssl*. Default: **smtp**.
+- `JASPERREPORTS_SMTP_PROTOCOL`: If specified, SMTP protocol to use. Allowed values: *smtp*, *smtps*, *tls*, *ssl*. Default: **smtp**.
 
 ##### JasperReports base URL configuration
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Add "smtp" as a valid option for JASPERREPORTS_SMTP_PROTOCOL and make it the default. I'm not sure if 'ssl' and 'tls' are even valid options - every piece of documentation I've seen only shows it set to 'smtp'. But just in case, I have not removed the other options.

### Benefits

Makes it possible to get email working from JasperReports.

### Possible drawbacks

None

### Applicable issues

  - fixes #4677 
  - fixes #7296 

### Additional information

I've tested this on my own install and was finally able to get emails working with this change.