### PR TITLE
Remove SPARK_MOUNTED_CONFDIR and SPARK_VOLUME_DIR

### DIFF
--- a/bitnami/spark/3.3/debian-11/rootfs/opt/bitnami/scripts/libspark.sh
+++ b/bitnami/spark/3.3/debian-11/rootfs/opt/bitnami/scripts/libspark.sh
@@ -25,9 +25,7 @@ spark_env() {
     cat <<"EOF"
 # Spark directories
 export SPARK_BASEDIR="/opt/bitnami/spark"
-export SPARK_VOLUMEDIR="/bitnami/spark"
 export SPARK_CONFDIR="${SPARK_BASEDIR}/conf"
-export SPARK_MOUNTED_CONFDIR="${SPARK_VOLUMEDIR}/conf"
 export SPARK_WORKDIR="${SPARK_BASEDIR}/work"
 export SPARK_CONF_FILE="${SPARK_CONFDIR}/spark-defaults.conf"
 export SPARK_LOGDIR="${SPARK_BASEDIR}/logs"
@@ -68,22 +66,6 @@ export SPARK_DAEMON_GROUP="spark"
 # Paths
 export SPARK_INITSCRIPTS_DIR="/docker-entrypoint-initdb.d"
 EOF
-}
-
-########################
-# Copy mounted configuration files
-# Globals:
-#   SPARK_*
-# Arguments:
-#   None
-# Returns:
-#   None
-#########################
-spark_copy_mounted_config() {
-    if ! is_dir_empty "$SPARK_MOUNTED_CONFDIR"; then
-        info "Found mounted configuration files in ${SPARK_MOUNTED_CONFDIR}. Copying them to ${SPARK_CONFDIR}"
-        cp -Lr "$SPARK_MOUNTED_CONFDIR"/* "$SPARK_CONFDIR"
-    fi
 }
 
 ########################
@@ -328,7 +310,6 @@ spark_conf_set() {
 spark_initialize() {
     ensure_dir_exists "$SPARK_WORKDIR"
     am_i_root && chown "$SPARK_DAEMON_USER:$SPARK_DAEMON_GROUP" "$SPARK_WORKDIR"
-    spark_copy_mounted_config
     if [[ ! -f "$SPARK_CONF_FILE" ]]; then
         # Generate default config file
         spark_generate_conf_file


### PR DESCRIPTION
Signed-off-by: George Zubrienko <GZU@ecco.com>

### Description of the change

Removes unused SPARK_VOLUME_DIR and associated code from a startup sequence.

### Benefits

Currently there are errors printed on Spark startup like `realpath: /bitnami/spark/conf: No such file or directory` which are misleading and might propagate to real errors in the future, while not being beneficial at all.

Spark configurations are mounted by replacing the default file as described in the readme:

```
$ docker run --name spark -v /path/to/spark-defaults.conf:/opt/bitnami/spark/conf/spark-defaults.conf bitnami/spark:latest
```

Same thing happens in Bitnami helm chart - spark-defaults.conf is mounted from configmap and there is no need to mount-then-copy it approach.

### Possible drawbacks

N/A

### Applicable issues

  - fixes #11199 

