### PR TITLE
[bitnami/mysql] Fix wrong my_custom.cnf directory

### DIFF
--- a/bitnami/mysql/README.md
+++ b/bitnami/mysql/README.md
@@ -386,7 +386,7 @@ The above command scales up the number of slaves to `3`. You can scale down in t
 
 ### Configuration file
 
-The image looks for user-defined configurations in `/opt/bitnami/mysql/conf/bitnami/my_custom.cnf`. Create a file named `my_custom.cnf` and mount it at `/opt/bitnami/mysql/conf/bitnami/my_custom.cnf`.
+The image looks for user-defined configurations in `/opt/bitnami/mysql/conf/my_custom.cnf`. Create a file named `my_custom.cnf` and mount it at `/opt/bitnami/mysql/conf/my_custom.cnf`.
 
 For example, in order to override the `max_allowed_packet` directive:
 
@@ -403,7 +403,7 @@ max_allowed_packet=32M
 $ docker run --name mysql \
     -p 3306:3306 \
     -e ALLOW_EMPTY_PASSWORD=yes \
-    -v /path/to/my_custom.cnf:/opt/bitnami/mysql/conf/bitnami/my_custom.cnf:ro \
+    -v /path/to/my_custom.cnf:/opt/bitnami/mysql/conf/my_custom.cnf:ro \
     -v /path/to/mysql-persistence:/bitnami/mysql/data \
     bitnami/mysql:latest
 ```
@@ -416,7 +416,7 @@ services:
   ...
     volumes:
       - /path/to/mysql-persistence:/bitnami/mysql/data
-      - /path/to/my_custom.cnf:/opt/bitnami/mysql/conf/bitnami/my_custom.cnf:ro
+      - /path/to/my_custom.cnf:/opt/bitnami/mysql/conf/my_custom.cnf:ro
   ...
 ```
 


### PR DESCRIPTION
Signed-off-by: Michel Tomas <michel@kissmy.co>


### Description of the change

Update documentation for custom MySQL configuration.  

MySQL custom config is not injected when mounted at `/opt/bitnami/mysql/conf/bitnami/my_custom.cnf:ro` 

### Benefits

Mounting it at `/opt/bitnami/mysql/conf/my_custom.cnf:ro` works: `mysql 17:23:20.93 INFO  ==> Injecting custom configuration 'my_custom.cnf'`

### Possible drawbacks

None 

### Applicable issues

None 

### Additional information
