### PR TITLE
[bitnami/minio] update minio container to use mc anonymous command when setting default bucket policies

### DIFF
--- a/bitnami/minio/2022/debian-11/rootfs/opt/bitnami/scripts/libminio.sh
+++ b/bitnami/minio/2022/debian-11/rootfs/opt/bitnami/scripts/libminio.sh
@@ -288,7 +288,7 @@ minio_create_default_buckets() {
                 fi
                 if [ ${#bucket_info[@]} -eq 2 ]; then
                     info "Setting policy ${bucket_info[1]} for local bucket ${bucket_info[0]}"
-                    minio_client_execute policy set "${bucket_info[1]}" local/"${bucket_info[0]}"/
+                    minio_client_execute anonymous set "${bucket_info[1]}" local/"${bucket_info[0]}"/
                 fi
             else
                 info "Bucket local/${bucket_info[0]} already exists, skipping creation."


### PR DESCRIPTION
The previously used `mc policy` command has been deprecated in the minio client and no longer works.

Signed-off-by: Cory Snyder <csnyder@iland.com>

### Description of the change

Replaces usage of the deprecated `mc policy` command with the new `mc anonymous` command.

### Benefits

Fixes broken functionality related to default bucket policy settings.

### Possible drawbacks

None known

### Applicable issues

None

### Additional information
https://github.com/minio/minio/pull/15779