### PR TITLE
[bitnami/mariadb] specifically mention how custom scripts are executed

### DIFF
--- a/bitnami/mariadb/README.md
+++ b/bitnami/mariadb/README.md
@@ -176,7 +176,9 @@ $ docker-compose up -d
 
 ### Initializing a new instance
 
-When the container is executed for the first time, it will execute the files with extensions `.sh`, `.sql` and `.sql.gz` located at `/docker-entrypoint-startdb.d`.
+The container can execute custom files on the first start and on every start. Files with extensions `.sh`, `.sql` and `.sql.gz` are supported.
+- files in `/docker-entrypoint-initdb.d` will only execute on the first container start
+- files in `/docker-entrypoint-startdb.d` will execute on every container start
 
 In order to have your custom files inside the docker image you can mount them as a volume.
 

--- a/bitnami/mariadb/README.md
+++ b/bitnami/mariadb/README.md
@@ -177,8 +177,9 @@ $ docker-compose up -d
 ### Initializing a new instance
 
 The container can execute custom files on the first start and on every start. Files with extensions `.sh`, `.sql` and `.sql.gz` are supported.
-- files in `/docker-entrypoint-initdb.d` will only execute on the first container start
-- files in `/docker-entrypoint-startdb.d` will execute on every container start
+
+- Files in `/docker-entrypoint-initdb.d` will only execute on the first container start.
+- Files in `/docker-entrypoint-startdb.d` will execute on every container start.
 
 In order to have your custom files inside the docker image you can mount them as a volume.
 


### PR DESCRIPTION
### Description of the change

Added more details about init and start custom script dirs to the README.

See https://github.com/bitnami/containers/blob/f5232bcd0f7c22223d0c327497e9e42f995fb43b/bitnami/mariadb/10.5/debian-11/rootfs/opt/bitnami/scripts/mariadb/setup.sh#L32-L35 and https://github.com/bitnami/containers/blob/0c85b3fea4df564512e4e822e3febb7879a0bd0f/bitnami/mariadb/10.5/debian-11/rootfs/opt/bitnami/scripts/libmariadb.sh#L329-L381 for the involved logic.

### Benefits

Currently it says "executed for the first time" for `/docker-entrypoint-startdb.d`, which in fact is executing on every start. See ☝🏽 for link to the involved logic.

### Possible drawbacks

My wording might be a bit confusing. Do you execute, start or run a container?
Before is was "You execute the container and it will execute the files".
Now it is "You start the container and it will execute the files"