### PR TITLE
[bitnami/containers] Add workflow to move issue cards based on PR changes

### DIFF
--- a/.github/workflows/pr-reviews.yml
+++ b/.github/workflows/pr-reviews.yml
@@ -1,0 +1,25 @@
+name: '[Support] Review based card movements'
+on:
+  pull_request_target:
+    types:
+      - review_requested
+      - synchronize
+permissions:
+  repository-projects: write
+jobs:
+  comments_handler:
+    runs-on: ubuntu-latest
+    # This job will ignore:
+    # * Events triggered by bitnami-bot (README commits for example).
+    # * Events triggered over automated PRs (They are managed in comments.yml workflow).
+    # * PRs with 'bitnami' label.
+    if: |
+      github.actor != 'bitnami-bot' && github.event.pull_request.user.login != 'bitnami-bot' &&
+      (!contains(github.event.pull_request.labels.*.name, 'bitnami'))
+    steps:
+      - name: Move into In Progress
+        uses: peter-evans/create-or-update-project-card@v2
+        with:
+          project-name: Support
+          column-name: In progress
+          issue-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Signed-off-by: Fran Mulero <fmulero@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Creates a new workflow to move cards properly in the support dashboard attending to PR request review and repository changes.

### Benefits

Cards will be properly moved according to our support workflow.

### Possible drawbacks

None identified

### Applicable issues

These PRs will not moved when the review was submitted
  - #14217
  - #14163

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
