### PR TITLE
[bitnami/openldap] Fix timing issue where openldap is not yet ready

### DIFF
--- a/bitnami/openldap/2.6/debian-11/rootfs/opt/bitnami/scripts/libopenldap.sh
+++ b/bitnami/openldap/2.6/debian-11/rootfs/opt/bitnami/scripts/libopenldap.sh
@@ -151,6 +151,19 @@ ldap_validate() {
 }
 
 ########################
+# Check if OpenLDAP is ready to answer
+# Globals:
+#   LDAP_PID_FILE
+# Arguments:
+#   None
+# Returns:
+#   Whether slapd is running
+#########################
+is_ldap_answering() {
+    is_ldap_running && debug_execute ldapsearch -Y EXTERNAL -H "ldapi:///" -b cn=config -s base || false
+}
+
+########################
 # Check if OpenLDAP is running
 # Globals:
 #   LDAP_PID_FILE
@@ -197,7 +210,7 @@ ldap_start_bg() {
         ulimit -n "$LDAP_ULIMIT_NOFILES"
         am_i_root && flags=("-u" "$LDAP_DAEMON_USER" "${flags[@]}")
         debug_execute slapd "${flags[@]}" &
-        if ! retry_while is_ldap_running "$retries" "$sleep_time"; then
+        if ! retry_while is_ldap_answering "$retries" "$sleep_time"; then
             error "OpenLDAP failed to start"
             return 1
         fi

--- a/bitnami/openldap/2.6/debian-11/rootfs/opt/bitnami/scripts/libopenldap.sh
+++ b/bitnami/openldap/2.6/debian-11/rootfs/opt/bitnami/scripts/libopenldap.sh
@@ -152,14 +152,12 @@ ldap_validate() {
 
 ########################
 # Check if OpenLDAP is ready to answer
-# Globals:
-#   LDAP_PID_FILE
 # Arguments:
 #   None
 # Returns:
-#   Whether slapd is running
+#   Whether slapd is ready to answer
 #########################
-is_ldap_answering() {
+is_ldap_ready() {
     is_ldap_running && debug_execute ldapsearch -Y EXTERNAL -H "ldapi:///" -b cn=config -s base || false
 }
 
@@ -210,7 +208,7 @@ ldap_start_bg() {
         ulimit -n "$LDAP_ULIMIT_NOFILES"
         am_i_root && flags=("-u" "$LDAP_DAEMON_USER" "${flags[@]}")
         debug_execute slapd "${flags[@]}" &
-        if ! retry_while is_ldap_answering "$retries" "$sleep_time"; then
+        if ! retry_while is_ldap_ready "$retries" "$sleep_time"; then
             error "OpenLDAP failed to start"
             return 1
         fi

--- a/bitnami/openldap/2.6/debian-11/rootfs/opt/bitnami/scripts/libopenldap.sh
+++ b/bitnami/openldap/2.6/debian-11/rootfs/opt/bitnami/scripts/libopenldap.sh
@@ -158,6 +158,7 @@ ldap_validate() {
 #   Whether slapd is ready to answer
 #########################
 is_ldap_ready() {
+    # shellcheck disable=SC2015
     is_ldap_running && debug_execute ldapsearch -Y EXTERNAL -H "ldapi:///" -b cn=config -s base || false
 }
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change
Wait till openldap listens for new connections before continuing setup.
<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits
It happens that de configure of the LDAP credentials for admin user fails. Probably because it is done before openldap is ready to accept connections. See for example: https://ci.joomla.org/joomla/joomla-cms/61339/1/5 and https://ci.joomla.org/joomla/joomla-cms/61364/1/5
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks
none
<!-- Describe any known limitations with your change -->

### Applicable issues
none
<!-- Enter any applicable Issues here (You can reference an issue using #) -->

### Additional information
none
<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
