### PR TITLE
Fix unassigned SPARK_EXECUTOR_JAVA_OPTS

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,2 @@
+# IntelliJ configurations
+.idea/

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,2 +1,0 @@
-# IntelliJ configurations
-.idea/

--- a/bitnami/spark/3.3/debian-11/rootfs/opt/bitnami/scripts/spark/entrypoint.sh
+++ b/bitnami/spark/3.3/debian-11/rootfs/opt/bitnami/scripts/spark/entrypoint.sh
@@ -43,6 +43,14 @@ case "$1" in
     ;;
   executor)
     shift 1
+
+    set +o pipefail
+
+    env | grep SPARK_JAVA_OPT_ | sort -t_ -k4 -n | sed 's/[^=]*=\(.*\)/\1/g' > /tmp/java_opts.txt
+    readarray -t SPARK_EXECUTOR_JAVA_OPTS < /tmp/java_opts.txt
+
+    set -o pipefail
+
     CMD=(
       ${JAVA_HOME}/bin/java
       "${SPARK_EXECUTOR_JAVA_OPTS[@]}"


### PR DESCRIPTION
Signed-off-by: George Zubrienko <GZU@ecco.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Fixes unassigned variable reference in spark 3.3 entrypoint.sh: `SPARK_EXECUTOR_JAVA_OPTS`

### Benefits

Spark with `k8s:/` master is able to use `spark.executor.extraJavaOptions`. This is also a mandatory change to make Java 17-based Spark work with k8s master.

### Possible drawbacks

N/A

### Applicable issues

  - fixes #11198 