### PR TITLE
[bitnami/wordpress-nginx] Reverting change that broke behavior

### DIFF
--- a/bitnami/wordpress-nginx/6/debian-11/rootfs/opt/bitnami/scripts/nginx/setup.sh
+++ b/bitnami/wordpress-nginx/6/debian-11/rootfs/opt/bitnami/scripts/nginx/setup.sh
@@ -31,7 +31,7 @@ nginx_custom_init_scripts
 ! am_i_root || chmod o+w "$(readlink /dev/stdout)" "$(readlink /dev/stderr)"
 
 # Configure HTTPS port number
-if [[ -n "${NGINX_HTTPS_PORT_NUMBER:-}" ]] && [[ ! -f "${NGINX_SERVER_BLOCKS_DIR}/default-https-server-block.conf" ]] && is_dir_empty "${NGINX_SERVER_BLOCKS_DIR}"; then
+if [[ -n "${NGINX_HTTPS_PORT_NUMBER:-}" ]] && [[ ! -f "${NGINX_SERVER_BLOCKS_DIR}/default-https-server-block.conf" ]] || is_dir_empty "${NGINX_SERVER_BLOCKS_DIR}"; then
     cp "${BITNAMI_ROOT_DIR}/scripts/nginx/server_blocks/default-https-server-block.conf" "${NGINX_SERVER_BLOCKS_DIR}/default-https-server-block.conf"
 fi
 


### PR DESCRIPTION
Signed-off-by: Ben Gray <gehzumteufel@gmail.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR recerts bahvior that broke the image for us and likely others.

### Benefits

The behavior is no longer broken

### Possible drawbacks

No idea, but I would argue behavior that changes should not be in minor versions.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #12995 

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
