### PR TITLE
[bitnami/redmine] Feature: Add bundle post install call

### DIFF
--- a/bitnami/redmine/5/debian-11/rootfs/opt/bitnami/scripts/libredmine.sh
+++ b/bitnami/redmine/5/debian-11/rootfs/opt/bitnami/scripts/libredmine.sh
@@ -459,3 +459,20 @@ redmine_migrate_database() {
     redmine_rake_execute "db:migrate" >/dev/null 2>&1
     redmine_rake_execute "redmine:plugins:migrate" >/dev/null 2>&1
 }
+
+########################
+# Install additional Rubygems if needed
+# Plugins might require additional plugins, which are not shipped with the default
+# bundle. In order to keep Redmine operative, we need to install them additionally.
+# Globals:
+#   REDMINE_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+redmine_ensure_gems() {
+    cd "$REDMINE_BASE_DIR" || false
+    bundle config unset deployment
+    bundle install
+}

--- a/bitnami/redmine/5/debian-11/rootfs/opt/bitnami/scripts/libredmine.sh
+++ b/bitnami/redmine/5/debian-11/rootfs/opt/bitnami/scripts/libredmine.sh
@@ -473,6 +473,7 @@ redmine_migrate_database() {
 #########################
 redmine_ensure_gems() {
     cd "$REDMINE_BASE_DIR" || false
-    bundle config unset deployment
-    bundle install
+    info "Ensuring all rubygems are installed"
+    debug_execute bundle config unset deployment
+    debug_execute bundle install
 }

--- a/bitnami/redmine/5/debian-11/rootfs/opt/bitnami/scripts/redmine/setup.sh
+++ b/bitnami/redmine/5/debian-11/rootfs/opt/bitnami/scripts/redmine/setup.sh
@@ -22,6 +22,9 @@ fi
 # Load libraries
 . /opt/bitnami/scripts/libredmine.sh
 
+# Ensure Redmine has all the necessary gems
+redmine_ensure_gems
+
 # Ensure Redmine environment variables are valid
 redmine_validate
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Some Redmine plugins (e.g. from RedmineUp) require some additional rubygems. They are right now not installed, which leads to a crash of the container. My change adds a function to post-install them during container startup.

### Benefits

Even with redmine plugins that require additional gems the container is able to operate.

### Possible drawbacks

I don't see any.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes chart issue https://github.com/bitnami/charts/issues/13863

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
