### PR TITLE
[bitnami/containers] Use Environment Files instead of set-output

### DIFF
--- a/.github/workflows/assign-asset-label.yml
+++ b/.github/workflows/assign-asset-label.yml
@@ -23,13 +23,13 @@ jobs:
           assets=($(echo "$files_changed" | xargs dirname | sed -nr "s|bitnami/([^/]*).*|\1|p" | sort | uniq || true))
 
           if [[ "${#assets[@]}" -ne "1" ]]; then
-            echo "::set-output name=result::skip"
-            echo "::set-output name=message::Label cannot be set, cannot infer a single label from: ${assets[@]}"
-            echo "::set-output name=name::NONE"
+            echo "result=skip" >> $GITHUB_OUTPUT
+            echo "message=Label cannot be set, cannot infer a single label from: ${assets[@]}" >> $GITHUB_OUTPUT
+            echo "name=NONE" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=result::ok"
-            echo "::set-output name=message::Adding label '${assets}'"
-            echo "::set-output name=name::${assets}"
+            echo "result=ok" >> $GITHUB_OUTPUT
+            echo "message=Adding label '${assets}'"  >> $GITHUB_OUTPUT
+            echo "name=${assets}" >> $GITHUB_OUTPUT
           fi
       - name: Show messages
         uses: actions/github-script@v6

--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -46,11 +46,11 @@ jobs:
 
           if [[ "${#containers[@]}" -le "0" ]]; then
             echo "No changes detected in containers. The rest of the steps will be skipped."
-            echo "::set-output name=result::skip"
+            echo "result=skip" >> $GITHUB_OUTPUT
           else
             containers_json=$(printf "%s\n" "${containers[@]}" | jq -R . | jq -cs .)
-            echo "::set-output name=result::ok"
-            echo "::set-output name=containers::${containers_json}"
+            echo "result=ok" >> $GITHUB_OUTPUT
+            echo "containers=${containers_json}" >> $GITHUB_OUTPUT
           fi
   vib-publish:
     runs-on: ubuntu-latest
@@ -79,14 +79,14 @@ jobs:
             else
               name="$(echo "${{ matrix.container }}" | awk -F '/' '{print $2}')"
               branch="$(echo "${{ matrix.container }}" | awk -F '/' '{print $3}')"
-              echo "::set-output name=tag::${tag}"
-              echo "::set-output name=name::${name}"
-              echo "::set-output name=branch::${branch}"
-              echo "::set-output name=result::ok"
+              echo "tag=${tag}" >> $GITHUB_OUTPUT
+              echo "name=${name}" >> $GITHUB_OUTPUT
+              echo "branch=${branch}" >> $GITHUB_OUTPUT
+              echo "result=ok" >> $GITHUB_OUTPUT
             fi
           else
             # Container folder doesn't exists we are assuming a deprecation
-            echo "::set-output name=result::skip"
+            echo "result=skip" >> $GITHUB_OUTPUT
           fi
       - id: get-registry-credentials
         name: Get marketplace's registry credentials
@@ -97,8 +97,8 @@ jobs:
           marketplace_passwd=$(echo "$repo_info" | jq -re .response.repodetails.token)
           echo "::add-mask::${marketplace_user}"
           echo "::add-mask::${marketplace_passwd}"
-          echo "::set-output name=marketplace_user::${marketplace_user}"
-          echo "::set-output name=marketplace_passwd::${marketplace_passwd}"
+          echo "marketplace_user=${marketplace_user}" >> $GITHUB_OUTPUT
+          echo "marketplace_passwd=${marketplace_passwd}" >> $GITHUB_OUTPUT
       - id: get-dsl-filepath
         name: Get pipeline DSL filepath
         run: |
@@ -106,7 +106,7 @@ jobs:
           if [[ -d ".vib/${dsl_path}/${{ steps.get-container-metadata.outputs.branch }}" ]]; then
             dsl_path="${dsl_path}/${{ steps.get-container-metadata.outputs.branch }}"
           fi
-          echo "::set-output name=dsl_path::${dsl_path}"
+          echo "dsl_path=${dsl_path}" >> $GITHUB_OUTPUT
       - uses: vmware-labs/vmware-image-builder-action@main
         name: 'Publish ${{ steps.get-container-metadata.outputs.name }}: ${{ steps.get-container-metadata.outputs.tag }}'
         if: ${{ steps.get-container-metadata.outputs.result == 'ok' }}

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -43,14 +43,14 @@ jobs:
 
           if [[ "$non_readme_files" -le "0" ]]; then
             # The only changes are .md files -> SKIP
-            echo "::set-output name=result::skip"
+            echo "result=skip" >> $GITHUB_OUTPUT
           elif [[ "${#assets[@]}" -ne "1" ]]; then
             echo "Changes should affect to only one asset. You are currently modifying: ${assets[@]}"
-            echo "::set-output name=result::skip"
+            echo "result=skip" >> $GITHUB_OUTPUT
           else
             containers_json=$(printf "%s\n" "${flavors[@]}" | jq -R . | jq -cs .)
-            echo "::set-output name=result::ok"
-            echo "::set-output name=containers::${containers_json}"
+            echo "result=ok" >> $GITHUB_OUTPUT
+            echo "containers=${containers_json}" >> $GITHUB_OUTPUT
           fi
   vib-verify:
     runs-on: ubuntu-latest
@@ -88,13 +88,13 @@ jobs:
               echo "No tag found for: ${{ matrix.container }}"
               exit 1
             else
-              echo "::set-output name=tag::${tag}"
-              echo "::set-output name=name::${name}"
-              echo "::set-output name=result::ok"
+              echo "tag=${tag}" >> $GITHUB_OUTPUT
+              echo "name=${name}" >> $GITHUB_OUTPUT
+              echo "result=ok" >> $GITHUB_OUTPUT
             fi
           else
             # Container folder doesn't exists we are assuming a deprecation
-            echo "::set-output name=result::skip"
+            echo "result=skip" >> $GITHUB_OUTPUT
           fi
       - uses: vmware-labs/vmware-image-builder-action@main
         name: Verify

--- a/.github/workflows/moving-cards.yml
+++ b/.github/workflows/moving-cards.yml
@@ -35,11 +35,11 @@ jobs:
           if [[ "${pull_request}" == "null" ]]; then
             type="issue"
           fi
-          echo "::set-output name=assignees::${assignees}"
-          echo "::set-output name=author::${author}"
-          echo "::set-output name=type::${type}"
-          echo "::set-output name=draft::${draft}"
-          echo "::set-output name=number::${number}"
+          echo "assignees=${assignees}" >> $GITHUB_OUTPUT
+          echo "author=${author}" >> $GITHUB_OUTPUT
+          echo "type=${type}" >> $GITHUB_OUTPUT
+          echo "draft=${draft}" >> $GITHUB_OUTPUT
+          echo "number=${number}" >> $GITHUB_OUTPUT
   label-card:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/srp-report.yml
+++ b/.github/workflows/srp-report.yml
@@ -34,7 +34,7 @@ jobs:
             --name "bac-containers" --path . --saveto ./source-provenance.json \
             --comp-uid "${SRP_UID}" --build-number "${GITHUB_RUN_ID}" \
             --version "1.0" --all-ephemeral true --build-type release
-          echo "::set-output name=uid::${SRP_UID}"
+          echo "uid=${SRP_UID}" >> $GITHUB_OUTPUT
       - name: Archive SRP report
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -27,7 +27,7 @@ jobs:
         id: get-issue
         run: |
           author="${{ github.event.issue != null && github.event.issue.user.login || github.event.pull_request.user.login }}"
-          echo "::set-output name=author::${author}"
+          echo "author=${author}" >> $GITHUB_OUTPUT
       - name: Send to the board
         uses: peter-evans/create-or-update-project-card@v2
         with:


### PR DESCRIPTION
Signed-off-by: Alejandro Gómez <morona@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

The `set-output` command is deprecated and will be disabled soon. Here we upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

### Benefits

Code is up to date and warnings disappear from action runs.

### Possible drawbacks

None identified

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
