### PR TITLE
[bitnami/pgpool] Fix sr_check_user value

### DIFF
--- a/bitnami/pgpool/4/debian-11/docker-compose.yml
+++ b/bitnami/pgpool/4/debian-11/docker-compose.yml
@@ -40,8 +40,8 @@ services:
       - 5432:5432
     environment:
       - PGPOOL_BACKEND_NODES=0:pg-0:5432,1:pg-1:5432
-      - PGPOOL_SR_CHECK_USER=customuser
-      - PGPOOL_SR_CHECK_PASSWORD=custompassword
+      - PGPOOL_SR_CHECK_USER=repmgr
+      - PGPOOL_SR_CHECK_PASSWORD=repmgrpassword
       - PGPOOL_ENABLE_LDAP=no
       - PGPOOL_POSTGRES_USERNAME=postgres
       - PGPOOL_POSTGRES_PASSWORD=adminpassword

--- a/bitnami/pgpool/README.md
+++ b/bitnami/pgpool/README.md
@@ -123,8 +123,8 @@ Use the `--network <NETWORK>` argument to the `docker run` command to attach the
 $ docker run --detach --rm --name pgpool \
   --network my-network \
   --env PGPOOL_BACKEND_NODES=0:pg-0:5432,1:pg-1:5432 \
-  --env PGPOOL_SR_CHECK_USER=customuser \
-  --env PGPOOL_SR_CHECK_PASSWORD=custompassword \
+  --env PGPOOL_SR_CHECK_USER=repmgr \
+  --env PGPOOL_SR_CHECK_PASSWORD=repmgrpassword \
   --env PGPOOL_ENABLE_LDAP=no \
   --env PGPOOL_POSTGRES_USERNAME=postgres \
   --env PGPOOL_POSTGRES_PASSWORD=adminpassword \
@@ -193,8 +193,8 @@ services:
       - 5432:5432
     environment:
       - PGPOOL_BACKEND_NODES=0:pg-0:5432,1:pg-1:5432
-      - PGPOOL_SR_CHECK_USER=customuser
-      - PGPOOL_SR_CHECK_PASSWORD=custompassword
+      - PGPOOL_SR_CHECK_USER=repmgr
+      - PGPOOL_SR_CHECK_PASSWORD=repmgrpassword
       - PGPOOL_ENABLE_LDAP=no
       - PGPOOL_POSTGRES_USERNAME=postgres
       - PGPOOL_POSTGRES_PASSWORD=adminpassword
@@ -350,8 +350,8 @@ $ docker run --detach --name pg-1 \
 $ docker run --detach --rm --name pgpool \
   --network my-network \
   --env PGPOOL_BACKEND_NODES=0:pg-0:5432,1:pg-1:5432 \
-  --env PGPOOL_SR_CHECK_USER=postgres \
-  --env PGPOOL_SR_CHECK_PASSWORD=adminpassword \
+  --env PGPOOL_SR_CHECK_USER=repmgr \
+  --env PGPOOL_SR_CHECK_PASSWORD=repmgrpassword \
   --env PGPOOL_ENABLE_LDAP=no \
   --env PGPOOL_USERNAME=customuser \
   --env PGPOOL_PASSWORD=custompassword \
@@ -387,7 +387,7 @@ In order to have your custom files inside the docker image you can mount them as
 +      - /path/to/init-scripts:/docker-entrypoint-initdb.d
      environment:
        - PGPOOL_BACKEND_NODES=0:pg-0:5432,1:pg-1:5432
-       - PGPOOL_SR_CHECK_USER=customuser
+       - PGPOOL_SR_CHECK_USER=repmgr
 ```
 
 ### Securing Pgpool traffic
@@ -461,7 +461,7 @@ Run the Pgpool image, mounting a directory from your host and setting `PGPOOL_US
 +      - PGPOOL_USER_CONF_FILE=/config/myconf.conf
 +      - PGPOOL_USER_HBA_FILE=/config/myhbaconf.conf
        - PGPOOL_BACKEND_NODES=0:pg-0:5432,1:pg-1:5432
-       - PGPOOL_SR_CHECK_USER=customuser
+       - PGPOOL_SR_CHECK_USER=repmgr
 ```
 
 #### Step 3: Start Pgpool

--- a/bitnami/pgpool/docker-compose.yml
+++ b/bitnami/pgpool/docker-compose.yml
@@ -40,8 +40,8 @@ services:
       - 5432:5432
     environment:
       - PGPOOL_BACKEND_NODES=0:pg-0:5432,1:pg-1:5432
-      - PGPOOL_SR_CHECK_USER=customuser
-      - PGPOOL_SR_CHECK_PASSWORD=custompassword
+      - PGPOOL_SR_CHECK_USER=repmgr
+      - PGPOOL_SR_CHECK_PASSWORD=repmgrpassword
       - PGPOOL_ENABLE_LDAP=no
       - PGPOOL_POSTGRES_USERNAME=postgres
       - PGPOOL_POSTGRES_PASSWORD=adminpassword


### PR DESCRIPTION
### Description of the change

The user indicated in **SR_CHECK_USER** is not a user intended to be used as a user of the pgpool application, it is only intended for the replication process, as indicated in the [following documentation:](https://access.crunchydata.com/documentation/pgpool/3.5.16/)
```
sr_check_user V3.1 -
The user name to perform streaming replication check. This user must exist in all the PostgreSQL backends. Otherwise, the check causes an error. Note that sr_check_user and sr_check_password are used even sr_check_period is 0. To identify the primary server, pgpool-II sends function call request to each backend. sr_check_user and sr_check_password are used for this session.
You need to reload pgpool.conf if you change sr_check_user.

sr_check_password V3.1 -
The password of the user to perform streaming replication check. If no password is required, specify empty string('').
You need to reload pgpool.conf if you change sr_check_password.
```
Therefore, it is more appropriate to change the name in the documentation and in the docker-compose files to make its function more understandable.

