### PR TITLE
[bitnami/several] Rename Cert Manager to cert-manager

### DIFF
--- a/bitnami/acmesolver/README.md
+++ b/bitnami/acmesolver/README.md
@@ -2,7 +2,7 @@
 
 ## What is ACME Solver?
 
-> ACME Solver is a part of the Cert Manager project. It will ensure certificates are valid and up to date periodically, and attempt to renew certificates at an appropriate time before expiry.
+> ACME Solver is a part of the cert-manager project. It will ensure certificates are valid and up to date periodically, and attempt to renew certificates at an appropriate time before expiry.
 > Cert-manager is a Kubernetes add-on to automate the management and issuance of TLS certificates from various issuing sources.
 
 [Overview of ACME Solver](https://github.com/jetstack/cert-manager)

--- a/bitnami/cert-manager-webhook/README.md
+++ b/bitnami/cert-manager-webhook/README.md
@@ -1,11 +1,11 @@
-# Cert Manager Webhook packaged by Bitnami
+# cert-manager Webhook packaged by Bitnami
 
-## What is Cert Manager Webhook?
+## What is cert-manager Webhook?
 
-> Cert Manager Webhook provides dynamic admission control over cert-manager resources using a webhook server.
+> cert-manager Webhook provides dynamic admission control over cert-manager resources using a webhook server.
 > Cert-manager is a Kubernetes add-on to automate the management and issuance of TLS certificates from various issuing sources.
 
-[Overview of Cert Manager Webhook](https://github.com/jetstack/cert-manager)
+[Overview of cert-manager Webhook](https://github.com/jetstack/cert-manager)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
 

--- a/bitnami/cert-manager/README.md
+++ b/bitnami/cert-manager/README.md
@@ -1,11 +1,11 @@
-# Cert Manager packaged by Bitnami
+# cert-manager packaged by Bitnami
 
-## What is Cert Manager?
+## What is cert-manager?
 
-> Cert Manager is a Kubernetes add-on to automate the management and issuance of TLS certificates from various issuing sources.
+> cert-manager is a Kubernetes add-on to automate the management and issuance of TLS certificates from various issuing sources.
 > Cert-manager is a Kubernetes add-on to automate the management and issuance of TLS certificates from various issuing sources.
 
-[Overview of Cert Manager](https://github.com/jetstack/cert-manager)
+[Overview of cert-manager](https://github.com/jetstack/cert-manager)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
 


### PR DESCRIPTION
Following the upstream nomenclature, all the occurrences of _Cert Manager_ were replaced by _cert-manager_.

Related to https://github.com/bitnami/charts/pull/13478