### PR TITLE
[postgresql-repmgr] pg_rewind ensure clean shutdown

### DIFF
--- a/bitnami/postgresql-repmgr/11/debian-11/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/bitnami/postgresql-repmgr/11/debian-11/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -170,6 +170,22 @@ postgresql_create_config() {
 }
 
 ########################
+# Copy the files if there is an User injected configuration
+# Globals:
+#   POSTGRESQL_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+postgresql_copy_custom_configuration() {
+    if [[ -d "$POSTGRESQL_MOUNTED_CONF_DIR" ]] && compgen -G "$POSTGRESQL_MOUNTED_CONF_DIR"/* >/dev/null; then
+        debug "Copying files from $POSTGRESQL_MOUNTED_CONF_DIR to $POSTGRESQL_CONF_DIR"
+        cp -fr "$POSTGRESQL_MOUNTED_CONF_DIR"/. "$POSTGRESQL_CONF_DIR"
+    fi
+}
+
+########################
 # Create ldap auth configuration in pg_hba,
 # but keeps postgres user to authenticate locally
 # Globals:
@@ -574,10 +590,8 @@ postgresql_initialize() {
     rm -f "$POSTGRESQL_PID_FILE"
 
     # User injected custom configuration
-    if [[ -d "$POSTGRESQL_MOUNTED_CONF_DIR" ]] && compgen -G "$POSTGRESQL_MOUNTED_CONF_DIR"/* >/dev/null; then
-        debug "Copying files from $POSTGRESQL_MOUNTED_CONF_DIR to $POSTGRESQL_CONF_DIR"
-        cp -fr "$POSTGRESQL_MOUNTED_CONF_DIR"/. "$POSTGRESQL_CONF_DIR"
-    fi
+    postgresql_copy_custom_configuration
+
     local create_conf_file=yes
     local create_pghba_file=yes
 

--- a/bitnami/postgresql-repmgr/11/debian-11/rootfs/opt/bitnami/scripts/librepmgr.sh
+++ b/bitnami/postgresql-repmgr/11/debian-11/rootfs/opt/bitnami/scripts/librepmgr.sh
@@ -632,6 +632,17 @@ repmgr_clone_primary() {
 #########################
 repmgr_pgrewind() {
     info "Running pg_rewind data to primary node..."
+
+    postgresql_create_pghba
+    postgresql_copy_custom_configuration
+
+    info "Starting PostgreSQL in background..."
+    local -r pg_ctl_flags=("-w" "-D" "$POSTGRESQL_DATA_DIR" "-o" "-F --config-file=$POSTGRESQL_CONF_FILE --external_pid_file=$POSTGRESQL_PID_FILE --hba_file=$POSTGRESQL_PGHBA_FILE")
+    "$POSTGRESQL_BIN_DIR"/pg_ctl "start" "${pg_ctl_flags[@]}"
+
+    info "Stopping PostgreSQL..."
+    "$POSTGRESQL_BIN_DIR"/pg_ctl "stop" "${pg_ctl_flags[@]}"
+
     local -r flags=("-D" "$POSTGRESQL_DATA_DIR" "--source-server" "host=${REPMGR_CURRENT_PRIMARY_HOST} port=${REPMGR_CURRENT_PRIMARY_PORT} user=${REPMGR_USERNAME} dbname=${REPMGR_DATABASE}")
 
     if [[ "$REPMGR_USE_PASSFILE" = "true" ]]; then

--- a/bitnami/postgresql-repmgr/11/debian-11/rootfs/opt/bitnami/scripts/librepmgr.sh
+++ b/bitnami/postgresql-repmgr/11/debian-11/rootfs/opt/bitnami/scripts/librepmgr.sh
@@ -665,7 +665,7 @@ repmgr_rewind() {
     info "Rejoining node..."
 
     ensure_dir_exists "$POSTGRESQL_DATA_DIR"
-    if is_boolean_yes "$REPMGR_USE_PGREWIND"; then
+    if is_boolean_yes "$REPMGR_USE_PGREWIND" && ! is_boolean_yes "$REPMGR_SWITCH_ROLE"; then
         info "Using pg_rewind to primary node..."
         if ! repmgr_pgrewind; then
             warn "pg_rewind failed, resorting to data cloning"

--- a/bitnami/postgresql-repmgr/11/debian-11/rootfs/opt/bitnami/scripts/librepmgr.sh
+++ b/bitnami/postgresql-repmgr/11/debian-11/rootfs/opt/bitnami/scripts/librepmgr.sh
@@ -206,6 +206,7 @@ repmgr_get_primary_node() {
     local upstream_port
     local primary_host=""
     local primary_port="$REPMGR_PRIMARY_PORT"
+    local switch_role="no"
 
     readarray -t upstream_node < <(repmgr_get_upstream_node)
     upstream_host=${upstream_node[0]}
@@ -220,7 +221,7 @@ repmgr_get_primary_node() {
         else
             info "Current master is '${upstream_host}:${upstream_port}'. Cloning/rewinding it and acting as a standby node..."
             rm -f "$REPMGR_PRIMARY_ROLE_LOCK_FILE_NAME"
-            export REPMGR_SWITCH_ROLE="yes"
+            switch_role="yes"
             primary_host="$upstream_host"
             primary_port="$upstream_port"
         fi
@@ -239,6 +240,7 @@ repmgr_get_primary_node() {
     [[ -n "$primary_host" ]] && debug "Primary node: '${primary_host}:${primary_port}'"
     echo "$primary_host"
     echo "$primary_port"
+    echo "$switch_role"
 }
 
 ########################
@@ -255,10 +257,12 @@ repmgr_set_role() {
     local primary_node
     local primary_host
     local primary_port
+    local switch_role
 
     readarray -t primary_node < <(repmgr_get_primary_node)
     primary_host=${primary_node[0]}
     primary_port=${primary_node[1]:-$REPMGR_PRIMARY_PORT}
+    switch_role=${primary_node[2]}
 
     if [[ -z "$primary_host" ]]; then
         info "There are no nodes with primary role. Assuming the primary role..."
@@ -269,6 +273,7 @@ repmgr_set_role() {
 export REPMGR_ROLE="$role"
 export REPMGR_CURRENT_PRIMARY_HOST="$primary_host"
 export REPMGR_CURRENT_PRIMARY_PORT="$primary_port"
+export REPMGR_SWITCH_ROLE="$switch_role"
 EOF
 }
 

--- a/bitnami/postgresql-repmgr/11/debian-11/rootfs/opt/bitnami/scripts/librepmgr.sh
+++ b/bitnami/postgresql-repmgr/11/debian-11/rootfs/opt/bitnami/scripts/librepmgr.sh
@@ -643,7 +643,13 @@ repmgr_pgrewind() {
     info "Stopping PostgreSQL..."
     "$POSTGRESQL_BIN_DIR"/pg_ctl "stop" "${pg_ctl_flags[@]}"
 
-    local -r flags=("-D" "$POSTGRESQL_DATA_DIR" "--source-server" "host=${REPMGR_CURRENT_PRIMARY_HOST} port=${REPMGR_CURRENT_PRIMARY_PORT} user=${REPMGR_USERNAME} dbname=${REPMGR_DATABASE}")
+    local -r psql_major_version="$(postgresql_get_major_version)"
+
+    local flags=("-D" "$POSTGRESQL_DATA_DIR" "--source-server" "host=${REPMGR_CURRENT_PRIMARY_HOST} port=${REPMGR_CURRENT_PRIMARY_PORT} user=${REPMGR_USERNAME} dbname=${REPMGR_DATABASE}")
+
+    if [[ "$psql_major_version" -gt "12" ]]; then
+        flags+=("--no-ensure-shutdown")
+    fi
 
     if [[ "$REPMGR_USE_PASSFILE" = "true" ]]; then
         PGPASSFILE="$REPMGR_PASSFILE_PATH" debug_execute "${POSTGRESQL_BIN_DIR}/pg_rewind" "${flags[@]}"

--- a/bitnami/postgresql-repmgr/12/debian-11/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/bitnami/postgresql-repmgr/12/debian-11/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -170,6 +170,22 @@ postgresql_create_config() {
 }
 
 ########################
+# Copy the files if there is an User injected configuration
+# Globals:
+#   POSTGRESQL_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+postgresql_copy_custom_configuration() {
+    if [[ -d "$POSTGRESQL_MOUNTED_CONF_DIR" ]] && compgen -G "$POSTGRESQL_MOUNTED_CONF_DIR"/* >/dev/null; then
+        debug "Copying files from $POSTGRESQL_MOUNTED_CONF_DIR to $POSTGRESQL_CONF_DIR"
+        cp -fr "$POSTGRESQL_MOUNTED_CONF_DIR"/. "$POSTGRESQL_CONF_DIR"
+    fi
+}
+
+########################
 # Create ldap auth configuration in pg_hba,
 # but keeps postgres user to authenticate locally
 # Globals:
@@ -574,10 +590,8 @@ postgresql_initialize() {
     rm -f "$POSTGRESQL_PID_FILE"
 
     # User injected custom configuration
-    if [[ -d "$POSTGRESQL_MOUNTED_CONF_DIR" ]] && compgen -G "$POSTGRESQL_MOUNTED_CONF_DIR"/* >/dev/null; then
-        debug "Copying files from $POSTGRESQL_MOUNTED_CONF_DIR to $POSTGRESQL_CONF_DIR"
-        cp -fr "$POSTGRESQL_MOUNTED_CONF_DIR"/. "$POSTGRESQL_CONF_DIR"
-    fi
+    postgresql_copy_custom_configuration
+
     local create_conf_file=yes
     local create_pghba_file=yes
 

--- a/bitnami/postgresql-repmgr/12/debian-11/rootfs/opt/bitnami/scripts/librepmgr.sh
+++ b/bitnami/postgresql-repmgr/12/debian-11/rootfs/opt/bitnami/scripts/librepmgr.sh
@@ -632,6 +632,17 @@ repmgr_clone_primary() {
 #########################
 repmgr_pgrewind() {
     info "Running pg_rewind data to primary node..."
+
+    postgresql_create_pghba
+    postgresql_copy_custom_configuration
+
+    info "Starting PostgreSQL in background..."
+    local -r pg_ctl_flags=("-w" "-D" "$POSTGRESQL_DATA_DIR" "-o" "-F --config-file=$POSTGRESQL_CONF_FILE --external_pid_file=$POSTGRESQL_PID_FILE --hba_file=$POSTGRESQL_PGHBA_FILE")
+    "$POSTGRESQL_BIN_DIR"/pg_ctl "start" "${pg_ctl_flags[@]}"
+
+    info "Stopping PostgreSQL..."
+    "$POSTGRESQL_BIN_DIR"/pg_ctl "stop" "${pg_ctl_flags[@]}"
+
     local -r flags=("-D" "$POSTGRESQL_DATA_DIR" "--source-server" "host=${REPMGR_CURRENT_PRIMARY_HOST} port=${REPMGR_CURRENT_PRIMARY_PORT} user=${REPMGR_USERNAME} dbname=${REPMGR_DATABASE}")
 
     if [[ "$REPMGR_USE_PASSFILE" = "true" ]]; then

--- a/bitnami/postgresql-repmgr/12/debian-11/rootfs/opt/bitnami/scripts/librepmgr.sh
+++ b/bitnami/postgresql-repmgr/12/debian-11/rootfs/opt/bitnami/scripts/librepmgr.sh
@@ -665,7 +665,7 @@ repmgr_rewind() {
     info "Rejoining node..."
 
     ensure_dir_exists "$POSTGRESQL_DATA_DIR"
-    if is_boolean_yes "$REPMGR_USE_PGREWIND"; then
+    if is_boolean_yes "$REPMGR_USE_PGREWIND" && ! is_boolean_yes "$REPMGR_SWITCH_ROLE"; then
         info "Using pg_rewind to primary node..."
         if ! repmgr_pgrewind; then
             warn "pg_rewind failed, resorting to data cloning"

--- a/bitnami/postgresql-repmgr/12/debian-11/rootfs/opt/bitnami/scripts/librepmgr.sh
+++ b/bitnami/postgresql-repmgr/12/debian-11/rootfs/opt/bitnami/scripts/librepmgr.sh
@@ -206,6 +206,7 @@ repmgr_get_primary_node() {
     local upstream_port
     local primary_host=""
     local primary_port="$REPMGR_PRIMARY_PORT"
+    local switch_role="no"
 
     readarray -t upstream_node < <(repmgr_get_upstream_node)
     upstream_host=${upstream_node[0]}
@@ -220,7 +221,7 @@ repmgr_get_primary_node() {
         else
             info "Current master is '${upstream_host}:${upstream_port}'. Cloning/rewinding it and acting as a standby node..."
             rm -f "$REPMGR_PRIMARY_ROLE_LOCK_FILE_NAME"
-            export REPMGR_SWITCH_ROLE="yes"
+            switch_role="yes"
             primary_host="$upstream_host"
             primary_port="$upstream_port"
         fi
@@ -239,6 +240,7 @@ repmgr_get_primary_node() {
     [[ -n "$primary_host" ]] && debug "Primary node: '${primary_host}:${primary_port}'"
     echo "$primary_host"
     echo "$primary_port"
+    echo "$switch_role"
 }
 
 ########################
@@ -255,10 +257,12 @@ repmgr_set_role() {
     local primary_node
     local primary_host
     local primary_port
+    local switch_role
 
     readarray -t primary_node < <(repmgr_get_primary_node)
     primary_host=${primary_node[0]}
     primary_port=${primary_node[1]:-$REPMGR_PRIMARY_PORT}
+    switch_role=${primary_node[2]}
 
     if [[ -z "$primary_host" ]]; then
         info "There are no nodes with primary role. Assuming the primary role..."
@@ -269,6 +273,7 @@ repmgr_set_role() {
 export REPMGR_ROLE="$role"
 export REPMGR_CURRENT_PRIMARY_HOST="$primary_host"
 export REPMGR_CURRENT_PRIMARY_PORT="$primary_port"
+export REPMGR_SWITCH_ROLE="$switch_role"
 EOF
 }
 

--- a/bitnami/postgresql-repmgr/12/debian-11/rootfs/opt/bitnami/scripts/librepmgr.sh
+++ b/bitnami/postgresql-repmgr/12/debian-11/rootfs/opt/bitnami/scripts/librepmgr.sh
@@ -643,7 +643,13 @@ repmgr_pgrewind() {
     info "Stopping PostgreSQL..."
     "$POSTGRESQL_BIN_DIR"/pg_ctl "stop" "${pg_ctl_flags[@]}"
 
-    local -r flags=("-D" "$POSTGRESQL_DATA_DIR" "--source-server" "host=${REPMGR_CURRENT_PRIMARY_HOST} port=${REPMGR_CURRENT_PRIMARY_PORT} user=${REPMGR_USERNAME} dbname=${REPMGR_DATABASE}")
+    local -r psql_major_version="$(postgresql_get_major_version)"
+
+    local flags=("-D" "$POSTGRESQL_DATA_DIR" "--source-server" "host=${REPMGR_CURRENT_PRIMARY_HOST} port=${REPMGR_CURRENT_PRIMARY_PORT} user=${REPMGR_USERNAME} dbname=${REPMGR_DATABASE}")
+
+    if [[ "$psql_major_version" -gt "12" ]]; then
+        flags+=("--no-ensure-shutdown")
+    fi
 
     if [[ "$REPMGR_USE_PASSFILE" = "true" ]]; then
         PGPASSFILE="$REPMGR_PASSFILE_PATH" debug_execute "${POSTGRESQL_BIN_DIR}/pg_rewind" "${flags[@]}"

--- a/bitnami/postgresql-repmgr/13/debian-11/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/bitnami/postgresql-repmgr/13/debian-11/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -170,6 +170,22 @@ postgresql_create_config() {
 }
 
 ########################
+# Copy the files if there is an User injected configuration
+# Globals:
+#   POSTGRESQL_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+postgresql_copy_custom_configuration() {
+    if [[ -d "$POSTGRESQL_MOUNTED_CONF_DIR" ]] && compgen -G "$POSTGRESQL_MOUNTED_CONF_DIR"/* >/dev/null; then
+        debug "Copying files from $POSTGRESQL_MOUNTED_CONF_DIR to $POSTGRESQL_CONF_DIR"
+        cp -fr "$POSTGRESQL_MOUNTED_CONF_DIR"/. "$POSTGRESQL_CONF_DIR"
+    fi
+}
+
+########################
 # Create ldap auth configuration in pg_hba,
 # but keeps postgres user to authenticate locally
 # Globals:
@@ -574,10 +590,8 @@ postgresql_initialize() {
     rm -f "$POSTGRESQL_PID_FILE"
 
     # User injected custom configuration
-    if [[ -d "$POSTGRESQL_MOUNTED_CONF_DIR" ]] && compgen -G "$POSTGRESQL_MOUNTED_CONF_DIR"/* >/dev/null; then
-        debug "Copying files from $POSTGRESQL_MOUNTED_CONF_DIR to $POSTGRESQL_CONF_DIR"
-        cp -fr "$POSTGRESQL_MOUNTED_CONF_DIR"/. "$POSTGRESQL_CONF_DIR"
-    fi
+    postgresql_copy_custom_configuration
+
     local create_conf_file=yes
     local create_pghba_file=yes
 

--- a/bitnami/postgresql-repmgr/13/debian-11/rootfs/opt/bitnami/scripts/librepmgr.sh
+++ b/bitnami/postgresql-repmgr/13/debian-11/rootfs/opt/bitnami/scripts/librepmgr.sh
@@ -632,7 +632,18 @@ repmgr_clone_primary() {
 #########################
 repmgr_pgrewind() {
     info "Running pg_rewind data to primary node..."
-    local -r flags=("-D" "$POSTGRESQL_DATA_DIR" "--source-server" "host=${REPMGR_CURRENT_PRIMARY_HOST} port=${REPMGR_CURRENT_PRIMARY_PORT} user=${REPMGR_USERNAME} dbname=${REPMGR_DATABASE}")
+
+    postgresql_create_pghba
+    postgresql_copy_custom_configuration
+
+    info "Starting PostgreSQL in background..."
+    local -r pg_ctl_flags=("-w" "-D" "$POSTGRESQL_DATA_DIR" "-o" "-F --config-file=$POSTGRESQL_CONF_FILE --external_pid_file=$POSTGRESQL_PID_FILE --hba_file=$POSTGRESQL_PGHBA_FILE")
+    "$POSTGRESQL_BIN_DIR"/pg_ctl "start" "${pg_ctl_flags[@]}"
+
+    info "Stopping PostgreSQL..."
+    "$POSTGRESQL_BIN_DIR"/pg_ctl "stop" "${pg_ctl_flags[@]}"
+
+    local -r flags=("-D" "$POSTGRESQL_DATA_DIR" "--no-ensure-shutdown" "--source-server" "host=${REPMGR_CURRENT_PRIMARY_HOST} port=${REPMGR_CURRENT_PRIMARY_PORT} user=${REPMGR_USERNAME} dbname=${REPMGR_DATABASE}")
 
     if [[ "$REPMGR_USE_PASSFILE" = "true" ]]; then
         PGPASSFILE="$REPMGR_PASSFILE_PATH" debug_execute "${POSTGRESQL_BIN_DIR}/pg_rewind" "${flags[@]}"

--- a/bitnami/postgresql-repmgr/13/debian-11/rootfs/opt/bitnami/scripts/librepmgr.sh
+++ b/bitnami/postgresql-repmgr/13/debian-11/rootfs/opt/bitnami/scripts/librepmgr.sh
@@ -643,7 +643,13 @@ repmgr_pgrewind() {
     info "Stopping PostgreSQL..."
     "$POSTGRESQL_BIN_DIR"/pg_ctl "stop" "${pg_ctl_flags[@]}"
 
-    local -r flags=("-D" "$POSTGRESQL_DATA_DIR" "--no-ensure-shutdown" "--source-server" "host=${REPMGR_CURRENT_PRIMARY_HOST} port=${REPMGR_CURRENT_PRIMARY_PORT} user=${REPMGR_USERNAME} dbname=${REPMGR_DATABASE}")
+    local -r psql_major_version="$(postgresql_get_major_version)"
+
+    local flags=("-D" "$POSTGRESQL_DATA_DIR" "--source-server" "host=${REPMGR_CURRENT_PRIMARY_HOST} port=${REPMGR_CURRENT_PRIMARY_PORT} user=${REPMGR_USERNAME} dbname=${REPMGR_DATABASE}")
+
+    if [[ "$psql_major_version" -gt "12" ]]; then
+        flags+=("--no-ensure-shutdown")
+    fi
 
     if [[ "$REPMGR_USE_PASSFILE" = "true" ]]; then
         PGPASSFILE="$REPMGR_PASSFILE_PATH" debug_execute "${POSTGRESQL_BIN_DIR}/pg_rewind" "${flags[@]}"

--- a/bitnami/postgresql-repmgr/13/debian-11/rootfs/opt/bitnami/scripts/librepmgr.sh
+++ b/bitnami/postgresql-repmgr/13/debian-11/rootfs/opt/bitnami/scripts/librepmgr.sh
@@ -665,7 +665,7 @@ repmgr_rewind() {
     info "Rejoining node..."
 
     ensure_dir_exists "$POSTGRESQL_DATA_DIR"
-    if is_boolean_yes "$REPMGR_USE_PGREWIND"; then
+    if is_boolean_yes "$REPMGR_USE_PGREWIND" && ! is_boolean_yes "$REPMGR_SWITCH_ROLE"; then
         info "Using pg_rewind to primary node..."
         if ! repmgr_pgrewind; then
             warn "pg_rewind failed, resorting to data cloning"

--- a/bitnami/postgresql-repmgr/13/debian-11/rootfs/opt/bitnami/scripts/librepmgr.sh
+++ b/bitnami/postgresql-repmgr/13/debian-11/rootfs/opt/bitnami/scripts/librepmgr.sh
@@ -206,6 +206,7 @@ repmgr_get_primary_node() {
     local upstream_port
     local primary_host=""
     local primary_port="$REPMGR_PRIMARY_PORT"
+    local switch_role="no"
 
     readarray -t upstream_node < <(repmgr_get_upstream_node)
     upstream_host=${upstream_node[0]}
@@ -220,7 +221,7 @@ repmgr_get_primary_node() {
         else
             info "Current master is '${upstream_host}:${upstream_port}'. Cloning/rewinding it and acting as a standby node..."
             rm -f "$REPMGR_PRIMARY_ROLE_LOCK_FILE_NAME"
-            export REPMGR_SWITCH_ROLE="yes"
+            switch_role="yes"
             primary_host="$upstream_host"
             primary_port="$upstream_port"
         fi
@@ -239,6 +240,7 @@ repmgr_get_primary_node() {
     [[ -n "$primary_host" ]] && debug "Primary node: '${primary_host}:${primary_port}'"
     echo "$primary_host"
     echo "$primary_port"
+    echo "$switch_role"
 }
 
 ########################
@@ -255,10 +257,12 @@ repmgr_set_role() {
     local primary_node
     local primary_host
     local primary_port
+    local switch_role
 
     readarray -t primary_node < <(repmgr_get_primary_node)
     primary_host=${primary_node[0]}
     primary_port=${primary_node[1]:-$REPMGR_PRIMARY_PORT}
+    switch_role=${primary_node[2]}
 
     if [[ -z "$primary_host" ]]; then
         info "There are no nodes with primary role. Assuming the primary role..."
@@ -269,6 +273,7 @@ repmgr_set_role() {
 export REPMGR_ROLE="$role"
 export REPMGR_CURRENT_PRIMARY_HOST="$primary_host"
 export REPMGR_CURRENT_PRIMARY_PORT="$primary_port"
+export REPMGR_SWITCH_ROLE="$switch_role"
 EOF
 }
 

--- a/bitnami/postgresql-repmgr/14/debian-11/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/bitnami/postgresql-repmgr/14/debian-11/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -170,6 +170,22 @@ postgresql_create_config() {
 }
 
 ########################
+# Copy the files if there is an User injected configuration
+# Globals:
+#   POSTGRESQL_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+postgresql_copy_custom_configuration() {
+    if [[ -d "$POSTGRESQL_MOUNTED_CONF_DIR" ]] && compgen -G "$POSTGRESQL_MOUNTED_CONF_DIR"/* >/dev/null; then
+        debug "Copying files from $POSTGRESQL_MOUNTED_CONF_DIR to $POSTGRESQL_CONF_DIR"
+        cp -fr "$POSTGRESQL_MOUNTED_CONF_DIR"/. "$POSTGRESQL_CONF_DIR"
+    fi
+}
+
+########################
 # Create ldap auth configuration in pg_hba,
 # but keeps postgres user to authenticate locally
 # Globals:
@@ -574,10 +590,8 @@ postgresql_initialize() {
     rm -f "$POSTGRESQL_PID_FILE"
 
     # User injected custom configuration
-    if [[ -d "$POSTGRESQL_MOUNTED_CONF_DIR" ]] && compgen -G "$POSTGRESQL_MOUNTED_CONF_DIR"/* >/dev/null; then
-        debug "Copying files from $POSTGRESQL_MOUNTED_CONF_DIR to $POSTGRESQL_CONF_DIR"
-        cp -fr "$POSTGRESQL_MOUNTED_CONF_DIR"/. "$POSTGRESQL_CONF_DIR"
-    fi
+    postgresql_copy_custom_configuration
+
     local create_conf_file=yes
     local create_pghba_file=yes
 

--- a/bitnami/postgresql-repmgr/14/debian-11/rootfs/opt/bitnami/scripts/librepmgr.sh
+++ b/bitnami/postgresql-repmgr/14/debian-11/rootfs/opt/bitnami/scripts/librepmgr.sh
@@ -632,7 +632,18 @@ repmgr_clone_primary() {
 #########################
 repmgr_pgrewind() {
     info "Running pg_rewind data to primary node..."
-    local -r flags=("-D" "$POSTGRESQL_DATA_DIR" "--source-server" "host=${REPMGR_CURRENT_PRIMARY_HOST} port=${REPMGR_CURRENT_PRIMARY_PORT} user=${REPMGR_USERNAME} dbname=${REPMGR_DATABASE}")
+
+    postgresql_create_pghba
+    postgresql_copy_custom_configuration
+
+    info "Starting PostgreSQL in background..."
+    local -r pg_ctl_flags=("-w" "-D" "$POSTGRESQL_DATA_DIR" "-o" "-F --config-file=$POSTGRESQL_CONF_FILE --external_pid_file=$POSTGRESQL_PID_FILE --hba_file=$POSTGRESQL_PGHBA_FILE")
+    "$POSTGRESQL_BIN_DIR"/pg_ctl "start" "${pg_ctl_flags[@]}"
+
+    info "Stopping PostgreSQL..."
+    "$POSTGRESQL_BIN_DIR"/pg_ctl "stop" "${pg_ctl_flags[@]}"
+
+    local -r flags=("-D" "$POSTGRESQL_DATA_DIR" "--no-ensure-shutdown" "--source-server" "host=${REPMGR_CURRENT_PRIMARY_HOST} port=${REPMGR_CURRENT_PRIMARY_PORT} user=${REPMGR_USERNAME} dbname=${REPMGR_DATABASE}")
 
     if [[ "$REPMGR_USE_PASSFILE" = "true" ]]; then
         PGPASSFILE="$REPMGR_PASSFILE_PATH" debug_execute "${POSTGRESQL_BIN_DIR}/pg_rewind" "${flags[@]}"

--- a/bitnami/postgresql-repmgr/14/debian-11/rootfs/opt/bitnami/scripts/librepmgr.sh
+++ b/bitnami/postgresql-repmgr/14/debian-11/rootfs/opt/bitnami/scripts/librepmgr.sh
@@ -643,7 +643,13 @@ repmgr_pgrewind() {
     info "Stopping PostgreSQL..."
     "$POSTGRESQL_BIN_DIR"/pg_ctl "stop" "${pg_ctl_flags[@]}"
 
-    local -r flags=("-D" "$POSTGRESQL_DATA_DIR" "--no-ensure-shutdown" "--source-server" "host=${REPMGR_CURRENT_PRIMARY_HOST} port=${REPMGR_CURRENT_PRIMARY_PORT} user=${REPMGR_USERNAME} dbname=${REPMGR_DATABASE}")
+    local -r psql_major_version="$(postgresql_get_major_version)"
+
+    local flags=("-D" "$POSTGRESQL_DATA_DIR" "--source-server" "host=${REPMGR_CURRENT_PRIMARY_HOST} port=${REPMGR_CURRENT_PRIMARY_PORT} user=${REPMGR_USERNAME} dbname=${REPMGR_DATABASE}")
+
+    if [[ "$psql_major_version" -gt "12" ]]; then
+        flags+=("--no-ensure-shutdown")
+    fi
 
     if [[ "$REPMGR_USE_PASSFILE" = "true" ]]; then
         PGPASSFILE="$REPMGR_PASSFILE_PATH" debug_execute "${POSTGRESQL_BIN_DIR}/pg_rewind" "${flags[@]}"

--- a/bitnami/postgresql-repmgr/14/debian-11/rootfs/opt/bitnami/scripts/librepmgr.sh
+++ b/bitnami/postgresql-repmgr/14/debian-11/rootfs/opt/bitnami/scripts/librepmgr.sh
@@ -665,7 +665,7 @@ repmgr_rewind() {
     info "Rejoining node..."
 
     ensure_dir_exists "$POSTGRESQL_DATA_DIR"
-    if is_boolean_yes "$REPMGR_USE_PGREWIND"; then
+    if is_boolean_yes "$REPMGR_USE_PGREWIND" && ! is_boolean_yes "$REPMGR_SWITCH_ROLE"; then
         info "Using pg_rewind to primary node..."
         if ! repmgr_pgrewind; then
             warn "pg_rewind failed, resorting to data cloning"

--- a/bitnami/postgresql-repmgr/14/debian-11/rootfs/opt/bitnami/scripts/librepmgr.sh
+++ b/bitnami/postgresql-repmgr/14/debian-11/rootfs/opt/bitnami/scripts/librepmgr.sh
@@ -206,6 +206,7 @@ repmgr_get_primary_node() {
     local upstream_port
     local primary_host=""
     local primary_port="$REPMGR_PRIMARY_PORT"
+    local switch_role="no"
 
     readarray -t upstream_node < <(repmgr_get_upstream_node)
     upstream_host=${upstream_node[0]}
@@ -220,7 +221,7 @@ repmgr_get_primary_node() {
         else
             info "Current master is '${upstream_host}:${upstream_port}'. Cloning/rewinding it and acting as a standby node..."
             rm -f "$REPMGR_PRIMARY_ROLE_LOCK_FILE_NAME"
-            export REPMGR_SWITCH_ROLE="yes"
+            switch_role="yes"
             primary_host="$upstream_host"
             primary_port="$upstream_port"
         fi
@@ -239,6 +240,7 @@ repmgr_get_primary_node() {
     [[ -n "$primary_host" ]] && debug "Primary node: '${primary_host}:${primary_port}'"
     echo "$primary_host"
     echo "$primary_port"
+    echo "$switch_role"
 }
 
 ########################
@@ -255,10 +257,12 @@ repmgr_set_role() {
     local primary_node
     local primary_host
     local primary_port
+    local switch_role
 
     readarray -t primary_node < <(repmgr_get_primary_node)
     primary_host=${primary_node[0]}
     primary_port=${primary_node[1]:-$REPMGR_PRIMARY_PORT}
+    switch_role=${primary_node[2]}
 
     if [[ -z "$primary_host" ]]; then
         info "There are no nodes with primary role. Assuming the primary role..."
@@ -269,6 +273,7 @@ repmgr_set_role() {
 export REPMGR_ROLE="$role"
 export REPMGR_CURRENT_PRIMARY_HOST="$primary_host"
 export REPMGR_CURRENT_PRIMARY_PORT="$primary_port"
+export REPMGR_SWITCH_ROLE="$switch_role"
 EOF
 }
 

--- a/bitnami/postgresql-repmgr/15/debian-11/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/bitnami/postgresql-repmgr/15/debian-11/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -170,6 +170,22 @@ postgresql_create_config() {
 }
 
 ########################
+# Copy the files if there is an User injected configuration
+# Globals:
+#   POSTGRESQL_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+postgresql_copy_custom_configuration() {
+    if [[ -d "$POSTGRESQL_MOUNTED_CONF_DIR" ]] && compgen -G "$POSTGRESQL_MOUNTED_CONF_DIR"/* >/dev/null; then
+        debug "Copying files from $POSTGRESQL_MOUNTED_CONF_DIR to $POSTGRESQL_CONF_DIR"
+        cp -fr "$POSTGRESQL_MOUNTED_CONF_DIR"/. "$POSTGRESQL_CONF_DIR"
+    fi
+}
+
+########################
 # Create ldap auth configuration in pg_hba,
 # but keeps postgres user to authenticate locally
 # Globals:
@@ -574,10 +590,8 @@ postgresql_initialize() {
     rm -f "$POSTGRESQL_PID_FILE"
 
     # User injected custom configuration
-    if [[ -d "$POSTGRESQL_MOUNTED_CONF_DIR" ]] && compgen -G "$POSTGRESQL_MOUNTED_CONF_DIR"/* >/dev/null; then
-        debug "Copying files from $POSTGRESQL_MOUNTED_CONF_DIR to $POSTGRESQL_CONF_DIR"
-        cp -fr "$POSTGRESQL_MOUNTED_CONF_DIR"/. "$POSTGRESQL_CONF_DIR"
-    fi
+    postgresql_copy_custom_configuration
+
     local create_conf_file=yes
     local create_pghba_file=yes
 

--- a/bitnami/postgresql-repmgr/15/debian-11/rootfs/opt/bitnami/scripts/librepmgr.sh
+++ b/bitnami/postgresql-repmgr/15/debian-11/rootfs/opt/bitnami/scripts/librepmgr.sh
@@ -632,6 +632,17 @@ repmgr_clone_primary() {
 #########################
 repmgr_pgrewind() {
     info "Running pg_rewind data to primary node..."
+
+    postgresql_create_pghba
+    postgresql_copy_custom_configuration
+
+    info "Starting PostgreSQL in background..."
+    local -r pg_ctl_flags=("-w" "-D" "$POSTGRESQL_DATA_DIR" "-o" "-F --config-file=$POSTGRESQL_CONF_FILE --external_pid_file=$POSTGRESQL_PID_FILE --hba_file=$POSTGRESQL_PGHBA_FILE")
+    "$POSTGRESQL_BIN_DIR"/pg_ctl "start" "${pg_ctl_flags[@]}"
+
+    info "Stopping PostgreSQL..."
+    "$POSTGRESQL_BIN_DIR"/pg_ctl "stop" "${pg_ctl_flags[@]}"
+
     local -r flags=("-D" "$POSTGRESQL_DATA_DIR" "--source-server" "host=${REPMGR_CURRENT_PRIMARY_HOST} port=${REPMGR_CURRENT_PRIMARY_PORT} user=${REPMGR_USERNAME} dbname=${REPMGR_DATABASE}")
 
     if [[ "$REPMGR_USE_PASSFILE" = "true" ]]; then

--- a/bitnami/postgresql-repmgr/15/debian-11/rootfs/opt/bitnami/scripts/librepmgr.sh
+++ b/bitnami/postgresql-repmgr/15/debian-11/rootfs/opt/bitnami/scripts/librepmgr.sh
@@ -665,7 +665,7 @@ repmgr_rewind() {
     info "Rejoining node..."
 
     ensure_dir_exists "$POSTGRESQL_DATA_DIR"
-    if is_boolean_yes "$REPMGR_USE_PGREWIND"; then
+    if is_boolean_yes "$REPMGR_USE_PGREWIND" && ! is_boolean_yes "$REPMGR_SWITCH_ROLE"; then
         info "Using pg_rewind to primary node..."
         if ! repmgr_pgrewind; then
             warn "pg_rewind failed, resorting to data cloning"

--- a/bitnami/postgresql-repmgr/15/debian-11/rootfs/opt/bitnami/scripts/librepmgr.sh
+++ b/bitnami/postgresql-repmgr/15/debian-11/rootfs/opt/bitnami/scripts/librepmgr.sh
@@ -206,6 +206,7 @@ repmgr_get_primary_node() {
     local upstream_port
     local primary_host=""
     local primary_port="$REPMGR_PRIMARY_PORT"
+    local switch_role="no"
 
     readarray -t upstream_node < <(repmgr_get_upstream_node)
     upstream_host=${upstream_node[0]}
@@ -220,7 +221,7 @@ repmgr_get_primary_node() {
         else
             info "Current master is '${upstream_host}:${upstream_port}'. Cloning/rewinding it and acting as a standby node..."
             rm -f "$REPMGR_PRIMARY_ROLE_LOCK_FILE_NAME"
-            export REPMGR_SWITCH_ROLE="yes"
+            switch_role="yes"
             primary_host="$upstream_host"
             primary_port="$upstream_port"
         fi
@@ -239,6 +240,7 @@ repmgr_get_primary_node() {
     [[ -n "$primary_host" ]] && debug "Primary node: '${primary_host}:${primary_port}'"
     echo "$primary_host"
     echo "$primary_port"
+    echo "$switch_role"
 }
 
 ########################
@@ -255,10 +257,12 @@ repmgr_set_role() {
     local primary_node
     local primary_host
     local primary_port
+    local switch_role
 
     readarray -t primary_node < <(repmgr_get_primary_node)
     primary_host=${primary_node[0]}
     primary_port=${primary_node[1]:-$REPMGR_PRIMARY_PORT}
+    switch_role=${primary_node[2]}
 
     if [[ -z "$primary_host" ]]; then
         info "There are no nodes with primary role. Assuming the primary role..."
@@ -269,6 +273,7 @@ repmgr_set_role() {
 export REPMGR_ROLE="$role"
 export REPMGR_CURRENT_PRIMARY_HOST="$primary_host"
 export REPMGR_CURRENT_PRIMARY_PORT="$primary_port"
+export REPMGR_SWITCH_ROLE="$switch_role"
 EOF
 }
 

--- a/bitnami/postgresql-repmgr/15/debian-11/rootfs/opt/bitnami/scripts/librepmgr.sh
+++ b/bitnami/postgresql-repmgr/15/debian-11/rootfs/opt/bitnami/scripts/librepmgr.sh
@@ -643,7 +643,13 @@ repmgr_pgrewind() {
     info "Stopping PostgreSQL..."
     "$POSTGRESQL_BIN_DIR"/pg_ctl "stop" "${pg_ctl_flags[@]}"
 
-    local -r flags=("-D" "$POSTGRESQL_DATA_DIR" "--source-server" "host=${REPMGR_CURRENT_PRIMARY_HOST} port=${REPMGR_CURRENT_PRIMARY_PORT} user=${REPMGR_USERNAME} dbname=${REPMGR_DATABASE}")
+    local -r psql_major_version="$(postgresql_get_major_version)"
+
+    local flags=("-D" "$POSTGRESQL_DATA_DIR" "--source-server" "host=${REPMGR_CURRENT_PRIMARY_HOST} port=${REPMGR_CURRENT_PRIMARY_PORT} user=${REPMGR_USERNAME} dbname=${REPMGR_DATABASE}")
+
+    if [[ "$psql_major_version" -gt "12" ]]; then
+        flags+=("--no-ensure-shutdown")
+    fi
 
     if [[ "$REPMGR_USE_PASSFILE" = "true" ]]; then
         PGPASSFILE="$REPMGR_PASSFILE_PATH" debug_execute "${POSTGRESQL_BIN_DIR}/pg_rewind" "${flags[@]}"


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.
 -->

### Description of the change

In order to execute `pg_rewind`, postgres has to be stopped correctly. Since this container uses a custom start script the default behavior of `pg_rewind` in postgresql 13 is not sufficient and the `--no-ensure-shutdown` flag is required in postgres 13 and onwards. 

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Stopped followers can be started again without doing a full clone. Large databases or clusters with slow connections are up and running faster this way. 

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

Failed primaries are excluded of taking advantage of pg_rewind since they need to rejoin in an other way. 

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - https://github.com/bitnami/bitnami-docker-postgresql-repmgr/issues/82

### Additional information

This pull-request was submitted before in the old repo: https://github.com/bitnami/bitnami-docker-postgresql-repmgr/pull/114

### Testing 

```yaml
version: '3'
services:
  pg-0:
    image: docker.io/bitnami/postgresql-repmgr:14
    build:
      context: .
      dockerfile: Dockerfile
    ports:
      - 49160:5432
    volumes:
      - pg_0_data:/bitnami/postgresql
    environment:
      - POSTGRESQL_POSTGRES_PASSWORD=adminpassword
      - POSTGRESQL_USERNAME=customuser
      - POSTGRESQL_PASSWORD=custompassword
      - POSTGRESQL_DATABASE=customdatabase
      - REPMGR_PASSWORD=repmgrpassword
      - REPMGR_PRIMARY_HOST=pg-0
      - REPMGR_PRIMARY_PORT=5432
      - REPMGR_PARTNER_NODES=pg-0,pg-1:5432
      - REPMGR_NODE_NAME=pg-0
      - REPMGR_NODE_NETWORK_NAME=pg-0
      - REPMGR_PORT_NUMBER=5432
      - REPMGR_USE_PGREWIND=True
      - REPMGR_LOG_LEVEL=DEBUG
      - BITNAMI_DEBUG=True
  pg-1:
    image: docker.io/bitnami/postgresql-repmgr:14
    build:
      context: .
      dockerfile: Dockerfile
    ports:
      - 49161:5432
    volumes:
      - pg_1_data:/bitnami/postgresql
    environment:
      - POSTGRESQL_POSTGRES_PASSWORD=adminpassword
      - POSTGRESQL_USERNAME=customuser
      - POSTGRESQL_PASSWORD=custompassword
      - POSTGRESQL_DATABASE=customdatabase
      - REPMGR_PASSWORD=repmgrpassword
      - REPMGR_PRIMARY_HOST=pg-0
      - REPMGR_PRIMARY_PORT=5432
      - REPMGR_PARTNER_NODES=pg-0,pg-1:5432
      - REPMGR_NODE_NAME=pg-1
      - REPMGR_NODE_NETWORK_NAME=pg-1
      - REPMGR_PORT_NUMBER=5432
      - REPMGR_USE_PGREWIND=True
      - REPMGR_LOG_LEVEL=DEBUG
      - BITNAMI_DEBUG=True
volumes:
  pg_0_data:
    driver: local
  pg_1_data:
    driver: local
```

Execute the following command to verify its behavior: 
```bash
# start the primary (use --build to be sure u have the latest changes)
$ docker-compose up -d --build pg-0

# start he follower 
$ docker-compose up -d --build pg-1

# check if both running correctly
$ docker-compose logs -f
pg-0 [DEBUG] child node: 1001; attached: yes
pg-1 [DEBUG] connection check type is "ping"

# shutdown follower
$ docker-compose stop pg-1

# verify 
$ docker-compose logs -f
pg-0 [DEBUG] child node: 1001; attached: no

# wait a moment and start it again
$ docker-compose up -d pg-1

# verify
$ docker-compose logs -f
pg-0 [DEBUG] child node: 1001; attached: yes

# failover, takes at least 15 seconds
docker-compose stop pg-0

# verify
$ ocker-compose logs -f
pg-1 [NOTICE] monitoring cluster primary "pg-1" (ID: 1001)

# rejoin with full clone
$ docker-compose up -d pg-0

# verify
$ docker-compose logs -f
pg-1 [DEBUG] child node: 1000; attached: yes
```