### PR TITLE
[bitnami/pgpool] Rename configuration parameter socket_dir to unix_socket_directories

### DIFF
--- a/bitnami/pgpool/4/debian-11/rootfs/opt/bitnami/scripts/libpgpool.sh
+++ b/bitnami/pgpool/4/debian-11/rootfs/opt/bitnami/scripts/libpgpool.sh
@@ -440,7 +440,7 @@ pgpool_create_config() {
     # ref: http://www.pgpool.net/docs/latest/en/html/runtime-config-connection.html#RUNTIME-CONFIG-CONNECTION-SETTINGS
     pgpool_set_property "listen_addresses" "*"
     pgpool_set_property "port" "$PGPOOL_PORT_NUMBER"
-    pgpool_set_property "socket_dir" "$PGPOOL_TMP_DIR"
+    pgpool_set_property "unix_socket_directories" "$PGPOOL_TMP_DIR"
     pgpool_set_property "pcp_socket_dir" "$PGPOOL_TMP_DIR"
     # Connection Pooling settings
     # http://www.pgpool.net/docs/latest/en/html/runtime-config-connection-pooling.html


### PR DESCRIPTION
### Description of the change

Rename configuration parameter socket_dir to [unix_socket_directories](https://www.pgpool.net/docs/latest/en/html/runtime-config-connection.html#GUC-UNIX-SOCKET-DIRECTORIES) as mentioned in the [4.4.0 release note](https://www.pgpool.net/docs/latest/en/html/release-4-4-0.html). Otherwise, the health check script fails with the following message.

```
psql: error: connection to server on socket "/opt/bitnami/pgpool/tmp/.s.PGSQL.5432" failed: No such file or directory
        Is the server running locally and accepting connections on that socket?
```

### Benefits

Set the right directory where the UNIX domain socket(s) accepting connections for Pgpool-II will be created.

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

N/A