### PR TITLE
Use 0.4.10 as pinned version for vib action

### DIFF
--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -109,7 +109,7 @@ jobs:
             dsl_path="${dsl_path}/${{ steps.get-container-metadata.outputs.branch }}"
           fi
           echo "dsl_path=${dsl_path}" >> $GITHUB_OUTPUT
-      - uses: vmware-labs/vmware-image-builder-action@0.4.7
+      - uses: vmware-labs/vmware-image-builder-action@0.4.10
         name: 'Publish ${{ steps.get-container-metadata.outputs.name }}: ${{ steps.get-container-metadata.outputs.tag }}'
         if: ${{ steps.get-container-metadata.outputs.result == 'ok' }}
         with:

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -96,7 +96,7 @@ jobs:
             # Container folder doesn't exists we are assuming a deprecation
             echo "result=skip" >> $GITHUB_OUTPUT
           fi
-      - uses: vmware-labs/vmware-image-builder-action@0.4.7
+      - uses: vmware-labs/vmware-image-builder-action@0.4.10
         name: Verify
         if: ${{ steps.get-container-metadata.outputs.result == 'ok' }}
         with:


### PR DESCRIPTION
This version should include changes from the following PRs:
* https://github.com/vmware-labs/vmware-image-builder-action/pull/100
* https://github.com/vmware-labs/vmware-image-builder-action/pull/101
* https://github.com/vmware-labs/vmware-image-builder-action/pull/102