### PR TITLE
Add $MATOMO_DATABASE_TABLE_PREFIX [default: "matomo_"] as wizard option

### DIFF
--- a/bitnami/matomo/4/debian-11/rootfs/opt/bitnami/scripts/libmatomo.sh
+++ b/bitnami/matomo/4/debian-11/rootfs/opt/bitnami/scripts/libmatomo.sh
@@ -115,6 +115,7 @@ matomo_initialize() {
         db_name="$MATOMO_DATABASE_NAME"
         db_user="$MATOMO_DATABASE_USER"
         db_pass="$MATOMO_DATABASE_PASSWORD"
+        db_table_prefix="$MATOMO_DATABASE_TABLE_PREFIX"
         matomo_wait_for_db_connection "$db_host" "$db_port" "$db_name" "$db_user" "$db_pass"
 
         if ! is_boolean_yes "$MATOMO_SKIP_BOOTSTRAP"; then
@@ -146,7 +147,7 @@ EOF
             ini-file set -s "database" -k "port" -v "$db_port" "$MATOMO_CONF_FILE"
             ini-file set -s "database" -k "dbname" -v "$db_name" "$MATOMO_CONF_FILE"
             ini-file set -s "database" -k "adapter" -v "MYSQLI" "$MATOMO_CONF_FILE"
-            ini-file set -s "database" -k "tables_prefix" -v "matomo_" "$MATOMO_CONF_FILE"
+            ini-file set -s "database" -k "tables_prefix" -v "$db_table_prefix" "$MATOMO_CONF_FILE"
         fi
 
         # Reverse Proxy Configuration options
@@ -361,6 +362,7 @@ matomo_pass_wizard() {
         "--data-urlencode" "username=${MATOMO_DATABASE_USER}"
         "--data-urlencode" "password=${MATOMO_DATABASE_PASSWORD}"
         "--data-urlencode" "dbname=${MATOMO_DATABASE_NAME}"
+        "--data-urlencode" "tables_prefix=${MATOMO_DATABASE_TABLE_PREFIX}"
         "--data-urlencode" "adapter=MYSQLI"
     )
     debug_execute "curl" "${curl_opts[@]}" "${curl_data_opts[@]}" "${wizard_url}"

--- a/bitnami/matomo/4/debian-11/rootfs/opt/bitnami/scripts/matomo-env.sh
+++ b/bitnami/matomo/4/debian-11/rootfs/opt/bitnami/scripts/matomo-env.sh
@@ -41,6 +41,7 @@ matomo_env_vars=(
     MATOMO_DATABASE_SSL_CERT_FILE
     MATOMO_DATABASE_SSL_KEY_FILE
     MATOMO_VERIFY_DATABASE_SSL
+    MATOMO_DATABASE_TABLE_PREFIX
     MATOMO_SMTP_HOST
     MATOMO_SMTP_PORT_NUMBER
     MATOMO_SMTP_USER
@@ -128,6 +129,7 @@ export MATOMO_DATABASE_PORT_NUMBER="${MATOMO_DATABASE_PORT_NUMBER:-3306}" # only
 export MATOMO_DATABASE_NAME="${MATOMO_DATABASE_NAME:-bitnami_matomo}" # only used during the first initialization
 export MATOMO_DATABASE_USER="${MATOMO_DATABASE_USER:-bn_matomo}" # only used during the first initialization
 export MATOMO_DATABASE_PASSWORD="${MATOMO_DATABASE_PASSWORD:-}" # only used during the first initialization
+export MATOMO_DATABASE_TABLE_PREFIX="${MATOMO_DATABASE_TABLE_PREFIX:-matomo_}" # only used during the first initialization
 
 # PHP configuration
 export PHP_DEFAULT_MEMORY_LIMIT="256M" # only used at build time

--- a/bitnami/matomo/README.md
+++ b/bitnami/matomo/README.md
@@ -281,6 +281,7 @@ When you start the Matomo image, you can adjust the configuration of the instanc
  - `MATOMO_DATABASE_SSL_CERT_FILE`: Path to the database client certificate file. No defaults.
  - `MATOMO_DATABASE_SSL_KEY_FILE`: Path to the database client certificate key. No defaults.
  - `MATOMO_VERIFY_DATABASE_SSL`: Whether to verify the database SSL certificate when SSL is enabled. Default: **yes**
+ - `MATOMO_DATABASE_TABLE_PREFIX`: Prefix to use when creating Matomo tables. Default: **matomo_**
  - `BITNAMI_DEBUG`: Increase verbosity on initialization logs. Default **false**
 
 #### Reverse proxy configuration options


### PR DESCRIPTION
### Description of the change

Add an option to set the prefix for database tables.

### Benefits

More options available to adapt this image to existing setups.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

None