### PR TITLE
fix readme [The user is able to specify a custom file in the default …

### DIFF
--- a/bitnami/mysql/README.md
+++ b/bitnami/mysql/README.md
@@ -386,7 +386,7 @@ The above command scales up the number of slaves to `3`. You can scale down in t
 
 ### Configuration file
 
-The image looks for user-defined configurations in `/opt/bitnami/mysql/conf/my_custom.cnf`. Create a file named `my_custom.cnf` and mount it at `/opt/bitnami/mysql/conf/my_custom.cnf`.
+The image looks for user-defined configurations in `/opt/bitnami/mysql/conf/bitnami/my_custom.cnf`. Create a file named `my_custom.cnf` and mount it at `/opt/bitnami/mysql/conf/bitnami/my_custom.cnf`.
 
 For example, in order to override the `max_allowed_packet` directive:
 
@@ -403,7 +403,7 @@ max_allowed_packet=32M
 $ docker run --name mysql \
     -p 3306:3306 \
     -e ALLOW_EMPTY_PASSWORD=yes \
-    -v /path/to/my_custom.cnf:/opt/bitnami/mysql/conf/my_custom.cnf:ro \
+    -v /path/to/my_custom.cnf:/opt/bitnami/mysql/conf/bitnami/my_custom.cnf:ro \
     -v /path/to/mysql-persistence:/bitnami/mysql/data \
     bitnami/mysql:latest
 ```
@@ -416,7 +416,7 @@ services:
   ...
     volumes:
       - /path/to/mysql-persistence:/bitnami/mysql/data
-      - /path/to/my_custom.cnf:/opt/bitnami/mysql/conf/my_custom.cnf:ro
+      - /path/to/my_custom.cnf:/opt/bitnami/mysql/conf/bitnami/my_custom.cnf:ro
   ...
 ```
 
@@ -492,7 +492,7 @@ services:
     ports:
       - '3306:3307'
     volumes:
-      - /path/to/my_custom.cnf:/opt/bitnami/mysql/conf/my_custom.cnf:ro
+      - /path/to/my_custom.cnf:/opt/bitnami/mysql/conf/bitnami/my_custom.cnf:ro
       - data:/bitnami/mysql/data
 volumes:
   data:


### PR DESCRIPTION
### Description of the change

change the default location of custom file

### Applicable issues

the old path [/opt/bitnami/mysql/conf] will case the follow error **/opt/bitnami/scripts/libmysql.sh: line 357: /opt/bitnami/mysql/conf/bitnami/my_custom.cnf: No such file or directory**

### Additional information
```
├── conf
├── data
└── docker-compose.yml
```
```yml
version: "3.9"
services:
  mysql:
    image: bitnami/mysql:8.0.19
    environment:
      MYSQL_ROOT_PASSWORD: "password"
      MYSQL_CHARACTER_SET: "utf8mb4"
      MYSQL_COLLATE: "utf8mb4_general_ci"
      BITNAMI_DEBUG: true
    volumes:
      - type: bind
        source: ./conf
        target: /opt/bitnami/mysql/conf
      - type: bind
        source: ./data
        target: /bitnami/mysql/data
```