### PR TITLE
[bitnami/odoo] Refine directory permissions for app persistence

### DIFF
--- a/bitnami/odoo/14/debian-11/Dockerfile
+++ b/bitnami/odoo/14/debian-11/Dockerfile
@@ -39,7 +39,7 @@ RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ && \
     done
 RUN apt-get update && apt-get upgrade -y && \
     apt-get clean && rm -rf /var/lib/apt/lists /var/cache/apt/archives
-RUN chmod g+rwX /opt/bitnami
+RUN chgrp -R 0 /opt/bitnami && chmod -R g+rwX /opt/bitnami
 RUN if [ "$OS_ARCH" = "amd64" ]; then \
     curl -sLO "https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.buster_${OS_ARCH}.deb" && \
     echo "dfab5506104447eef2530d1adb9840ee3a67f30caaad5e9bcb8743ef2f9421bd  wkhtmltox_0.12.5-1.buster_${OS_ARCH}.deb" | sha256sum -c - && \

--- a/bitnami/odoo/15/debian-11/Dockerfile
+++ b/bitnami/odoo/15/debian-11/Dockerfile
@@ -39,7 +39,7 @@ RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ && \
     done
 RUN apt-get update && apt-get upgrade -y && \
     apt-get clean && rm -rf /var/lib/apt/lists /var/cache/apt/archives
-RUN chmod g+rwX /opt/bitnami
+RUN chgrp -R 0 /opt/bitnami && chmod -R g+rwX /opt/bitnami
 RUN if [ "$OS_ARCH" = "amd64" ]; then \
     curl -sLO "https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.buster_${OS_ARCH}.deb" && \
     echo "dfab5506104447eef2530d1adb9840ee3a67f30caaad5e9bcb8743ef2f9421bd  wkhtmltox_0.12.5-1.buster_${OS_ARCH}.deb" | sha256sum -c - && \

--- a/bitnami/odoo/16/debian-11/Dockerfile
+++ b/bitnami/odoo/16/debian-11/Dockerfile
@@ -39,7 +39,7 @@ RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ && \
     done
 RUN apt-get update && apt-get upgrade -y && \
     apt-get clean && rm -rf /var/lib/apt/lists /var/cache/apt/archives
-RUN chmod g+rwX /opt/bitnami
+RUN chgrp -R 0 /opt/bitnami && chmod -R g+rwX /opt/bitnami
 RUN if [ "$OS_ARCH" = "amd64" ]; then \
     curl -sLO "https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.buster_${OS_ARCH}.deb" && \
     echo "dfab5506104447eef2530d1adb9840ee3a67f30caaad5e9bcb8743ef2f9421bd  wkhtmltox_0.12.5-1.buster_${OS_ARCH}.deb" | sha256sum -c - && \


### PR DESCRIPTION
### Description of the change

This change refines the directory permissions of the application directory so that the image runs properly on configurations with tight permissions, like OpenShift.

### Benefits

Image works out-of-the box on OpenShift.

### Possible drawbacks

None to my knowledge.

### Applicable issues

  - fixes #17806

### Additional information

The change is also documented in the official [OpenShift documentation](https://docs.openshift.com/container-platform/4.11/openshift_images/create-images.html#images-create-guide-openshift_create-images).
