### PR TITLE
[bitnami/dokuwiki] fix DOKU_INC path

### DIFF
--- a/bitnami/dokuwiki/20220731/debian-11/rootfs/opt/bitnami/scripts/dokuwiki/postunpack.sh
+++ b/bitnami/dokuwiki/20220731/debian-11/rootfs/opt/bitnami/scripts/dokuwiki/postunpack.sh
@@ -39,7 +39,7 @@ php_conf_set memory_limit "$PHP_DEFAULT_MEMORY_LIMIT"
 
 # Fix DOKU_INC, since we split application from state, DokuWiki's plugins and templates need to know where they live
 info "Fix DOKU_INC variable"
-auto_prepend_file="/tmp/auto_prepend.php"
+auto_prepend_file="$DOKUWIKI_BASE_DIR/conf/auto_prepend.php"
 printf '<?php\ndefine("DOKU_INC", "%s/");\n' "$DOKUWIKI_BASE_DIR" >>$auto_prepend_file
 php_conf_set auto_prepend_file "$auto_prepend_file"
 

--- a/bitnami/dokuwiki/20220731/debian-11/rootfs/opt/bitnami/scripts/dokuwiki/postunpack.sh
+++ b/bitnami/dokuwiki/20220731/debian-11/rootfs/opt/bitnami/scripts/dokuwiki/postunpack.sh
@@ -37,6 +37,12 @@ done
 info "Configuring default PHP options for DokuWiki"
 php_conf_set memory_limit "$PHP_DEFAULT_MEMORY_LIMIT"
 
+# Fix DOKU_INC, since we split application from state, DokuWiki's plugins and templates need to know where they live
+info "Fix DOKU_INC variable"
+auto_prepend_file="/tmp/auto_prepend.php"
+printf '<?php\ndefine("DOKU_INC", "%s/");\n' "$DOKUWIKI_BASE_DIR" >>$auto_prepend_file
+php_conf_set auto_prepend_file "$auto_prepend_file"
+
 # Enable default web server configuration for DokuWiki
 info "Creating default web server configuration for DokuWiki"
 web_server_validate


### PR DESCRIPTION
### Description of the change

Sets auto_prepend_file in php.ini to let DokuWiki's templates and plugins know where DokuWiki really lives(default: "/opt/bitnami/dokuwiki") Since this container splits application from state files(/opt/bitnami/dokuwiki vs. /bitnami/dokuwiki) it is important that the DOKU_INC path is set accordingly. The PHP interpreter will prepend the file content specified in auto_prepend_file to every php file that gets executed.

### Benefits

Templates and plugins relying on the DOKU_INC path will work now(e.g. farmer plugin).

### Possible drawbacks

nothing known

### Additional information

As discussed with DokuWiki founder @splitbrain this is the best solution to get all templates and plugins to work.