### PR TITLE
[bitnami/kafka] chore: Fixed double default for `KAFKA_INTER_BROKER_USER` in README

### DIFF
--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -185,7 +185,7 @@ $ docker-compose up -d
 The configuration can easily be setup with the Bitnami Apache Kafka Docker image using the following environment variables:
 
 * `ALLOW_PLAINTEXT_LISTENER`: Allow to use the PLAINTEXT listener. Default: **no**.
-* `KAFKA_INTER_BROKER_USER`: Apache Kafka inter broker communication user. Default: admin. Default: **user**.
+* `KAFKA_INTER_BROKER_USER`: Apache Kafka inter broker communication user. Default: **user**.
 * `KAFKA_INTER_BROKER_PASSWORD`: Apache Kafka inter broker communication password. Default: **bitnami**.
 * `KAFKA_CERTIFICATE_PASSWORD`: Password for certificates. No defaults.
 * `KAFKA_HEAP_OPTS`: Apache Kafka's Java Heap size. Default: **-Xmx1024m -Xms1024m**.


### PR DESCRIPTION



Signed-off-by: Joost De Cock <joost@joost.at>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Updated the **README.md** file to fix an issue.

The default for the `KAFKA_INTER_BROKER_USER` environment variable is specified twice. I double-checked in the code, and the default is `user` so I've removed the other default `admin`.

### Benefits

Less confusion for people.

### Possible drawbacks

Pretty sure there are none.


### Additional information

Documentation change only. No impact on code.
