### PR TITLE
[bitnami/wordpress] set PHP error_log to /dev/stderr

### DIFF
--- a/bitnami/wordpress/6/debian-11/rootfs/opt/bitnami/scripts/php/postunpack.sh
+++ b/bitnami/wordpress/6/debian-11/rootfs/opt/bitnami/scripts/php/postunpack.sh
@@ -26,6 +26,9 @@ php_conf_set "listen" "$PHP_FPM_DEFAULT_LISTEN_ADDRESS" "${PHP_CONF_DIR}/php-fpm
 php_conf_set "upload_tmp_dir" "${PHP_BASE_DIR}/tmp"
 php_conf_set "session.save_path" "${PHP_TMP_DIR}/session"
 
+# Log errors to stdout for easy debugging
+php_conf_set "error_log" "/dev/stderr"
+
 # Ensure directories used by PHP-FPM exist and have proper ownership and permissions
 for dir in "$PHP_CONF_DIR" "${PHP_BASE_DIR}/tmp" "$PHP_TMP_DIR" "$PHP_FPM_LOGS_DIR" "${PHP_TMP_DIR}/session"; do
     ensure_dir_exists "$dir"


### PR DESCRIPTION
### Description of the change

Sets the `error_log` directive for the wordpress container to `/dev/stdout` so that PHP errors are available in the container's logs.

### Benefits

Makes debugging of PHP errors possible.

### Possible drawbacks

None that I'm aware of.

### Applicable issues

- fixes #12775

