### PR TITLE
[bitnami/airflow] Add Kerberos utilities package krb5-user to airflow Dockerfile

### DIFF
--- a/bitnami/airflow/2/debian-11/Dockerfile
+++ b/bitnami/airflow/2/debian-11/Dockerfile
@@ -19,7 +19,7 @@ ENV HOME="/" \
 COPY prebuildfs /
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Install required system packages and dependencies
-RUN install_packages ca-certificates curl git libbsd0 libbz2-1.0 libcdt5 libcgraph6 libcom-err2 libcrypt1 libedit2 libexpat1 libffi7 libgcc-s1 libgmp10 libgnutls30 libgssapi-krb5-2 libgvc6 libhogweed6 libicu67 libidn2-0 libk5crypto3 libkeyutils1 libkrb5-3 libkrb5support0 libldap-2.4-2 libltdl7 liblzma5 libmariadb3 libmd0 libncursesw6 libnettle8 libnsl2 libp11-kit0 libpathplan4 libpq5 libreadline8 libsasl2-2 libsasl2-modules libsqlite3-0 libssl1.1 libstdc++6 libtasn1-6 libtinfo6 libtirpc3 libunistring2 libuuid1 libxml2 libxslt1.1 locales netbase procps zlib1g
+RUN install_packages ca-certificates curl git libbsd0 libbz2-1.0 libcdt5 libcgraph6 libcom-err2 libcrypt1 libedit2 libexpat1 libffi7 libgcc-s1 libgmp10 libgnutls30 libgssapi-krb5-2 libgvc6 libhogweed6 libicu67 libidn2-0 libk5crypto3 libkeyutils1 libkrb5-3 libkrb5support0 libldap-2.4-2 libltdl7 liblzma5 libmariadb3 libmd0 libncursesw6 libnettle8 libnsl2 libp11-kit0 libpathplan4 libpq5 libreadline8 libsasl2-2 libsasl2-modules libsqlite3-0 libssl1.1 libstdc++6 libtasn1-6 libtinfo6 libtirpc3 libunistring2 libuuid1 libxml2 libxslt1.1 locales netbase procps zlib1g krb5-user
 RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ && \
     COMPONENTS=( \
       "wait-for-port-1.0.6-0-linux-${OS_ARCH}-debian-11" \


### PR DESCRIPTION
### Description of the change
Change adds the Kerberos utilities package krb5-user to the airflow image.

### Benefits
Adding the krb5-user package will ensure core Kerberos utilities (krb5-config, kinit, etc) are available to Airflow in the base image.  Airflow requires these in order to support Kerberos related functionality. 

### Possible drawbacks
Minimal increase in the size of the resulting image.

### Applicable issues
Airflow has support for Kerberos. This means that Airflow can renew Kerberos tickets for itself and store them in its ticket cache. The hooks and dags can make use of tickets to authenticate against Kerberized services.  The krb5-user utilities are required for this.

### Additional information
https://airflow.apache.org/docs/apache-airflow/stable/administration-and-deployment/security/kerberos.html

Relates to
- https://github.com/bitnami/containers/pull/21884
- https://github.com/bitnami/containers/pull/21885
- https://github.com/bitnami/containers/pull/21886