### PR TITLE
Bump reitermarkus/automerge version

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -167,7 +167,7 @@ jobs:
     steps:
       - name: Enable auto-merge feature
         if: ${{ needs.verification-summary.outputs.result == 'success' }}
-        uses: reitermarkus/automerge@v2.1.2
+        uses: reitermarkus/automerge@v2.2.0
         with:
           # Necessary to trigger CD workflow
           token: ${{ secrets.BITNAMI_BOT_TOKEN }}


### PR DESCRIPTION
We are receiving the following warning in relation to some of the GH actions we are running as part of our release and support workflows:
> *Reviewal for automated PRs*
> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: reitermarkus/automerge, hmarr/auto-approve-action
{quote}

Taking a look at the version used for `reitermarkus/automerge`:
```console
$ ag 'reitermarkus/automerge' charts/.github vms/.github containers/.github
charts/.github/workflows/ci-pipeline.yml
136:        uses: reitermarkus/automerge@v2.1.2

containers/.github/workflows/ci-pipeline.yml
170:        uses: reitermarkus/automerge@v2.1.2
```

According to the above warning, we should bump the `reitermarkus/automerge` version. The node version was bumped at https://github.com/reitermarkus/automerge/pull/1941