### PR TITLE
[bitnami/apache] Use for loop to install intermediate bitnami packages

### DIFF
--- a/bitnami/apache/2.4/debian-11/Dockerfile
+++ b/bitnami/apache/2.4/debian-11/Dockerfile
@@ -20,29 +20,18 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Install required system packages and dependencies
 RUN install_packages ca-certificates curl libc6 libcrypt1 libexpat1 libffi7 libgcc-s1 libgmp10 libgnutls30 libhogweed6 libicu67 libidn2-0 libldap-2.4-2 liblzma5 libnettle8 libnghttp2-14 libp11-kit0 libpcre3 libsasl2-2 libssl1.1 libstdc++6 libtasn1-6 libunistring2 libxml2 procps zlib1g
 RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ && \
-    if [ ! -f render-template-1.0.3-153-linux-${OS_ARCH}-debian-11.tar.gz ]; then \
-      curl -SsLf https://downloads.bitnami.com/files/stacksmith/render-template-1.0.3-153-linux-${OS_ARCH}-debian-11.tar.gz -O ; \
-      curl -SsLf https://downloads.bitnami.com/files/stacksmith/render-template-1.0.3-153-linux-${OS_ARCH}-debian-11.tar.gz.sha256 -O ; \
-    fi && \
-    sha256sum -c render-template-1.0.3-153-linux-${OS_ARCH}-debian-11.tar.gz.sha256 && \
-    tar -zxf render-template-1.0.3-153-linux-${OS_ARCH}-debian-11.tar.gz -C /opt/bitnami --strip-components=2 --no-same-owner --wildcards '*/files' && \
-    rm -rf render-template-1.0.3-153-linux-${OS_ARCH}-debian-11.tar.gz render-template-1.0.3-153-linux-${OS_ARCH}-debian-11.tar.gz.sha256
-RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ && \
-    if [ ! -f gosu-1.14.0-154-linux-${OS_ARCH}-debian-11.tar.gz ]; then \
-      curl -SsLf https://downloads.bitnami.com/files/stacksmith/gosu-1.14.0-154-linux-${OS_ARCH}-debian-11.tar.gz -O ; \
-      curl -SsLf https://downloads.bitnami.com/files/stacksmith/gosu-1.14.0-154-linux-${OS_ARCH}-debian-11.tar.gz.sha256 -O ; \
-    fi && \
-    sha256sum -c gosu-1.14.0-154-linux-${OS_ARCH}-debian-11.tar.gz.sha256 && \
-    tar -zxf gosu-1.14.0-154-linux-${OS_ARCH}-debian-11.tar.gz -C /opt/bitnami --strip-components=2 --no-same-owner --wildcards '*/files' && \
-    rm -rf gosu-1.14.0-154-linux-${OS_ARCH}-debian-11.tar.gz gosu-1.14.0-154-linux-${OS_ARCH}-debian-11.tar.gz.sha256
-RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ && \
-    if [ ! -f apache-2.4.54-156-linux-${OS_ARCH}-debian-11.tar.gz ]; then \
-      curl -SsLf https://downloads.bitnami.com/files/stacksmith/apache-2.4.54-156-linux-${OS_ARCH}-debian-11.tar.gz -O ; \
-      curl -SsLf https://downloads.bitnami.com/files/stacksmith/apache-2.4.54-156-linux-${OS_ARCH}-debian-11.tar.gz.sha256 -O ; \
-    fi && \
-    sha256sum -c apache-2.4.54-156-linux-${OS_ARCH}-debian-11.tar.gz.sha256 && \
-    tar -zxf apache-2.4.54-156-linux-${OS_ARCH}-debian-11.tar.gz -C /opt/bitnami --strip-components=2 --no-same-owner --wildcards '*/files' && \
-    rm -rf apache-2.4.54-156-linux-${OS_ARCH}-debian-11.tar.gz apache-2.4.54-156-linux-${OS_ARCH}-debian-11.tar.gz.sha256
+    for COMPONENT in "apache-2.4.54-156-linux-${OS_ARCH}-debian-11.tar.gz" \
+                     "render-template-1.0.3-153-linux-${OS_ARCH}-debian-11.tar.gz" \
+                     "gosu-1.14.0-154-linux-${OS_ARCH}-debian-11.tar.gz"; \
+    do \
+        if [ ! -f "${COMPONENT}" ]; then \
+          curl -SsLf "https://downloads.bitnami.com/files/stacksmith/${COMPONENT}" -O ; \
+          curl -SsLf "https://downloads.bitnami.com/files/stacksmith/${COMPONENT}.sha256" -O ; \
+        fi && \
+        sha256sum -c "${COMPONENT}.sha256" && \
+        tar -zxf "${COMPONENT}" -C /opt/bitnami --strip-components=2 --no-same-owner --wildcards '*/files' && \
+        rm -rf "${COMPONENT}" "${COMPONENT}.sha256" \
+    done
 RUN apt-get update && apt-get upgrade -y && \
     apt-get clean && rm -rf /var/lib/apt/lists /var/cache/apt/archives
 RUN chmod g+rwX /opt/bitnami


### PR DESCRIPTION
### Description of the change

Test to check how the Dockerfile will look if we replace every bitnami package installation with a unique `for` loop

-----------------------

Please note this is just a visual PoC, there should be a syntax error since the container is not buildable:
```console
$  docker build . -t carrodher/test
[+] Building 0.6s (8/13)
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                       0.0s
 => => transferring dockerfile: 2.41kB                                                                                                                                                                                                                                     0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                          0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                            0.0s
 => [internal] load metadata for docker.io/bitnami/minideb:bullseye                                                                                                                                                                                                        0.1s
 => [1/9] FROM docker.io/bitnami/minideb:bullseye@sha256:b9fa6f86c6126b1fa2564c5bfa80e5ab2184192f27a792c31f887eb30ce20f8e                                                                                                                                                  0.0s
 => [internal] load build context                                                                                                                                                                                                                                          0.0s
 => => transferring context: 4.13kB                                                                                                                                                                                                                                        0.0s
 => CACHED [2/9] COPY prebuildfs /                                                                                                                                                                                                                                         0.0s
 => CACHED [3/9] RUN install_packages ca-certificates curl libc6 libcrypt1 libexpat1 libffi7 libgcc-s1 libgmp10 libgnutls30 libhogweed6 libicu67 libidn2-0 libldap-2.4-2 liblzma5 libnettle8 libnghttp2-14 libp11-kit0 libpcre3 libsasl2-2 libssl1.1 libstdc++6 libtasn1-  0.0s
 => ERROR [4/9] RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ &&     for COMPONENT in "apache-2.4.54-156-linux-amd64-debian-11.tar.gz"                      "render-template-1.0.3-153-linux-amd64-debian-11.tar.gz"                      "gosu-1.14  0.5s
------
 > [4/9] RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ &&     for COMPONENT in "apache-2.4.54-156-linux-amd64-debian-11.tar.gz"                      "render-template-1.0.3-153-linux-amd64-debian-11.tar.gz"                      "gosu-1.14.0-154-linux-amd64-debian-11.tar.gz";     do         if [ ! -f "${COMPONENT}" ]; then           curl -SsLf "https://downloads.bitnami.com/files/stacksmith/${COMPONENT}" -O ;           curl -SsLf "https://downloads.bitnami.com/files/stacksmith/${COMPONENT}.sha256" -O ;         fi &&         sha256sum -c "${COMPONENT}.sha256" &&         tar -zxf "${COMPONENT}" -C /opt/bitnami --strip-components=2 --no-same-owner --wildcards '*/files' &&         rm -rf "${COMPONENT}" "${COMPONENT}.sha256"     done:
#8 0.343 /bin/bash: -c: line 2: syntax error: unexpected end of file
------
executor failed running [/bin/bash -o pipefail -c mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ &&     for COMPONENT in "apache-2.4.54-156-linux-${OS_ARCH}-debian-11.tar.gz"                      "render-template-1.0.3-153-linux-${OS_ARCH}-debian-11.tar.gz"                      "gosu-1.14.0-154-linux-${OS_ARCH}-debian-11.tar.gz";     do         if [ ! -f "${COMPONENT}" ]; then           curl -SsLf "https://downloads.bitnami.com/files/stacksmith/${COMPONENT}" -O ;           curl -SsLf "https://downloads.bitnami.com/files/stacksmith/${COMPONENT}.sha256" -O ;         fi &&         sha256sum -c "${COMPONENT}.sha256" &&         tar -zxf "${COMPONENT}" -C /opt/bitnami --strip-components=2 --no-same-owner --wildcards '*/files' &&         rm -rf "${COMPONENT}" "${COMPONENT}.sha256"     done]: exit code: 2
```