### PR TITLE
[bitnami/rabbitmq] Enable ARM support

### DIFF
--- a/.vib/rabbitmq/3.9/vib-publish.json
+++ b/.vib/rabbitmq/3.9/vib-publish.json
@@ -18,8 +18,7 @@
               }
             },
             "architectures": [
-              "linux/amd64",
-              "linux/arm64"
+              "linux/amd64"
             ]
           }
         },


### PR DESCRIPTION
Signed-off-by: Miguel Ruiz <miruiz@vmware.com>

### Description of the change

Enable support for ARM64 except for branch 3.9, which depends on Erlang@24
