### PR TITLE
[bitnami/*] Allow for publish pipeline's branch granularity

### DIFF
--- a/.github/workflows/cd-pipeline-harbor.yml
+++ b/.github/workflows/cd-pipeline-harbor.yml
@@ -78,19 +78,29 @@ jobs:
               exit 1
             else
               name="$(echo "${{ matrix.container }}" | awk -F '/' '{print $2}')"
+              branch="$(echo "${{ matrix.container }}" | awk -F '/' '{print $3}')"
               echo "::set-output name=tag::${tag}"
               echo "::set-output name=name::${name}"
+              echo "::set-output name=branch::${branch}"
               echo "::set-output name=result::ok"
             fi
           else
             # Container folder doesn't exists we are assuming a deprecation
             echo "::set-output name=result::skip"
           fi
+      - id: get-dsl-filepath
+        name: Get pipeline DSL filepath
+        run: |
+          dsl_path="${{ steps.get-container-metadata.outputs.name }}"
+          if [[ -d ".vib/${dsl_path}/${{ steps.get-container-metadata.outputs.branch }}" ]]; then
+            dsl_path="${dsl_path}/${{ steps.get-container-metadata.outputs.branch }}"
+          fi
+          echo "::set-output name=dsl_path::${dsl_path}"
       - uses: vmware-labs/vmware-image-builder-action@main
         name: 'Publish ${{ steps.get-container-metadata.outputs.name }}: ${{ steps.get-container-metadata.outputs.tag }}'
         if: ${{ steps.get-container-metadata.outputs.result == 'ok' }}
         with:
-          pipeline: ${{ steps.get-container-metadata.outputs.name }}/vib-publish.json
+          pipeline: ${{ steps.get-dsl-filepath.outputs.dsl_path }}/vib-publish.json
         env:
           # Path with docker resources
           VIB_ENV_PATH:  ${{ matrix.container }}

--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -78,8 +78,10 @@ jobs:
               exit 1
             else
               name="$(echo "${{ matrix.container }}" | awk -F '/' '{print $2}')"
+              branch="$(echo "${{ matrix.container }}" | awk -F '/' '{print $3}')"
               echo "::set-output name=tag::${tag}"
               echo "::set-output name=name::${name}"
+              echo "::set-output name=branch::${branch}"
               echo "::set-output name=result::ok"
             fi
           else
@@ -97,11 +99,19 @@ jobs:
           echo "::add-mask::${marketplace_passwd}"
           echo "::set-output name=marketplace_user::${marketplace_user}"
           echo "::set-output name=marketplace_passwd::${marketplace_passwd}"
+      - id: get-dsl-filepath
+        name: Get pipeline DSL filepath
+        run: |
+          dsl_path="${{ steps.get-container-metadata.outputs.name }}"
+          if [[ -d ".vib/${dsl_path}/${{ steps.get-container-metadata.outputs.branch }}" ]]; then
+            dsl_path="${dsl_path}/${{ steps.get-container-metadata.outputs.branch }}"
+          fi
+          echo "::set-output name=dsl_path::${dsl_path}"
       - uses: vmware-labs/vmware-image-builder-action@main
         name: 'Publish ${{ steps.get-container-metadata.outputs.name }}: ${{ steps.get-container-metadata.outputs.tag }}'
         if: ${{ steps.get-container-metadata.outputs.result == 'ok' }}
         with:
-          pipeline: ${{ steps.get-container-metadata.outputs.name }}/vib-publish.json
+          pipeline: ${{ steps.get-dsl-filepath.outputs.dsl_path }}/vib-publish.json
         env:
           # Path with docker resources
           VIB_ENV_PATH:  ${{ matrix.container }}

--- a/.vib/envoy/1.20/vib-publish.json
+++ b/.vib/envoy/1.20/vib-publish.json
@@ -18,8 +18,7 @@
               }
             },
             "architectures": [
-              "linux/amd64",
-              "linux/arm64"
+              "linux/amd64"
             ]
           }
         },

--- a/.vib/mariadb-galera/10.3/vib-publish.json
+++ b/.vib/mariadb-galera/10.3/vib-publish.json
@@ -18,8 +18,7 @@
               }
             },
             "architectures": [
-              "linux/amd64",
-              "linux/arm64"
+              "linux/amd64"
             ]
           }
         },

--- a/.vib/mariadb-galera/10.4/vib-publish.json
+++ b/.vib/mariadb-galera/10.4/vib-publish.json
@@ -18,8 +18,7 @@
               }
             },
             "architectures": [
-              "linux/amd64",
-              "linux/arm64"
+              "linux/amd64"
             ]
           }
         },

--- a/.vib/mariadb-galera/vib-publish.json
+++ b/.vib/mariadb-galera/vib-publish.json
@@ -18,7 +18,8 @@
               }
             },
             "architectures": [
-              "linux/amd64"
+              "linux/amd64",
+              "linux/arm64"
             ]
           }
         },

--- a/.vib/mariadb/10.3/vib-publish.json
+++ b/.vib/mariadb/10.3/vib-publish.json
@@ -18,8 +18,7 @@
               }
             },
             "architectures": [
-              "linux/amd64",
-              "linux/arm64"
+              "linux/amd64"
             ]
           }
         },

--- a/.vib/mariadb/10.4/vib-publish.json
+++ b/.vib/mariadb/10.4/vib-publish.json
@@ -18,8 +18,7 @@
               }
             },
             "architectures": [
-              "linux/amd64",
-              "linux/arm64"
+              "linux/amd64"
             ]
           }
         },

--- a/.vib/mariadb/vib-publish.json
+++ b/.vib/mariadb/vib-publish.json
@@ -18,7 +18,8 @@
               }
             },
             "architectures": [
-              "linux/amd64"
+              "linux/amd64",
+              "linux/arm64"
             ]
           }
         },

--- a/.vib/odoo/13/vib-publish.json
+++ b/.vib/odoo/13/vib-publish.json
@@ -18,8 +18,7 @@
               }
             },
             "architectures": [
-              "linux/amd64",
-              "linux/arm64"
+              "linux/amd64"
             ]
           }
         },

--- a/.vib/odoo/14/vib-publish.json
+++ b/.vib/odoo/14/vib-publish.json
@@ -18,8 +18,7 @@
               }
             },
             "architectures": [
-              "linux/amd64",
-              "linux/arm64"
+              "linux/amd64"
             ]
           }
         },

--- a/.vib/odoo/vib-publish.json
+++ b/.vib/odoo/vib-publish.json
@@ -18,7 +18,8 @@
               }
             },
             "architectures": [
-              "linux/amd64"
+              "linux/amd64",
+              "linux/arm64"
             ]
           }
         },

--- a/.vib/parse/4/vib-publish.json
+++ b/.vib/parse/4/vib-publish.json
@@ -18,8 +18,7 @@
               }
             },
             "architectures": [
-              "linux/amd64",
-              "linux/arm64"
+              "linux/amd64"
             ]
           }
         },

--- a/.vib/parse/vib-publish.json
+++ b/.vib/parse/vib-publish.json
@@ -18,7 +18,8 @@
               }
             },
             "architectures": [
-              "linux/amd64"
+              "linux/amd64",
+              "linux/arm64"
             ]
           }
         },


### PR DESCRIPTION
Signed-off-by: FraPazGal <fdepaz@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

This PR updates the CD logic so it checks for specific `vib-publish.json` pipeline definitions for the modified branch/es in that commit. For each asset's branch modified it will:

- Check if there is a branch's folder under `.vib/asset/branch`:
  - If the folder exists, use `.vib/asset/branch/vib-publish.json` as the DSL path.
  - If it doesn't exist, use the default `.vib/asset/vib-publish.json`.

Given that non-ARM branches are usually the oldest ones, we will create a non-ARM publish pipeline for each of those branches and leave a common publish pipeline supporting ARM for the rest of the asset branches. The assets with branches supporting different architectures are:

- Envoy --> branch 1.20 does not support ARM64
- MariaDB Galera --> branches 10.3 & 10.4 do not support ARM64
- MariaDB --> branches 10.3 & 10.4 do not support ARM64
- Odoo --> branches 13 & 14 do not support ARM64
- Parse --> branch 4 does not support ARM64

### Benefits

Allows for publish pipeline's branch granularity.

### Possible drawbacks

As it is, we are duplicating a lot of code, but this is unavoidable unless we do a major refactor to build our final vib pipelines using `jsonnet` files.

### Additional information

Tested in fork: https://github.com/FraPazGal/containers/actions/runs/3188969818/jobs/5202241895


