### PR TITLE
ensure that DOKU_INC gets set correctly on every startup

### DIFF
--- a/bitnami/dokuwiki/20220731/debian-11/rootfs/opt/bitnami/scripts/libdokuwiki.sh
+++ b/bitnami/dokuwiki/20220731/debian-11/rootfs/opt/bitnami/scripts/libdokuwiki.sh
@@ -62,8 +62,9 @@ dokuwiki_initialize() {
             dokuwiki_pass_wizard
             web_server_stop
             dokuwiki_enable_friendly_urls
-            dokuwiki_configure_DOKU_INC
         fi
+
+        dokuwiki_configure_DOKU_INC
 
         info "Persisting DokuWiki installation"
         persist_app "$app_name" "$DOKUWIKI_DATA_TO_PERSIST"
@@ -141,6 +142,6 @@ dokuwiki_configure_DOKU_INC() {
     # Fix DOKU_INC, since we split application from state, DokuWiki's plugins and templates need to know where they live
     info "Fix DOKU_INC variable"
     auto_prepend_file="$DOKUWIKI_BASE_DIR/conf/auto_prepend.php"
-    printf '<?php\ndefine("DOKU_INC", "%s/");\n' "$DOKUWIKI_BASE_DIR" >>"$auto_prepend_file"
+    printf '<?php\ndefine("DOKU_INC", "%s/");\n' "$DOKUWIKI_BASE_DIR" >"$auto_prepend_file"
     php_conf_set auto_prepend_file "$auto_prepend_file"
 }


### PR DESCRIPTION
This is for the DokuWiki container image

### Description of the change

This patch writes the auto prepend file on every startup

### Benefits

This ensures that the feature is applied correctly when upgrading an existing container

### Possible drawbacks

The file is rewritten on every startup, but since it's tiny I don't see any real drawback.

### Applicable issues

Fixes #22466

Related to #12535