### PR TITLE
[bitnami/pgpool] extend health check configuration

### DIFF
--- a/bitnami/pgpool/README.md
+++ b/bitnami/pgpool/README.md
@@ -271,6 +271,8 @@ Pgpool configuration:
 * `PGPOOL_HEALTH_CHECK_TIMEOUT`: Specifies the timeout in seconds to give up connecting to the backend PostgreSQL if the TCP connect does not succeed within this time. Defaults to `10`.
 * `PGPOOL_HEALTH_CHECK_MAX_RETRIES`: Specifies the maximum number of retries to do before giving up and initiating failover when health check fails. Defaults to `5`.
 * `PGPOOL_HEALTH_CHECK_RETRY_DELAY`: Specifies the amount of time in seconds to sleep between failed health check retries. Defaults to `5`.
+* `PGPOOL_CONNECT_TIMEOUT`: Specifies the amount of time in milliseconds before giving up connecting to backend using `connect()` system call. Default is `10000`.
+* `PGPOOL_HEALTH_CHECK_PSQL_TIMEOUT`: Specifies the maximum amount of time in seconds function `pgpool_healthcheck()` waits for result of `show pool_nodes` command. It is set to `PGCONNECT_TIMEOUT` of respective `psql` execution. Default is `15`.
 * `PGPOOL_USER_CONF_FILE`: Configuration file to be added to the generated config file. This allow to override configuration set by the initializacion process. No defaults.
 * `PGPOOL_USER_HBA_FILE`: Configuration file to be added to the generated hba file. This allow to override configuration set by the initialization process. No defaults.
 * `PGPOOL_POSTGRES_CUSTOM_USERS`: List of comma or semicolon separeted list of postgres usernames. This will create entries in `pgpool_passwd`. No defaults.


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Introduce the following changes:
- Introduce PGPOOL_CONNECT_TIMEOUT variable and set default to 10000ms.
  User can setup pgpool to fail faster when trying to connect to unreachable
  PG node.
- Introduce PGPOOL_HEALTH_CHECK_PSQL_TIMEOUT variable with default to 15.
  User can control "show pool_nodes" command timeout in healthcheck
  function.
- Only nodes in pgpool state DOWN which are UP in reality are attached.

### Benefits

Makes pgpool pod configuration more versatile. It is used by PR https://github.com/bitnami/charts/pull/14175

### Possible drawbacks

Do not know.

### Applicable issues

It fixes https://github.com/bitnami/charts/issues/12263.

### Additional information

N/A
