### PR TITLE
[bitnami/mysql] Correction on README.MD

### DIFF
--- a/bitnami/mysql/README.md
+++ b/bitnami/mysql/README.md
@@ -330,7 +330,7 @@ $ docker run --name mysql-slave --link mysql-master:master \
   -e MYSQL_REPLICATION_MODE=slave \
   -e MYSQL_REPLICATION_USER=my_repl_user \
   -e MYSQL_REPLICATION_PASSWORD=my_repl_password \
-  -e MYSQL_MASTER_HOST=master \
+  -e MYSQL_MASTER_HOST=mysql-master \
   -e MYSQL_MASTER_ROOT_PASSWORD=master_root_password \
   bitnami/mysql:latest
 ```


### PR DESCRIPTION
MYSQL_MASTER_HOST in replication is mysql-master, not master for the example provided

Signed-off-by: Abhiramthejas <abhirampanakkal@gmail.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
