### PR TITLE
[bitnami/postresql] Removed curl removal

### DIFF
--- a/bitnami/postgresql/10/debian-11/Dockerfile
+++ b/bitnami/postgresql/10/debian-11/Dockerfile
@@ -34,8 +34,7 @@ RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ && \
       tar -zxf "${COMPONENT}.tar.gz" -C /opt/bitnami --strip-components=2 --no-same-owner --wildcards '*/files' && \
       rm -rf "${COMPONENT}.tar.gz{,sha256}" ; \
     done
-RUN apt-get autoremove --purge -y curl && \
-    apt-get update && apt-get upgrade -y && \
+RUN apt-get update && apt-get upgrade -y && \
     apt-get clean && rm -rf /var/lib/apt/lists /var/cache/apt/archives
 RUN chmod g+rwX /opt/bitnami
 RUN localedef -c -f UTF-8 -i en_US en_US.UTF-8

--- a/bitnami/postgresql/11/debian-11/Dockerfile
+++ b/bitnami/postgresql/11/debian-11/Dockerfile
@@ -34,8 +34,7 @@ RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ && \
       tar -zxf "${COMPONENT}.tar.gz" -C /opt/bitnami --strip-components=2 --no-same-owner --wildcards '*/files' && \
       rm -rf "${COMPONENT}.tar.gz{,sha256}" ; \
     done
-RUN apt-get autoremove --purge -y curl && \
-    apt-get update && apt-get upgrade -y && \
+RUN apt-get update && apt-get upgrade -y && \
     apt-get clean && rm -rf /var/lib/apt/lists /var/cache/apt/archives
 RUN chmod g+rwX /opt/bitnami
 RUN localedef -c -f UTF-8 -i en_US en_US.UTF-8

--- a/bitnami/postgresql/12/debian-11/Dockerfile
+++ b/bitnami/postgresql/12/debian-11/Dockerfile
@@ -34,8 +34,7 @@ RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ && \
       tar -zxf "${COMPONENT}.tar.gz" -C /opt/bitnami --strip-components=2 --no-same-owner --wildcards '*/files' && \
       rm -rf "${COMPONENT}.tar.gz{,sha256}" ; \
     done
-RUN apt-get autoremove --purge -y curl && \
-    apt-get update && apt-get upgrade -y && \
+RUN apt-get update && apt-get upgrade -y && \
     apt-get clean && rm -rf /var/lib/apt/lists /var/cache/apt/archives
 RUN chmod g+rwX /opt/bitnami
 RUN localedef -c -f UTF-8 -i en_US en_US.UTF-8

--- a/bitnami/postgresql/13/debian-11/Dockerfile
+++ b/bitnami/postgresql/13/debian-11/Dockerfile
@@ -34,8 +34,7 @@ RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ && \
       tar -zxf "${COMPONENT}.tar.gz" -C /opt/bitnami --strip-components=2 --no-same-owner --wildcards '*/files' && \
       rm -rf "${COMPONENT}.tar.gz{,sha256}" ; \
     done
-RUN apt-get autoremove --purge -y curl && \
-    apt-get update && apt-get upgrade -y && \
+RUN apt-get update && apt-get upgrade -y && \
     apt-get clean && rm -rf /var/lib/apt/lists /var/cache/apt/archives
 RUN chmod g+rwX /opt/bitnami
 RUN localedef -c -f UTF-8 -i en_US en_US.UTF-8

--- a/bitnami/postgresql/14/debian-11/Dockerfile
+++ b/bitnami/postgresql/14/debian-11/Dockerfile
@@ -37,8 +37,7 @@ RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ && \
     sha256sum -c postgresql-14.5.0-10-linux-${OS_ARCH}-debian-11.tar.gz.sha256 && \
     tar -zxf postgresql-14.5.0-10-linux-${OS_ARCH}-debian-11.tar.gz -C /opt/bitnami --strip-components=2 --no-same-owner --wildcards '*/files' && \
     rm -rf postgresql-14.5.0-10-linux-${OS_ARCH}-debian-11.tar.gz postgresql-14.5.0-10-linux-${OS_ARCH}-debian-11.tar.gz.sha256
-RUN apt-get autoremove --purge -y curl && \
-    apt-get update && apt-get upgrade -y && \
+RUN apt-get update && apt-get upgrade -y && \
     apt-get clean && rm -rf /var/lib/apt/lists /var/cache/apt/archives
 RUN chmod g+rwX /opt/bitnami
 RUN localedef -c -f UTF-8 -i en_US en_US.UTF-8


### PR DESCRIPTION
### Description of the change

The latest automated updates (e.g. https://github.com/bitnami/containers/pull/8834) removed curl. Since the removal might be breaking for some users (as noted here https://github.com/bitnami/containers/commit/6158f772fbdc67abc07a4c8a526dc27e182f6809#r85770695), it is hereby removed.

### Benefits

Projects using postresql and curl don't break.

### Possible drawbacks

I can't think of any.

### Applicable issues

  - relates to #8834