### PR TITLE
[bitnami/jasperreports] fix valid SMTP protocols.

### DIFF
--- a/bitnami/jasperreports/8/debian-11/rootfs/opt/bitnami/scripts/libjasperreports.sh
+++ b/bitnami/jasperreports/8/debian-11/rootfs/opt/bitnami/scripts/libjasperreports.sh
@@ -98,7 +98,9 @@ jasperreports_validate() {
         done
         is_empty_value "$JASPERREPORTS_SMTP_PORT_NUMBER" && print_validation_error "The JASPERREPORTS_SMTP_PORT_NUMBER environment variable is empty or not set."
         ! is_empty_value "$JASPERREPORTS_SMTP_PORT_NUMBER" && check_valid_port "JASPERREPORTS_SMTP_PORT_NUMBER"
-        ! is_empty_value "$JASPERREPORTS_SMTP_PROTOCOL" && check_multi_value "JASPERREPORTS_SMTP_PROTOCOL" "smtp smtps ssl tls"
+        
+        #  'smtp' and 'smtps' are the only valid values (see issue [#112](https://github.com/bitnami/bitnami-docker-jasperreports/#112)).
+        ! is_empty_value "$JASPERREPORTS_SMTP_PROTOCOL" && check_multi_value "JASPERREPORTS_SMTP_PROTOCOL" "smtp smtps"
     fi
 
     return "$error_code"
@@ -362,8 +364,10 @@ jasperreports_initialize() {
                 # Add a new prop node with mail.smtp.startls.enable=true
                 xmlstarlet ed -L --subnode '//*[name()="property" and @name="javaMailProperties"]/*[name()="props"]' --type elem -n "prop" -v "true" "${JASPERREPORTS_BASE_DIR}/WEB-INF/applicationContext-report-scheduling.xml"
                 xmlstarlet ed -L -i '//*[name()="prop" and not(@key)]' --type "attr" -n "key" -v "mail.smtp.starttls.enable" "${JASPERREPORTS_BASE_DIR}/WEB-INF/applicationContext-report-scheduling.xml"
+                # Add a new prop node with mail.smtp.ssl.protocols=TLSv1.2 (see issue [#112](https://github.com/bitnami/bitnami-docker-jasperreports/#112)).
+                xmlstarlet ed -L --subnode '//*[name()="property" and @name="javaMailProperties"]/*[name()="props"]' --type elem -n "prop" -v "TLSv1.2" "${JASPERREPORTS_BASE_DIR}/WEB-INF/applicationContext-report-scheduling.xml"
+                xmlstarlet ed -L -i '//*[name()="prop" and not(@key)]' --type "attr" -n "key" -v "mail.smtp.ssl.protocols" "${JASPERREPORTS_BASE_DIR}/WEB-INF/applicationContext-report-scheduling.xml"
             fi
-
         else
             info "An already initialized JasperReports database was provided, configuration will be skipped"
             jasperreports_run_upgrade_scripts

--- a/bitnami/jasperreports/README.md
+++ b/bitnami/jasperreports/README.md
@@ -283,7 +283,7 @@ To configure JasperReports to send email using SMTP you can set the following en
 - `JASPERREPORTS_SMTP_PORT_NUMBER`: SMTP port.
 - `JASPERREPORTS_SMTP_USER`: SMTP account user.
 - `JASPERREPORTS_SMTP_PASSWORD`: SMTP account password.
-- `JASPERREPORTS_SMTP_PROTOCOL`: If specified, SMTP protocol to use. Allowed values: *smtp*, *smtps*, *tls*, *ssl*. Default: **smtp**.
+- `JASPERREPORTS_SMTP_PROTOCOL`: If specified, SMTP protocol to use. Allowed values: *smtp* and *smtps*. Default: **smtp**.
 
 ##### JasperReports base URL configuration
 
@@ -305,6 +305,7 @@ This would be an example of SMTP configuration using a Gmail account:
           - ALLOW_EMPTY_PASSWORD=yes
           - JASPERREPORTS_SMTP_HOST=smtp.gmail.com
           - JASPERREPORTS_SMTP_PORT_NUMBER=587
+          - JASPERREPORTS_SMTP_PROTOCOL=smtps
           - JASPERREPORTS_SMTP_USER=your_email@gmail.com
           - JASPERREPORTS_SMTP_PASSWORD=your_password
       ...
@@ -318,6 +319,7 @@ This would be an example of SMTP configuration using a Gmail account:
       --env JASPERREPORTS_DATABASE_NAME=bitnami_jasperreports \
       --env JASPERREPORTS_SMTP_HOST=smtp.gmail.com \
       --env JASPERREPORTS_SMTP_PORT_NUMBER=587 \
+      --env JASPERREPORTS_SMTP_PROTOCOL=smtps \
       --env JASPERREPORTS_SMTP_USER=your_email@gmail.com \
       --env JASPERREPORTS_SMTP_PASSWORD=your_password \
       --network jasperreports-tier \


### PR DESCRIPTION
### Description of the change

Previously, "tls" and "ssl" have been valid configuration parameters for the SMTP protocol. Both have not been valid from the view of Jasper and Java for years. This patch drops "tls" and "ssl" and replaces the valid values with "smtp" and "smtps". The content of this patch had been previously discussed in https://github.com/bitnami/bitnami-docker-jasperreports/issues/112.

In addition to that, TLS 1.2 or newer is enforced for TLS encrypted connections.

### Benefits

- Allow SMTPS and TLS 1.2

### Possible drawbacks

Hopefully, none.

### Applicable issues

  - fixes https://github.com/bitnami/bitnami-docker-jasperreports/issues/112
