### PR TITLE
[bitnami/containers] Fix label assignment issue

### DIFF
--- a/.github/workflows/moving-cards.yml
+++ b/.github/workflows/moving-cards.yml
@@ -66,7 +66,8 @@ jobs:
           remove-labels: on-hold, in-progress, triage, solved
       - name: Verify labeling
         # Only if moved into bitnami column and the PR is ready for review
-        # This step uses a github-script to add the label intentionally. Consecutive calls to andymckay/labeler@1.0.4 can remove previous assigned labels
+        # This step uses a github-script to add the label intentionally.
+        # Consecutive calls to andymckay/labeler@1.0.4 can remove previous assigned labels, see https://github.com/andymckay/labeler/issues/40
         if: |
           github.event.project_card.column_id == env.BITNAMI_COLUMN_ID &&
           needs.get-issue.outputs.type == 'pull_request' && needs.get-issue.outputs.draft == 'false'

--- a/.github/workflows/moving-cards.yml
+++ b/.github/workflows/moving-cards.yml
@@ -66,14 +66,26 @@ jobs:
           remove-labels: on-hold, in-progress, triage, solved
       - name: Verify labeling
         # Only if moved into bitnami column and the PR is ready for review
+        # This step uses a github-script to add the label intentionally. Consecutive calls to andymckay/labeler@1.0.4 can remove previous assigned labels
         if: |
           github.event.project_card.column_id == env.BITNAMI_COLUMN_ID &&
           needs.get-issue.outputs.type == 'pull_request' && needs.get-issue.outputs.draft == 'false'
-        uses: andymckay/labeler@1.0.4
+        uses: actions/github-script@v6
         with:
-          add-labels: verify
           # Required to trigger CI workflow
-          repo-token: ${{ secrets.BITNAMI_BOT_TOKEN }}
+          github-token: ${{ secrets.BITNAMI_BOT_TOKEN }}
+          script: |
+            try {
+              await github.rest.issues.addLabels({
+                owner: context.payload.repository.owner.login,
+                repo: context.payload.repository.name,
+                issue_number: context.payload.pull_request.number,
+                labels: ['verify']
+              })
+              core.info(`Updated labels in ${context.payload.pull_request.number}. Added: 'verify'`)
+            } catch (error) {
+              core.setFailed(error.message)
+            }
       - name: Build Maintenance labeling
         if: ${{ github.event.project_card.column_id == env.BUILD_MAINTENANCE_COLUMN_ID }}
         uses: andymckay/labeler@1.0.4


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Use `github-script` to assign verify label. Consecutive calls to the `labeler` action can remove accidentally previous assigned labels

### Benefits

This change avoids https://github.com/andymckay/labeler/issues/40

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

Unmerged automated PRs like: #7950 or #7954
