### PR TITLE
[bitnami/clickhouse] listen on ipv4 and ipv6 address

### DIFF
--- a/bitnami/clickhouse/22.3/debian-11/Dockerfile
+++ b/bitnami/clickhouse/22.3/debian-11/Dockerfile
@@ -49,4 +49,4 @@ EXPOSE 8123 9000 9004 9005 9009
 
 USER 1001
 ENTRYPOINT [ "/opt/bitnami/scripts/clickhouse/entrypoint.sh" ]
-CMD [ "/opt/bitnami/scripts/clickhouse/run.sh", "--", "--listen_host=0.0.0.0" ]
+CMD [ "/opt/bitnami/scripts/clickhouse/run.sh", "--", "--listen_host=::" ]

--- a/bitnami/clickhouse/22.5/debian-11/Dockerfile
+++ b/bitnami/clickhouse/22.5/debian-11/Dockerfile
@@ -49,4 +49,4 @@ EXPOSE 8123 9000 9004 9005 9009
 
 USER 1001
 ENTRYPOINT [ "/opt/bitnami/scripts/clickhouse/entrypoint.sh" ]
-CMD [ "/opt/bitnami/scripts/clickhouse/run.sh", "--", "--listen_host=0.0.0.0" ]
+CMD [ "/opt/bitnami/scripts/clickhouse/run.sh", "--", "--listen_host=::" ]

--- a/bitnami/clickhouse/22.6/debian-11/Dockerfile
+++ b/bitnami/clickhouse/22.6/debian-11/Dockerfile
@@ -49,4 +49,4 @@ EXPOSE 8123 9000 9004 9005 9009
 
 USER 1001
 ENTRYPOINT [ "/opt/bitnami/scripts/clickhouse/entrypoint.sh" ]
-CMD [ "/opt/bitnami/scripts/clickhouse/run.sh", "--", "--listen_host=0.0.0.0" ]
+CMD [ "/opt/bitnami/scripts/clickhouse/run.sh", "--", "--listen_host=::" ]

--- a/bitnami/clickhouse/22.7/debian-11/Dockerfile
+++ b/bitnami/clickhouse/22.7/debian-11/Dockerfile
@@ -49,4 +49,4 @@ EXPOSE 8123 9000 9004 9005 9009
 
 USER 1001
 ENTRYPOINT [ "/opt/bitnami/scripts/clickhouse/entrypoint.sh" ]
-CMD [ "/opt/bitnami/scripts/clickhouse/run.sh", "--", "--listen_host=0.0.0.0" ]
+CMD [ "/opt/bitnami/scripts/clickhouse/run.sh", "--", "--listen_host=::" ]

--- a/bitnami/clickhouse/22.8/debian-11/Dockerfile
+++ b/bitnami/clickhouse/22.8/debian-11/Dockerfile
@@ -49,4 +49,4 @@ EXPOSE 8123 9000 9004 9005 9009
 
 USER 1001
 ENTRYPOINT [ "/opt/bitnami/scripts/clickhouse/entrypoint.sh" ]
-CMD [ "/opt/bitnami/scripts/clickhouse/run.sh", "--", "--listen_host=0.0.0.0" ]
+CMD [ "/opt/bitnami/scripts/clickhouse/run.sh", "--", "--listen_host=::" ]

--- a/bitnami/clickhouse/22.9/debian-11/Dockerfile
+++ b/bitnami/clickhouse/22.9/debian-11/Dockerfile
@@ -49,4 +49,4 @@ EXPOSE 8123 9000 9004 9005 9009
 
 USER 1001
 ENTRYPOINT [ "/opt/bitnami/scripts/clickhouse/entrypoint.sh" ]
-CMD [ "/opt/bitnami/scripts/clickhouse/run.sh", "--", "--listen_host=0.0.0.0" ]
+CMD [ "/opt/bitnami/scripts/clickhouse/run.sh", "--", "--listen_host=::" ]


### PR DESCRIPTION
### Description of the change

change clickhouse command line options, hardcoded in Dockerfile CMD to
`listen_host=::`

Clickhouse listen on all ipv4 and ipv6 adresses

### Benefits

This image work on AWS ipv6-only EKS (amazon managment kubernetes)
