### PR TITLE
[bitnami/mastodon] Remove architectures field in publish action

### DIFF
--- a/.vib/mastodon/vib-publish.json
+++ b/.vib/mastodon/vib-publish.json
@@ -16,11 +16,7 @@
                 "name": "{VIB_ENV_CONTAINER}",
                 "tag": "{VIB_ENV_TAG}"
               }
-            },
-            "architectures": [
-              "linux/amd64",
-              "linux/arm64"
-            ]
+            }
           }
         },
         {


### PR DESCRIPTION
Signed-off-by: Fran Mulero <fmulero@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Remove architectures field from publish pipeline to match with verification one.

### Benefits

Use the same architectures in verification and publish pipelines.

### Possible drawbacks

None identified

### Applicable issues
Fixes failing CD actions:
  - https://github.com/bitnami/containers/actions/runs/3606297097
  - https://github.com/bitnami/containers/actions/runs/3605798520

