### PR TITLE
[bitnami/containers] Human friendly name for assign-label job

### DIFF
--- a/.github/workflows/assign-labels.yml
+++ b/.github/workflows/assign-labels.yml
@@ -8,6 +8,7 @@ permissions:
   issues: write
 jobs:
   assign-label:
+    name: Assign label
     runs-on: ubuntu-latest
     steps:
       - id: get-asset


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

* Human friendly name for `assign-label` job in assign-label workflow

### Benefits

It avoids a manual assignment during triage

### Possible drawbacks

None

### Additional information

Follow up: #7961