### PR TITLE
Increase retry-count from 3 (default) to 6 in VIB action

### DIFF
--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -112,6 +112,7 @@ jobs:
         if: ${{ steps.get-container-metadata.outputs.result == 'ok' }}
         with:
           pipeline: ${{ steps.get-dsl-filepath.outputs.dsl_path }}/vib-publish.json
+          retry-count: 6
         env:
           # Path with docker resources
           VIB_ENV_PATH:  ${{ matrix.container }}

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -101,6 +101,7 @@ jobs:
         if: ${{ steps.get-container-metadata.outputs.result == 'ok' }}
         with:
           pipeline: ${{ steps.get-container-metadata.outputs.name }}/vib-verify.json
+          retry-count: 6
         env:
           # Path with docker resources
           VIB_ENV_PATH: ${{ matrix.container }}


### PR DESCRIPTION
This is a temporary workaround in order to solve an internal networking issue that is producing some actions to fail due to
```
  Substituting variable VIB_ENV_TARGET_PLATFORM in parse/vib-publish.json
  Warning: Environment variable VIB_ENV_ALTERNATIVE_TARGET_PLATFORM is set but is not used within pipeline parse/vib-publish.json
  Substituting variable VIB_ENV_S3_URL in parse/vib-publish.json
  Substituting variable VIB_ENV_S3_USERNAME in parse/vib-publish.json
  Substituting variable VIB_ENV_S3_PASSWORD in parse/vib-publish.json
  The pipeline has been validated successfully.
  Request to /v1/pipelines failed. Retry: 0. Waiting 5000
  Request to /v1/pipelines failed. Retry: 1. Waiting 10000
  Request to /v1/pipelines failed. Retry: 2. Waiting 15000
  Error: Could not execute operation. Retried 3 times.
```