### PR TITLE
Added redis-cluster image support for RDB persistence strategy parameters

### DIFF
--- a/bitnami/redis-cluster/7.0/debian-11/prebuildfs/opt/bitnami/scripts/libfile.sh
+++ b/bitnami/redis-cluster/7.0/debian-11/prebuildfs/opt/bitnami/scripts/libfile.sh
@@ -34,7 +34,13 @@ replace_in_file() {
     if [[ $posix_regex = true ]]; then
         result="$(sed -E "s${del}${match_regex}${del}${substitute_regex}${del}g" "$filename")"
     else
-        result="$(sed "s${del}${match_regex}${del}${substitute_regex}${del}g" "$filename")"
+     #Added substitute_regex matching to the environment, matching the save keyword to write the substitute_regex value into the redis.conf file
+        if [[ "$substitute_regex" =~ ^save.* ]];then
+            echo "$substitute_regex" >> $filename
+            result=$(cat $filename)
+        else
+            result="$(sed "s${del}${match_regex}${del}${substitute_regex}${del}g" "$filename")"
+        fi
     fi
     echo "$result" > "$filename"
 }

--- a/bitnami/redis-cluster/7.0/debian-11/rootfs/opt/bitnami/scripts/libredis.sh
+++ b/bitnami/redis-cluster/7.0/debian-11/rootfs/opt/bitnami/scripts/libredis.sh
@@ -402,6 +402,14 @@ redis_configure_default() {
         # Enable AOF https://redis.io/topics/persistence#append-only-file
         # Leave default fsync (every second)
         redis_conf_set appendonly "${REDIS_AOF_ENABLED}"
+
+        if [ "${REDIS_RDB_ENABLED}" == "yes" ];then
+        #The value stored in $i here is the number of seconds and times of save rules in redis rdb mode
+            for i in ${REDIS_RDB_POLICY};do
+                redis_conf_set save "${i//#/ }"
+            done
+        fi
+
         redis_conf_set port "$REDIS_PORT_NUMBER"
         # TLS configuration
         if is_boolean_yes "$REDIS_TLS_ENABLED"; then

--- a/bitnami/redis-cluster/7.0/debian-11/rootfs/opt/bitnami/scripts/redis-cluster-env.sh
+++ b/bitnami/redis-cluster/7.0/debian-11/rootfs/opt/bitnami/scripts/redis-cluster-env.sh
@@ -21,12 +21,15 @@ export BITNAMI_DEBUG="${BITNAMI_DEBUG:-false}"
 
 # By setting an environment variable matching *_FILE to a file path, the prefixed environment
 # variable will be overridden with the value specified in that file
+#Added REDIS_RDB_ENABLED and REDIS_RDB_POLICY variables
 redis_cluster_env_vars=(
     REDIS_DATA_DIR
     REDIS_OVERRIDES_FILE
     REDIS_DISABLE_COMMANDS
     REDIS_DATABASE
     REDIS_AOF_ENABLED
+    REDIS_RDB_ENABLED
+    REDIS_RDB_POLICY
     REDIS_MASTER_HOST
     REDIS_MASTER_PORT_NUMBER
     REDIS_PORT_NUMBER
@@ -94,10 +97,14 @@ export PATH="${REDIS_BIN_DIR}:${BITNAMI_ROOT_DIR}/common/bin:${PATH}"
 export REDIS_DAEMON_USER="redis"
 export REDIS_DAEMON_GROUP="redis"
 
+
 # Redis settings
+# Added REDIS_RDB_ENABLED and REDIS_RDB_POLICY variables
 export REDIS_DISABLE_COMMANDS="${REDIS_DISABLE_COMMANDS:-}"
 export REDIS_DATABASE="${REDIS_DATABASE:-redis}"
 export REDIS_AOF_ENABLED="${REDIS_AOF_ENABLED:-yes}"
+export REDIS_RDB_ENABLED="${REDIS_RDB_ENABLED:-yes}"
+export REDIS_RDB_POLICY="${REDIS_RDB_POLICY:-900#1 300#10 60#10000}"
 export REDIS_MASTER_HOST="${REDIS_MASTER_HOST:-}"
 export REDIS_MASTER_PORT_NUMBER="${REDIS_MASTER_PORT_NUMBER:-6379}"
 export REDIS_DEFAULT_PORT_NUMBER="6379" # only used at build time


### PR DESCRIPTION
Author: HuangJianChen <huangjc7@foxmail.com>
Date: Tue Feb 14 13:12:06 CST 2023

    Update redis-cluster/7.0/debian-11/prebuildfs/opt/bitnami/scripts/libfile.sh
    Update redis-cluster/7.0/debian-11/rootfs/opt/bitnami/scripts/libredis.sh
    Update redis-cluster/7.0/debian-11/rootfs/opt/bitnami/scripts/redis-cluster-env.sh

    Signed-off-by: Author HuangJianChen <huangjc7@foxmail.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

`Update redis-cluster/7.0/debian-11/prebuildfs/opt/bitnami/scripts/libfile.sh`
`Update redis-cluster/7.0/debian-11/rootfs/opt/bitnami/scripts/libredis.sh`
`Update redis-cluster/7.0/debian-11/rootfs/opt/bitnami/scripts/redis-cluster-env.sh`

### Benefits

Added REDIS_RDB_ENABLED and REDIS_RDB_POLICY environment variable parameters, which can freely open and close the RDB persistent policy