### PR TITLE
[bitnami/*] Merge automated PRs instead of enabling auto-merge

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -165,21 +165,33 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'auto-merge') &&
       github.event.pull_request.user.login == 'bitnami-bot'
     steps:
-      - name: Enable auto-merge feature
-        if: ${{ needs.verification-summary.outputs.result == 'success' }}
-        uses: reitermarkus/automerge@v2.2.0
-        with:
-          # Necessary to trigger CD workflow
-          token: ${{ secrets.BITNAMI_BOT_TOKEN }}
-          merge-method: squash
-          pull-request: ${{ github.event.number }}
+      # Approve the CI's PR if the 'VIB Verify' job succeeded
+      # Approved by the 'github-actions' user; a PR can't be approved by its author
       - name: PR Approval
         if: ${{ needs.verification-summary.outputs.result == 'success' }}
         uses: hmarr/auto-approve-action@v3.0.0
         with:
           pull-request-number: ${{ github.event.number }}
+      - name: Merge
+        id: merge
+        if: ${{ needs.verification-summary.outputs.result == 'success' }}
+        uses: actions/github-script@v6
+        with:
+          result-encoding: string
+          retries: 3
+          # Necessary to trigger CD workflows
+          github-token: ${{ secrets.BITNAMI_BOT_TOKEN }}
+          script: |
+            github.rest.pulls.merge({
+              pull_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              merge_method: 'squash'
+            })
+      # If the CI did not succeed ('VIB Verify' failed or skipped),
+      # post a comment on the PR and assign a maintainer agent to review it
       - name: Manual review required
-        if: ${{ needs.verification-summary.outputs.result != 'success' }}
+        if: ${{ always() && (needs.verification-summary.outputs.result != 'success' || steps.merge.outcome != 'success') }}
         uses: peter-evans/create-or-update-comment@v2.0.0
         with:
           issue-number: ${{ github.event.number }}


### PR DESCRIPTION
Signed-off-by: Fran Mulero <fmulero@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change
Merge directly the PR instead of enabling the auto-merge.

### Benefits

In certain occasions the auto-merge process for bitnami-bot PRs may fail without notifying the team due to changes in base branch. Also retries were included to avoid temporary issues.

### Possible drawbacks

None identified

### Applicable issues
![image](https://user-images.githubusercontent.com/23502572/207124377-6eb84e19-8463-4a6a-b616-fe587b438f82.png)

### Additional information

* https://github.com/bitnami/charts/pull/13932

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [ ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
