### PR TITLE
[bitnami/redis-cluster] perf: add cluster-announce port and bus-port

### DIFF
--- a/bitnami/redis-cluster/6.2/debian-11/rootfs/opt/bitnami/scripts/librediscluster.sh
+++ b/bitnami/redis-cluster/6.2/debian-11/rootfs/opt/bitnami/scripts/librediscluster.sh
@@ -91,6 +91,12 @@ redis_cluster_override_conf() {
         redis_conf_set tls-cluster yes
         redis_conf_set tls-replication yes
     fi
+    if ! is_empty_value "$REDIS_CLUSTER_ANNOUNCE_PORT"; then
+        redis_conf_set "cluster-announce-port" "$REDIS_CLUSTER_ANNOUNCE_PORT"
+    fi
+    if ! is_empty_value "$REDIS_CLUSTER_ANNOUNCE_BUS_PORT"; then
+        redis_conf_set "cluster-announce-bus-port" "$REDIS_CLUSTER_ANNOUNCE_BUS_PORT"
+    fi
     # Multithreading configuration
     if ! is_empty_value "$REDIS_IO_THREADS_DO_READS"; then
         redis_conf_set "io-threads-do-reads" "$REDIS_IO_THREADS_DO_READS"

--- a/bitnami/redis-cluster/7.0/debian-11/rootfs/opt/bitnami/scripts/librediscluster.sh
+++ b/bitnami/redis-cluster/7.0/debian-11/rootfs/opt/bitnami/scripts/librediscluster.sh
@@ -91,6 +91,12 @@ redis_cluster_override_conf() {
         redis_conf_set tls-cluster yes
         redis_conf_set tls-replication yes
     fi
+    if ! is_empty_value "$REDIS_CLUSTER_ANNOUNCE_PORT"; then
+        redis_conf_set "cluster-announce-port" "$REDIS_CLUSTER_ANNOUNCE_PORT"
+    fi
+    if ! is_empty_value "$REDIS_CLUSTER_ANNOUNCE_BUS_PORT"; then
+        redis_conf_set "cluster-announce-bus-port" "$REDIS_CLUSTER_ANNOUNCE_BUS_PORT"
+    fi
     # Multithreading configuration
     if ! is_empty_value "$REDIS_IO_THREADS_DO_READS"; then
         redis_conf_set "io-threads-do-reads" "$REDIS_IO_THREADS_DO_READS"

--- a/bitnami/redis-cluster/README.md
+++ b/bitnami/redis-cluster/README.md
@@ -181,6 +181,8 @@ The following env vars are supported for this container:
 | `REDIS_CLUSTER_REPLICAS`                | Number of replicas for every master that the cluster will have.                                                                                                    |
 | `REDIS_NODES`                           | String delimited by spaces containing the hostnames of all of the nodes that will be part of the cluster                                                           |
 | `REDIS_CLUSTER_ANNOUNCE_IP`             | IP that the node should announce, used for non dynamic ip environents                                                                                              |
+| `REDIS_CLUSTER_ANNOUNCE_PORT`           | Port that the node should announce, used for non dynamic ip environents                                                                                            |
+| `REDIS_CLUSTER_ANNOUNCE_BUS_PORT`       | The cluster bus port to announce                                                                                                                                   |
 | `REDIS_CLUSTER_DYNAMIC_IPS`             | Set to `no` if your Redis(R) cluster will be created with statical IPs. Default: `yes`                                                                             |
 | `REDIS_TLS_ENABLED`                     | Whether to enable TLS for traffic or not. Defaults to `no`.                                                                                                        |
 | `REDIS_TLS_PORT`                        | Port used for TLS secure traffic. Defaults to `6379`.                                                                                                              |


### PR DESCRIPTION
### Description of the change

Add cluster-announce-port and cluster-announce-bus-port to allow users to run redis clusters on a single node.

| Name                                    | Description                                                                                                                                                        |
|-----------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| `REDIS_CLUSTER_ANNOUNCE_IP`             | IP that the node should announce, used for non dynamic ip environents                                                                                              |
| `REDIS_CLUSTER_ANNOUNCE_PORT`           | Port that the node should announce, used for non dynamic ip environents                                                                                            |
| `REDIS_CLUSTER_ANNOUNCE_BUS_PORT`       | The cluster bus port to announce                                                                                                                                   |

- close: #12104