### PR TITLE
[bitnami/pgbouncer] Remove IPv4 listen_addr validation

### DIFF
--- a/bitnami/pgbouncer/1/debian-11/rootfs/opt/bitnami/scripts/libpgbouncer.sh
+++ b/bitnami/pgbouncer/1/debian-11/rootfs/opt/bitnami/scripts/libpgbouncer.sh
@@ -52,18 +52,7 @@ pgbouncer_validate() {
         fi
     }
 
-    check_ip_value() {
-        if ! validate_ipv4 "${!1}"; then
-            if ! is_hostname_resolved "${!1}"; then
-                print_validation_error "The value for $1 should be an IPv4 address or it must be a resolvable hostname"
-            else
-                debug "Hostname resolvable for $1"
-            fi
-        fi
-    }
-
     check_valid_port "PGBOUNCER_PORT"
-    check_ip_value "PGBOUNCER_LISTEN_ADDRESS"
     check_multi_value "PGBOUNCER_AUTH_TYPE" "any cert md5 hba pam plain scram-sha-256 trust"
     ! is_empty_value "$PGBOUNCER_POOL_MODE" && check_multi_value "PGBOUNCER_POOL_MODE" "session statement transaction"
     if [[ "$PGBOUNCER_AUTH_TYPE" = "trust" ]]; then


### PR DESCRIPTION
### Description of the change

The pgbouncer image currently validates that the `PGBOUNCER_LISTEN_ADDRESS` environment variable is either an IPv4 address, or a resolvable hostname.  

The pgbouncer documentation states that the `listen_addr` accepts IPv4, IPv6, and wildcard (`*`) values.

This change removes the IPv4 address validation, so that IPv6 and wildcard (`*`) values are accepted.

### Benefits

The pgbouncer container now supports all of pgbouncer's supported `listen_addr` values.

### Possible drawbacks

The container no longer validates the `listen_addr` that's passed to pgbouncer, meaning that address validation would fallback on pgbouncer itself.

An alternative would be to modify the validation step to accept IPv6 and wildcard (`*`) values.

### Applicable issues
  - fixes #13866
