### PR TITLE
[bitnami/containers] Fix result check in automatic PRs

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -115,7 +115,7 @@ jobs:
       - get-containers
       - vib-verify
     outputs:
-      result: ${{ steps.get-status.outputs.state }}
+      result: ${{ steps.get-status.outputs.result }}
     if: ${{ always() }}
     steps:
       - id: get-status

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -122,6 +122,7 @@ jobs:
         name: Check Status
         uses: actions/github-script@v6
         with:
+          result-encoding: string
           script: |
             state = 'success'
             description = 'Well done! Everything looks good. Please wait for the Bitnami Team review.'
@@ -139,7 +140,6 @@ jobs:
             } else {
               core.notice(description)
             }
-            core.setOutput('state', state)
             try {
               await github.rest.repos.createCommitStatus({
                 context: `${context.workflow} / Verification Summary (${context.eventName})`,
@@ -154,6 +154,7 @@ jobs:
             } catch (error) {
               core.setFailed(error.message)
             }
+            return state
   auto-pr-review:
     runs-on: ubuntu-latest
     name: Reviewal for automated PRs

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -114,9 +114,12 @@ jobs:
     needs:
       - get-containers
       - vib-verify
+    outputs:
+      result: ${{ steps.get-status.outputs.result }}
     if: ${{ always() }}
     steps:
-      - name: Check Status
+      - id: get-status
+        name: Check Status
         uses: actions/github-script@v6
         with:
           script: |
@@ -136,6 +139,7 @@ jobs:
             } else {
               core.notice(description)
             }
+            core.setOutput('result', state)
             try {
               await github.rest.repos.createCommitStatus({
                 context: `${context.workflow} / Verification Summary (${context.eventName})`,
@@ -161,7 +165,7 @@ jobs:
       github.event.pull_request.user.login == 'bitnami-bot'
     steps:
       - name: Enable auto-merge feature
-        if: ${{ needs.verification-summary.result == 'success' }}
+        if: ${{ needs.verification-summary.outputs.result == 'success' }}
         uses: reitermarkus/automerge@v2.1.2
         with:
           # Necessary to trigger CD workflow
@@ -169,12 +173,12 @@ jobs:
           merge-method: squash
           pull-request: ${{ github.event.number }}
       - name: PR Approval
-        if: ${{ needs.verification-summary.result == 'success' }}
+        if: ${{ needs.verification-summary.outputs.result == 'success' }}
         uses: hmarr/auto-approve-action@v2.4.0
         with:
           pull-request-number: ${{ github.event.number }}
       - name: Manual review required
-        if: ${{ needs.verification-summary.result != 'success' }}
+        if: ${{ needs.verification-summary.outputs.result != 'success' }}
         uses: peter-evans/create-or-update-comment@v2.0.0
         with:
           issue-number: ${{ github.event.number }}

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -115,7 +115,7 @@ jobs:
       - get-containers
       - vib-verify
     outputs:
-      result: ${{ steps.get-status.outputs.result }}
+      result: ${{ steps.get-status.outputs.state }}
     if: ${{ always() }}
     steps:
       - id: get-status
@@ -139,7 +139,7 @@ jobs:
             } else {
               core.notice(description)
             }
-            core.setOutput('result', state)
+            core.setOutput('state', state)
             try {
               await github.rest.repos.createCommitStatus({
                 context: `${context.workflow} / Verification Summary (${context.eventName})`,


### PR DESCRIPTION
Signed-off-by: Fran Mulero <fmulero@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Use the right output to check if the PR can be merged or not. 

### Benefits

Currently if `VIB verify` fails the `auto-pr-review` job won't retrieve that failure because is using the exit code from `verification-summary`

### Possible drawbacks

None

### Additional information

The following log came from previous PR (#8772) which was reverted:

```
::set-output name=result::error
##[debug]steps.get-status.outputs.result='error'

::set-output name=result::
##[debug]steps.get-status.outputs.result=''
##[debug]Node Action run completed with exit code 0
##[debug]Finishing: Check Status
```

`github-script` uses the `result` output by default for any `return` from the script: https://github.com/actions/github-script#reading-step-results

Follow up: #8772 