### PR TITLE
[bitnami/mariadb] Change default charset to utf8mb4

### DIFF
--- a/bitnami/mariadb/10.10/debian-11/rootfs/opt/bitnami/scripts/mariadb-env.sh
+++ b/bitnami/mariadb/10.10/debian-11/rootfs/opt/bitnami/scripts/mariadb-env.sh
@@ -91,9 +91,9 @@ export DB_DAEMON_GROUP="mysql"
 # Default configuration (build-time)
 export MARIADB_DEFAULT_PORT_NUMBER="3306"
 export DB_DEFAULT_PORT_NUMBER="$MARIADB_DEFAULT_PORT_NUMBER" # only used at build time
-export MARIADB_DEFAULT_CHARACTER_SET="utf8"
+export MARIADB_DEFAULT_CHARACTER_SET="utf8mb4"
 export DB_DEFAULT_CHARACTER_SET="$MARIADB_DEFAULT_CHARACTER_SET" # only used at build time
-export MARIADB_DEFAULT_COLLATE="utf8_general_ci"
+export MARIADB_DEFAULT_COLLATE="utf8mb4_unicode_ci"
 export DB_DEFAULT_COLLATE="$MARIADB_DEFAULT_COLLATE" # only used at build time
 export MARIADB_DEFAULT_BIND_ADDRESS="0.0.0.0"
 export DB_DEFAULT_BIND_ADDRESS="$MARIADB_DEFAULT_BIND_ADDRESS" # only used at build time

--- a/bitnami/mariadb/10.3/debian-11/rootfs/opt/bitnami/scripts/mariadb-env.sh
+++ b/bitnami/mariadb/10.3/debian-11/rootfs/opt/bitnami/scripts/mariadb-env.sh
@@ -91,9 +91,9 @@ export DB_DAEMON_GROUP="mysql"
 # Default configuration (build-time)
 export MARIADB_DEFAULT_PORT_NUMBER="3306"
 export DB_DEFAULT_PORT_NUMBER="$MARIADB_DEFAULT_PORT_NUMBER" # only used at build time
-export MARIADB_DEFAULT_CHARACTER_SET="utf8"
+export MARIADB_DEFAULT_CHARACTER_SET="utf8mb4"
 export DB_DEFAULT_CHARACTER_SET="$MARIADB_DEFAULT_CHARACTER_SET" # only used at build time
-export MARIADB_DEFAULT_COLLATE="utf8_general_ci"
+export MARIADB_DEFAULT_COLLATE="utf8mb4_unicode_ci"
 export DB_DEFAULT_COLLATE="$MARIADB_DEFAULT_COLLATE" # only used at build time
 export MARIADB_DEFAULT_BIND_ADDRESS="0.0.0.0"
 export DB_DEFAULT_BIND_ADDRESS="$MARIADB_DEFAULT_BIND_ADDRESS" # only used at build time

--- a/bitnami/mariadb/10.4/debian-11/rootfs/opt/bitnami/scripts/mariadb-env.sh
+++ b/bitnami/mariadb/10.4/debian-11/rootfs/opt/bitnami/scripts/mariadb-env.sh
@@ -91,9 +91,9 @@ export DB_DAEMON_GROUP="mysql"
 # Default configuration (build-time)
 export MARIADB_DEFAULT_PORT_NUMBER="3306"
 export DB_DEFAULT_PORT_NUMBER="$MARIADB_DEFAULT_PORT_NUMBER" # only used at build time
-export MARIADB_DEFAULT_CHARACTER_SET="utf8"
+export MARIADB_DEFAULT_CHARACTER_SET="utf8mb4"
 export DB_DEFAULT_CHARACTER_SET="$MARIADB_DEFAULT_CHARACTER_SET" # only used at build time
-export MARIADB_DEFAULT_COLLATE="utf8_general_ci"
+export MARIADB_DEFAULT_COLLATE="utf8mb4_unicode_ci"
 export DB_DEFAULT_COLLATE="$MARIADB_DEFAULT_COLLATE" # only used at build time
 export MARIADB_DEFAULT_BIND_ADDRESS="0.0.0.0"
 export DB_DEFAULT_BIND_ADDRESS="$MARIADB_DEFAULT_BIND_ADDRESS" # only used at build time

--- a/bitnami/mariadb/10.5/debian-11/rootfs/opt/bitnami/scripts/mariadb-env.sh
+++ b/bitnami/mariadb/10.5/debian-11/rootfs/opt/bitnami/scripts/mariadb-env.sh
@@ -91,9 +91,9 @@ export DB_DAEMON_GROUP="mysql"
 # Default configuration (build-time)
 export MARIADB_DEFAULT_PORT_NUMBER="3306"
 export DB_DEFAULT_PORT_NUMBER="$MARIADB_DEFAULT_PORT_NUMBER" # only used at build time
-export MARIADB_DEFAULT_CHARACTER_SET="utf8"
+export MARIADB_DEFAULT_CHARACTER_SET="utf8mb4"
 export DB_DEFAULT_CHARACTER_SET="$MARIADB_DEFAULT_CHARACTER_SET" # only used at build time
-export MARIADB_DEFAULT_COLLATE="utf8_general_ci"
+export MARIADB_DEFAULT_COLLATE="utf8mb4_unicode_ci"
 export DB_DEFAULT_COLLATE="$MARIADB_DEFAULT_COLLATE" # only used at build time
 export MARIADB_DEFAULT_BIND_ADDRESS="0.0.0.0"
 export DB_DEFAULT_BIND_ADDRESS="$MARIADB_DEFAULT_BIND_ADDRESS" # only used at build time

--- a/bitnami/mariadb/10.6/debian-11/rootfs/opt/bitnami/scripts/mariadb-env.sh
+++ b/bitnami/mariadb/10.6/debian-11/rootfs/opt/bitnami/scripts/mariadb-env.sh
@@ -91,9 +91,9 @@ export DB_DAEMON_GROUP="mysql"
 # Default configuration (build-time)
 export MARIADB_DEFAULT_PORT_NUMBER="3306"
 export DB_DEFAULT_PORT_NUMBER="$MARIADB_DEFAULT_PORT_NUMBER" # only used at build time
-export MARIADB_DEFAULT_CHARACTER_SET="utf8"
+export MARIADB_DEFAULT_CHARACTER_SET="utf8mb4"
 export DB_DEFAULT_CHARACTER_SET="$MARIADB_DEFAULT_CHARACTER_SET" # only used at build time
-export MARIADB_DEFAULT_COLLATE="utf8_general_ci"
+export MARIADB_DEFAULT_COLLATE="utf8mb4_unicode_ci"
 export DB_DEFAULT_COLLATE="$MARIADB_DEFAULT_COLLATE" # only used at build time
 export MARIADB_DEFAULT_BIND_ADDRESS="0.0.0.0"
 export DB_DEFAULT_BIND_ADDRESS="$MARIADB_DEFAULT_BIND_ADDRESS" # only used at build time

--- a/bitnami/mariadb/10.7/debian-11/rootfs/opt/bitnami/scripts/mariadb-env.sh
+++ b/bitnami/mariadb/10.7/debian-11/rootfs/opt/bitnami/scripts/mariadb-env.sh
@@ -91,9 +91,9 @@ export DB_DAEMON_GROUP="mysql"
 # Default configuration (build-time)
 export MARIADB_DEFAULT_PORT_NUMBER="3306"
 export DB_DEFAULT_PORT_NUMBER="$MARIADB_DEFAULT_PORT_NUMBER" # only used at build time
-export MARIADB_DEFAULT_CHARACTER_SET="utf8"
+export MARIADB_DEFAULT_CHARACTER_SET="utf8mb4"
 export DB_DEFAULT_CHARACTER_SET="$MARIADB_DEFAULT_CHARACTER_SET" # only used at build time
-export MARIADB_DEFAULT_COLLATE="utf8_general_ci"
+export MARIADB_DEFAULT_COLLATE="utf8mb4_unicode_ci"
 export DB_DEFAULT_COLLATE="$MARIADB_DEFAULT_COLLATE" # only used at build time
 export MARIADB_DEFAULT_BIND_ADDRESS="0.0.0.0"
 export DB_DEFAULT_BIND_ADDRESS="$MARIADB_DEFAULT_BIND_ADDRESS" # only used at build time

--- a/bitnami/mariadb/10.8/debian-11/rootfs/opt/bitnami/scripts/mariadb-env.sh
+++ b/bitnami/mariadb/10.8/debian-11/rootfs/opt/bitnami/scripts/mariadb-env.sh
@@ -91,9 +91,9 @@ export DB_DAEMON_GROUP="mysql"
 # Default configuration (build-time)
 export MARIADB_DEFAULT_PORT_NUMBER="3306"
 export DB_DEFAULT_PORT_NUMBER="$MARIADB_DEFAULT_PORT_NUMBER" # only used at build time
-export MARIADB_DEFAULT_CHARACTER_SET="utf8"
+export MARIADB_DEFAULT_CHARACTER_SET="utf8mb4"
 export DB_DEFAULT_CHARACTER_SET="$MARIADB_DEFAULT_CHARACTER_SET" # only used at build time
-export MARIADB_DEFAULT_COLLATE="utf8_general_ci"
+export MARIADB_DEFAULT_COLLATE="utf8mb4_unicode_ci"
 export DB_DEFAULT_COLLATE="$MARIADB_DEFAULT_COLLATE" # only used at build time
 export MARIADB_DEFAULT_BIND_ADDRESS="0.0.0.0"
 export DB_DEFAULT_BIND_ADDRESS="$MARIADB_DEFAULT_BIND_ADDRESS" # only used at build time

--- a/bitnami/mariadb/10.9/debian-11/rootfs/opt/bitnami/scripts/mariadb-env.sh
+++ b/bitnami/mariadb/10.9/debian-11/rootfs/opt/bitnami/scripts/mariadb-env.sh
@@ -91,9 +91,9 @@ export DB_DAEMON_GROUP="mysql"
 # Default configuration (build-time)
 export MARIADB_DEFAULT_PORT_NUMBER="3306"
 export DB_DEFAULT_PORT_NUMBER="$MARIADB_DEFAULT_PORT_NUMBER" # only used at build time
-export MARIADB_DEFAULT_CHARACTER_SET="utf8"
+export MARIADB_DEFAULT_CHARACTER_SET="utf8mb4"
 export DB_DEFAULT_CHARACTER_SET="$MARIADB_DEFAULT_CHARACTER_SET" # only used at build time
-export MARIADB_DEFAULT_COLLATE="utf8_general_ci"
+export MARIADB_DEFAULT_COLLATE="utf8mb4_unicode_ci"
 export DB_DEFAULT_COLLATE="$MARIADB_DEFAULT_COLLATE" # only used at build time
 export MARIADB_DEFAULT_BIND_ADDRESS="0.0.0.0"
 export DB_DEFAULT_BIND_ADDRESS="$MARIADB_DEFAULT_BIND_ADDRESS" # only used at build time

--- a/bitnami/mariadb/README.md
+++ b/bitnami/mariadb/README.md
@@ -210,8 +210,8 @@ services:
 
 It is possible to configure the character set and collation used by default by the database with the following environment variables:
 
-- `MARIADB_CHARACTER_SET`: The default character set to use. Default: `utf8`
-- `MARIADB_COLLATE`: The default collation to use. Default: `utf8_general_ci`
+- `MARIADB_CHARACTER_SET`: The default character set to use. Default: `utf8mb4`
+- `MARIADB_COLLATE`: The default collation to use. Default: `utf8mb4_unicode_ci`
 
 ### Setting the root password on first run
 


### PR DESCRIPTION
### Description of the change

Changed the default character set for MariaDB from 3-byte `utf8` to 4-byte `utf8mb4` which is the recommended default for both MySQL and MariaDB nowadays. Also changed the default collation to `utf8mb4_unicode_ci` for better sorting.

### Benefits

With this change, any 4-byte Unicode characters like emojis and other recently introduced characters will appear correctly out of the box and not as question marks or squares. This will also benefit all MariaDB-powered installations like WordPress, Redmine etc.

### Possible drawbacks

I don't know about any limitations. The collation change, according to [this](https://stackoverflow.com/a/766996/1604592) very detailed StackOverflow answer, can lead to slight performance degradation. However, as CPU’s are fast enough in our times, I find sorting benefits far more important.

### Applicable issues

N/A

### Additional information


I applied the change to all MariaDB versions, from 10.3 to 10.10. If this PR is merged, I'll apply the same change to mariadb-galera.