### PR TITLE
[bitnami/redis] - Include overrides config once only

### DIFF
--- a/bitnami/redis-cluster/6.2/debian-11/rootfs/opt/bitnami/scripts/libredis.sh
+++ b/bitnami/redis-cluster/6.2/debian-11/rootfs/opt/bitnami/scripts/libredis.sh
@@ -361,6 +361,10 @@ redis_initialize() {
 #########################
 redis_append_include_conf() {
     if [[ -f "$REDIS_OVERRIDES_FILE" ]]; then
+        # Remove all include statements including commented ones
+        redis_conf_set include "$REDIS_OVERRIDES_FILE"
+        redis_conf_unset "include"
+
         echo "include $REDIS_OVERRIDES_FILE" >> "${REDIS_BASE_DIR}/etc/redis.conf"
     fi
 }

--- a/bitnami/redis-cluster/7.0/debian-11/rootfs/opt/bitnami/scripts/libredis.sh
+++ b/bitnami/redis-cluster/7.0/debian-11/rootfs/opt/bitnami/scripts/libredis.sh
@@ -361,6 +361,10 @@ redis_initialize() {
 #########################
 redis_append_include_conf() {
     if [[ -f "$REDIS_OVERRIDES_FILE" ]]; then
+        # Remove all include statements including commented ones
+        redis_conf_set include "$REDIS_OVERRIDES_FILE"
+        redis_conf_unset "include"
+
         echo "include $REDIS_OVERRIDES_FILE" >> "${REDIS_BASE_DIR}/etc/redis.conf"
     fi
 }

--- a/bitnami/redis/6.2/debian-11/rootfs/opt/bitnami/scripts/libredis.sh
+++ b/bitnami/redis/6.2/debian-11/rootfs/opt/bitnami/scripts/libredis.sh
@@ -361,6 +361,10 @@ redis_initialize() {
 #########################
 redis_append_include_conf() {
     if [[ -f "$REDIS_OVERRIDES_FILE" ]]; then
+        # Remove all include statements including commented ones
+        redis_conf_set include "$REDIS_OVERRIDES_FILE"
+        redis_conf_unset "include"
+
         echo "include $REDIS_OVERRIDES_FILE" >> "${REDIS_BASE_DIR}/etc/redis.conf"
     fi
 }

--- a/bitnami/redis/7.0/debian-11/rootfs/opt/bitnami/scripts/libredis.sh
+++ b/bitnami/redis/7.0/debian-11/rootfs/opt/bitnami/scripts/libredis.sh
@@ -361,6 +361,10 @@ redis_initialize() {
 #########################
 redis_append_include_conf() {
     if [[ -f "$REDIS_OVERRIDES_FILE" ]]; then
+        # Remove all include statements including commented ones
+        redis_conf_set include "$REDIS_OVERRIDES_FILE"
+        redis_conf_unset "include"
+
         echo "include $REDIS_OVERRIDES_FILE" >> "${REDIS_BASE_DIR}/etc/redis.conf"
     fi
 }


### PR DESCRIPTION
Fixes issue where ACL in overrides file would result in an error:

`Duplicate user found. A user can only be defined once in config files`

This is cause by the behaviour of the `redis_append_include_conf` method in `libredis.sh` that only appends the overrides file to the end of the config. When restarting the container or the host the method would be ran again adding another include statement.

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Include overrides config only once in the base `redis.conf` configuration. Clean out stale includes that could be present also.

### Benefits

Able to use the overrides file to store ACL configuration.

### Possible drawbacks

None: if specifying a custom `redis.conf` the overrides logic is not executed. Will only be executed with the default configuration which doesn't have any include in it

### Applicable issues

N/A

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
