### PR TITLE
Redis-Cluster: Ensure Proper Host Resolution

### DIFF
--- a/bitnami/redis-cluster/6.2/debian-11/rootfs/opt/bitnami/scripts/librediscluster.sh
+++ b/bitnami/redis-cluster/6.2/debian-11/rootfs/opt/bitnami/scripts/librediscluster.sh
@@ -201,7 +201,8 @@ redis_cluster_update_ips() {
     if [[ ! -f "${REDIS_DATA_DIR}/nodes.sh" ]]; then
         # It is the first initialization so store the nodes
         for node in "${nodes[@]}"; do
-            ip=$(wait_for_dns_lookup "$node" "$REDIS_DNS_RETRIES" 5)
+            read -r -a host_and_port <<< "$(to_host_and_port "$node")"
+            ip=$(wait_for_dns_lookup "${host_and_port[0]}" "$REDIS_DNS_RETRIES" 5)
             host_2_ip_array["$node"]="$ip"
         done
         echo "Storing map with hostnames and IPs"
@@ -211,7 +212,8 @@ redis_cluster_update_ips() {
         . "${REDIS_DATA_DIR}/nodes.sh"
         # Update the IPs in the nodes.conf
         for node in "${nodes[@]}"; do
-            newIP=$(wait_for_dns_lookup "$node" "$REDIS_DNS_RETRIES" 5)
+            read -r -a host_and_port <<< "$(to_host_and_port "$node")"
+            newIP=$(wait_for_dns_lookup "${host_and_port[0]}" "$REDIS_DNS_RETRIES" 5)
             # The node can be new if we are updating the cluster, so catch the unbound variable error
             if [[ ${host_2_ip_array[$node]+true} ]]; then
                 echo "Changing old IP ${host_2_ip_array[$node]} by the new one ${newIP}"

--- a/bitnami/redis-cluster/7.0/debian-11/rootfs/opt/bitnami/scripts/librediscluster.sh
+++ b/bitnami/redis-cluster/7.0/debian-11/rootfs/opt/bitnami/scripts/librediscluster.sh
@@ -201,7 +201,8 @@ redis_cluster_update_ips() {
     if [[ ! -f "${REDIS_DATA_DIR}/nodes.sh" ]]; then
         # It is the first initialization so store the nodes
         for node in "${nodes[@]}"; do
-            ip=$(wait_for_dns_lookup "$node" "$REDIS_DNS_RETRIES" 5)
+            read -r -a host_and_port <<< "$(to_host_and_port "$node")"
+            ip=$(wait_for_dns_lookup "${host_and_port[0]}" "$REDIS_DNS_RETRIES" 5)
             host_2_ip_array["$node"]="$ip"
         done
         echo "Storing map with hostnames and IPs"
@@ -211,7 +212,8 @@ redis_cluster_update_ips() {
         . "${REDIS_DATA_DIR}/nodes.sh"
         # Update the IPs in the nodes.conf
         for node in "${nodes[@]}"; do
-            newIP=$(wait_for_dns_lookup "$node" "$REDIS_DNS_RETRIES" 5)
+            read -r -a host_and_port <<< "$(to_host_and_port "$node")"
+            newIP=$(wait_for_dns_lookup "${host_and_port[0]}" "$REDIS_DNS_RETRIES" 5)
             # The node can be new if we are updating the cluster, so catch the unbound variable error
             if [[ ${host_2_ip_array[$node]+true} ]]; then
                 echo "Changing old IP ${host_2_ip_array[$node]} by the new one ${newIP}"


### PR DESCRIPTION
### Description of the change
Ensure that cluster setup scripts support proper DNS 
resolution of Redis nodes running on nonstandard ports.

Here is an example docker-compose.yml of a cluster that can be configured by this 
change:
```yml
  redis:
    image: "bitnami/redis-cluster:6.2"
    environment:
      ALLOW_EMPTY_PASSWORD: "yes"
      REDIS_NODES: "redis redis-node-0:6380 redis-node-1:6381 redis-node-2:6382 redis-node-3:6383 redis-node-4:6384"
      REDIS_CLUSTER_CREATOR: "yes"
      REDIS_CLUSTER_REPLICAS: "1"
    volumes:
      - redis-cluster_data:/bitnami/redis/data
    depends_on:
      - redis-node-0
      - redis-node-1
      - redis-node-2
      - redis-node-3
      - redis-node-4
    ports:
      - "6379:6379"
 
  redis-node-0:
    image: "bitnami/redis-cluster:6.2"
    volumes:
      - redis-cluster_data-0:/bitnami/redis/data
    environment:
      ALLOW_EMPTY_PASSWORD: "yes"
      REDIS_NODES: "redis redis-node-0:6380 redis-node-1:6381 redis-node-2:6382 redis-node-3:6383 redis-node-4:6384"
      REDIS_PORT_NUMBER: "6380"
    ports:
      - "6380:6380"

  redis-node-1:
    image: "bitnami/redis-cluster:6.2"
    volumes:
      - redis-cluster_data-1:/bitnami/redis/data
    environment:
      ALLOW_EMPTY_PASSWORD: "yes"
      REDIS_NODES: "redis redis-node-0:6380 redis-node-1:6381 redis-node-2:6382 redis-node-3:6383 redis-node-4:6384"
      REDIS_PORT_NUMBER: "6381"
    ports:
      - "6381:6381"

  redis-node-2:
    image: "bitnami/redis-cluster:6.2"
    volumes:
      - redis-cluster_data-2:/bitnami/redis/data
    environment:
      ALLOW_EMPTY_PASSWORD: "yes"
      REDIS_NODES: "redis redis-node-0:6380 redis-node-1:6381 redis-node-2:6382 redis-node-3:6383 redis-node-4:6384"
      REDIS_PORT_NUMBER: "6382"
    ports:
      - "6382:6382"

  redis-node-3:
    image: "bitnami/redis-cluster:6.2"
    volumes:
      - redis-cluster_data-3:/bitnami/redis/data
    environment:
      ALLOW_EMPTY_PASSWORD: "yes"
      REDIS_NODES: "redis redis-node-0:6380 redis-node-1:6381 redis-node-2:6382 redis-node-3:6383 redis-node-4:6384"
      REDIS_PORT_NUMBER: "6383"
    ports:
      - "6383:6383"

  redis-node-4:
    image: "bitnami/redis-cluster:6.2"
    volumes:
      - redis-cluster_data-4:/bitnami/redis/data
    environment:
      ALLOW_EMPTY_PASSWORD: "yes"
      REDIS_NODES: "redis redis-node-0:6380 redis-node-1:6381 redis-node-2:6382 redis-node-3:6383 redis-node-4:6384"
      REDIS_PORT_NUMBER: "6384"
    ports:
      - "6384:6384"
```

### Benefits
Allow for setup of redis-clusters with nodes running on nonstandard ports. 
Prior to this change, parsing of `REDIS_NODES` would fail due to inconsistent
parsing node hostname and port.


### Possible drawbacks
None known.


### Applicable issues
N/A

### Additional information
N/A
