### PR TITLE
Update keycloak/docker-compose.yml

### DIFF
--- a/bitnami/keycloak/docker-compose.yml
+++ b/bitnami/keycloak/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     depends_on:
       - postgresql
     ports:
-      - "80:8080"
+      - "8080:8080/tcp"
 
 volumes:
   postgresql_data:


### PR DESCRIPTION
I had issue running this keycloak/docker-compose.yml configuration. It is probably small mistake, because default KC configuration file doesn't have port 80 configured as http-port value, it is 8080. After fixing it, it started working. It is also mentioned in oneliner https://www.keycloak.org/getting-started/getting-started-docker

```
keycloak@7aced9861fde:/opt/bitnami/keycloak/conf$ grep port *
keycloak.conf:http-port = 8080
keycloak.conf:https-port = 8443
```

Signed-off-by: noraisk <noraisk@users.noreply.github.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Specified resource service port and protocol.

### Benefits

Less time consuming for other engineers.

### Possible drawbacks

Unknown.

### Applicable issues

Didn't find from open issues.

### Additional information

