### PR TITLE
[bitnami/**] Bump and changing origin for labeler action to fmulero/labeler@1.0.5

### DIFF
--- a/.github/workflows/assign-asset-label.yml
+++ b/.github/workflows/assign-asset-label.yml
@@ -42,6 +42,6 @@ jobs:
             }
       - name: Labeling
         if: ${{ steps.get-asset.outputs.result == 'ok' }}
-        uses: andymckay/labeler@1.0.4
+        uses: fmulero/labeler@1.0.5
         with:
           add-labels: "${{ steps.get-asset.outputs.name }}"

--- a/.github/workflows/moving-cards.yml
+++ b/.github/workflows/moving-cards.yml
@@ -57,20 +57,20 @@ jobs:
       - name: Triage labeling
         # Only if moved into triage
         if: ${{ github.event.project_card.column_id == env.TRIAGE_COLUMN_ID }}
-        uses: andymckay/labeler@1.0.4
+        uses: fmulero/labeler@1.0.5
         with:
           add-labels: triage
           remove-labels: on-hold, in-progress, solved
       - name: From Bitnami labeling
         if: ${{ github.event.project_card.column_id == env.BITNAMI_COLUMN_ID }}
-        uses: andymckay/labeler@1.0.4
+        uses: fmulero/labeler@1.0.5
         with:
           add-labels: ${{ (needs.get-issue.outputs.author == 'bitnami-bot' && needs.get-issue.outputs.type == 'pull_request') && 'automated, auto-merge' || 'bitnami' }}
           remove-labels: on-hold, in-progress, triage, solved
       - name: Verify labeling
         # Only if moved into bitnami column and the PR is ready for review
         # This step uses a github-script to add the label intentionally.
-        # Consecutive calls to andymckay/labeler@1.0.4 can remove previous assigned labels, see https://github.com/andymckay/labeler/issues/40
+        # Consecutive calls to fmulero/labeler@1.0.5 can remove previous assigned labels, see https://github.com/fmulero/labeler/pull/2
         if: |
           github.event.project_card.column_id == env.BITNAMI_COLUMN_ID &&
           needs.get-issue.outputs.type == 'pull_request' && needs.get-issue.outputs.draft == 'false'
@@ -92,21 +92,21 @@ jobs:
             }
       - name: Build Maintenance labeling
         if: ${{ github.event.project_card.column_id == env.BUILD_MAINTENANCE_COLUMN_ID }}
-        uses: andymckay/labeler@1.0.4
+        uses: fmulero/labeler@1.0.5
         with:
           add-labels: review-required
           remove-labels: auto-merge
       - name: On hold labeling
         # Only if moved into on hold
         if: ${{ github.event.project_card.column_id == env.ON_HOLD_COLUMN_ID  }}
-        uses: andymckay/labeler@1.0.4
+        uses: fmulero/labeler@1.0.5
         with:
           add-labels: on-hold
           remove-labels: triage, in-progress, solved
       - name: In progress labeling
         # Only if moved into In progress
         if: ${{ github.event.project_card.column_id == env.IN_PROGRESS_COLUMN_ID  }}
-        uses: andymckay/labeler@1.0.4
+        uses: fmulero/labeler@1.0.5
         with:
           add-labels: in-progress
           remove-labels: on-hold, triage, solved
@@ -115,7 +115,7 @@ jobs:
         if: |
           github.event.project_card.column_id == env.SOLVED_COLUMN_ID &&
           (needs.get-issue.outputs.author != 'bitnami-bot')
-        uses: andymckay/labeler@1.0.4
+        uses: fmulero/labeler@1.0.5
         with:
           add-labels: solved
           # Triage is not on the list to know how many issues/PRs are solved

--- a/.github/workflows/moving-cards.yml
+++ b/.github/workflows/moving-cards.yml
@@ -69,27 +69,14 @@ jobs:
           remove-labels: on-hold, in-progress, triage, solved
       - name: Verify labeling
         # Only if moved into bitnami column and the PR is ready for review
-        # This step uses a github-script to add the label intentionally.
-        # Consecutive calls to fmulero/labeler@1.0.5 can remove previous assigned labels, see https://github.com/fmulero/labeler/pull/2
+        # Consecutive calls were fixed in fmulero/labeler@1.0.5, see https://github.com/fmulero/labeler/pull/2
         if: |
           github.event.project_card.column_id == env.BITNAMI_COLUMN_ID &&
           needs.get-issue.outputs.type == 'pull_request' && needs.get-issue.outputs.draft == 'false'
-        uses: actions/github-script@v6
+        uses: fmulero/labeler@1.0.5
         with:
-          # Required to trigger CI workflow
-          github-token: ${{ secrets.BITNAMI_BOT_TOKEN }}
-          script: |
-            try {
-              await github.rest.issues.addLabels({
-                owner: context.payload.repository.owner.login,
-                repo: context.payload.repository.name,
-                issue_number: ${{ needs.get-issue.outputs.number }},
-                labels: ['verify']
-              })
-              core.info(`Updated labels in ${{ needs.get-issue.outputs.number }}. Added: 'verify'`)
-            } catch (error) {
-              core.setFailed(error.message)
-            }
+          repo-token: ${{ secrets.BITNAMI_BOT_TOKEN }}
+          add-labels: verify
       - name: Build Maintenance labeling
         if: ${{ github.event.project_card.column_id == env.BUILD_MAINTENANCE_COLUMN_ID }}
         uses: fmulero/labeler@1.0.5


### PR DESCRIPTION
Signed-off-by: Alejandro Gómez <morona@vmware.com>

We are receiving the following warning in relation to some of the GH actions we are running as part of our release and support workflows:

> **Reviewal for automated PRs**
> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: andymckay/labeler

Taking a look at the repository of `andymckay/labeler` was archived some days ago. @fmulero has been working on some changes using [`fmulero/labeler`](https://github.com/fmulero/labeler) as the origin and the new version which pumps the Node.js engine into 16.