### PR TITLE
Bump actions/stale version to v5

### DIFF
--- a/.github/workflows/clossing-issues.yml
+++ b/.github/workflows/clossing-issues.yml
@@ -10,7 +10,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v4
+      - uses: actions/stale@v5
         with:
           any-of-labels: 'solved'
           stale-issue-label: 'solved'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # This step will add the stale comment and label for the first 15 days without activity. It won't close any task
-      - uses: actions/stale@v4
+      - uses: actions/stale@v5
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: 'This Issue has been automatically marked as "stale" because it has not had recent activity (for 15 days). It will be closed if no further activity occurs. Thanks for the feedback.'
@@ -23,7 +23,7 @@ jobs:
           exempt-pr-labels: 'on-hold'
           operations-per-run: 500
       # This step will add the 'solved' label and the last comment before closing the issue or PR. Note that it won't close any issue or PR, they will be closed by the clossing-issues workflow
-      - uses: actions/stale@v4
+      - uses: actions/stale@v5
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: 'Due to the lack of activity in the last 5 days since it was marked as "stale", we proceed to close this Issue. Do not hesitate to reopen it later if necessary.'


### PR DESCRIPTION
We are receiving the following warning in relation to some of the GH actions we are running as part of our release and support workflows:

> **Stale**
> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/stale


Taking a look at the version used for `actions/stale`:
```console
$ ag 'actions/stale' charts/.github vms/.github containers/.github
charts/.github/workflows/stale.yml
15:      - uses: actions/stale@v4
26:      - uses: actions/stale@v4

charts/.github/workflows/clossing-issues.yml
13:      - uses: actions/stale@v4

vms/.github/workflows/stale.yml
10:      - uses: actions/stale@v3

vms/.github/workflows/clossing-issues.yml
15:      - uses: actions/stale@v4

containers/.github/workflows/stale.yml
15:      - uses: actions/stale@v4
26:      - uses: actions/stale@v4

containers/.github/workflows/clossing-issues.yml
13:      - uses: actions/stale@v4
```

According to the above warning, we should bump the `actions/stale` version to, at least, `v5` everywhere in order to use the latest NodeJS version. Taking a look at the [`actions/stale` releases](https://github.com/actions/stale/releases/tag/v5.0.0), the new NodeJS version is used from `v5` on.

⚠️ Please note there is a [new major version (`v6`)](https://github.com/actions/stale/releases/tag/v6.0.0) containing some breaking changes. That's why I'm suggesting a bump to `v5`