### PR TITLE
odoo: replace longpolling_port with gevent_port

### DIFF
--- a/bitnami/odoo/16/debian-11/rootfs/opt/bitnami/scripts/odoo/bitnami-templates/odoo.conf.tpl
+++ b/bitnami/odoo/16/debian-11/rootfs/opt/bitnami/scripts/odoo/bitnami-templates/odoo.conf.tpl
@@ -27,7 +27,7 @@ limit_time_real = 150
 ; log_handler = [':INFO']
 ; log_level = info
 ; logfile = {{ODOO_LOG_FILE}}
-longpolling_port = {{ODOO_LONGPOLLING_PORT_NUMBER}}
+gevent_port = {{ODOO_LONGPOLLING_PORT_NUMBER}}
 ; https://www.odoo.com/es_ES/forum/ayuda-1/could-not-obtain-lock-on-row-in-relation-ir-cron-74519
 max_cron_threads = 1
 pidfile = {{ODOO_PID_FILE}}


### PR DESCRIPTION
longpolling_port is deprecated in doo16 see https://github.com/odoo/odoo/blob/16.0/odoo/tools/config.py#L565

Signed-off-by: Amin Cheloh <amincheloh@gmail.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
