### PR TITLE
[bitnami/clickhouse] find symlink configuration to override settings

### DIFF
--- a/bitnami/clickhouse/22.8/debian-11/rootfs/opt/bitnami/scripts/libclickhouse.sh
+++ b/bitnami/clickhouse/22.8/debian-11/rootfs/opt/bitnami/scripts/libclickhouse.sh
@@ -78,16 +78,16 @@ clickhouse_copy_mounted_configuration() {
             info "Copying mounted configuration from $CLICKHOUSE_MOUNTED_CONF_DIR"
             # Copy first the files at the base of the mounted folder to go to ClickHouse
             # base etc folder
-            find "$CLICKHOUSE_MOUNTED_CONF_DIR" -maxdepth 1 -type f -exec cp -L {} "$CLICKHOUSE_CONF_DIR" \;
+            find "$CLICKHOUSE_MOUNTED_CONF_DIR" -maxdepth 1 -type f,l -exec cp -L {} "$CLICKHOUSE_CONF_DIR" \;
 
             # The ClickHouse override directories (etc/conf.d and etc/users.d) do not support subfolders. That means we cannot
             # copy directly with cp -RL because we need all override xml files to have at the root of these subfolders. In the helm
             # chart we want to allow overrides from different ConfigMaps and Secrets so we need to use the find command
             if [[ -d "${CLICKHOUSE_MOUNTED_CONF_DIR}/conf.d" ]]; then
-                find "${CLICKHOUSE_MOUNTED_CONF_DIR}/conf.d" -type f -exec cp -L {} "${CLICKHOUSE_CONF_DIR}/conf.d" \;
+                find "${CLICKHOUSE_MOUNTED_CONF_DIR}/conf.d" -type f,l -exec cp -L {} "${CLICKHOUSE_CONF_DIR}/conf.d" \;
             fi
             if [[ -d "${CLICKHOUSE_MOUNTED_CONF_DIR}/users.d" ]]; then
-                find "${CLICKHOUSE_MOUNTED_CONF_DIR}/users.d" -type f -exec cp -L {} "${CLICKHOUSE_CONF_DIR}/users.d" \;
+                find "${CLICKHOUSE_MOUNTED_CONF_DIR}/users.d" -type f,l -exec cp -L {} "${CLICKHOUSE_CONF_DIR}/users.d" \;
             fi
         fi
     else


### PR DESCRIPTION
Signed-off-by: LiuHanCheng <buaa_cnlhc@buaa.edu.cn>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Find the symbol link files in the mounted configuration directory to help the user override the default clickhouse configuration.
<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Currently, if a user provides symbol link configuration files, those files will not be discovered by the setup script and omitted.
Adding `-type l` will solve this problem.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

Adding `-type l` may find some directories and cause several warnings during the copying process.
<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
