### PR TITLE
run dokuwiki_configure_DOKU_INC on every startup

### DIFF
--- a/bitnami/dokuwiki/20220731/debian-11/rootfs/opt/bitnami/scripts/libdokuwiki.sh
+++ b/bitnami/dokuwiki/20220731/debian-11/rootfs/opt/bitnami/scripts/libdokuwiki.sh
@@ -63,7 +63,6 @@ dokuwiki_initialize() {
             web_server_stop
             dokuwiki_enable_friendly_urls
         fi
-        dokuwiki_configure_DOKU_INC
 
         info "Persisting DokuWiki installation"
         persist_app "$app_name" "$DOKUWIKI_DATA_TO_PERSIST"
@@ -71,6 +70,7 @@ dokuwiki_initialize() {
         info "Restoring persisted DokuWiki installation"
         restore_persisted_app "$app_name" "$DOKUWIKI_DATA_TO_PERSIST"
     fi
+    dokuwiki_configure_DOKU_INC
 
     # Avoid exit code of previous commands to affect the result of this function
     true


### PR DESCRIPTION
Signed-off-by: Karsten Kosmala <kosmala@cosmocode.de>

### Description of the change

We need to run dokuwiki_configure_DOKU_INC on **every** startup, not only when DW gets persisted the first time. So already persisted and new installations will benefit from this.

### Applicable issues

Fixes https://github.com/bitnami/containers/issues/22466

Related to https://github.com/bitnami/containers/pull/12535
