### PR TITLE
Use 0.4.11 as pinned version for vib action

### DIFF
--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -109,7 +109,7 @@ jobs:
             dsl_path="${dsl_path}/${{ steps.get-container-metadata.outputs.branch }}"
           fi
           echo "dsl_path=${dsl_path}" >> $GITHUB_OUTPUT
-      - uses: vmware-labs/vmware-image-builder-action@0.4.10
+      - uses: vmware-labs/vmware-image-builder-action@0.4.11
         name: 'Publish ${{ steps.get-container-metadata.outputs.name }}: ${{ steps.get-container-metadata.outputs.tag }}'
         if: ${{ steps.get-container-metadata.outputs.result == 'ok' }}
         with:

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -96,7 +96,7 @@ jobs:
             # Container folder doesn't exists we are assuming a deprecation
             echo "result=skip" >> $GITHUB_OUTPUT
           fi
-      - uses: vmware-labs/vmware-image-builder-action@0.4.10
+      - uses: vmware-labs/vmware-image-builder-action@0.4.11
         name: Verify
         if: ${{ steps.get-container-metadata.outputs.result == 'ok' }}
         with:


### PR DESCRIPTION
This version should include changes from the following PR:
* https://github.com/vmware-labs/vmware-image-builder-action/pull/104

**Changelog**:
* Timeouts are now 120s
* There is a new info log line that will print on slow requests (>60s)
* Removed the stack from the trace on retries and almost reverted to the simpler format that we had before plus a couple of additional pieces of info.