### PR TITLE
[bitnami/dotnet] Fix vib-publish pipeline

### DIFF
--- a/.vib/dotnet/vib-publish.json
+++ b/.vib/dotnet/vib-publish.json
@@ -10,19 +10,6 @@
     "package": {
       "actions": [
         {
-          "action_id": "goss",
-          "params": {
-            "resources": {
-              "path": "/.vib"
-            },
-            "tests_file": "dotnet/goss/goss.yaml",
-            "vars_file": "dotnet/goss/vars.yaml",
-            "remote": {
-              "workload": "deploy-dotnet"
-            }
-          }
-        },
-        {
           "action_id": "container-image-package",
           "params": {
             "application": {
@@ -46,6 +33,21 @@
     },
     "verify": {
       "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "dotnet/goss/goss.yaml",
+            "vars_file": "dotnet/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-dotnet"
+              }
+            }
+          }
+        },
         {
           "action_id": "trivy",
           "params": {

--- a/.vib/dotnet/vib-verify.json
+++ b/.vib/dotnet/vib-verify.json
@@ -39,7 +39,9 @@
             "tests_file": "dotnet/goss/goss.yaml",
             "vars_file": "dotnet/goss/vars.yaml",
             "remote": {
-              "workload": "deploy-dotnet"
+              "pod": {
+                "workload": "deploy-dotnet"
+              }
             }
           }
         },


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Place goss action in the verify phase. Resolve deprecations in [goss action](https://cp.bromelia.vmware.com/v1/execution-graphs/bc5c22ab-ee81-47c3-aaa0-461bb65a4d83/tasks/e9ab8c53-0d1b-4565-8e73-0ec69ade686f/logs/raw):
```
2023-02-17T14:36:51.184+0000 [    main][ WARN] $.remote.workload is deprecated and will be replaced by $.remote.pod.workload. Please, update your input params and use the new property
```
### Benefits

Fix vib-publish pipeline

### Possible drawbacks

None

### Applicable issues
- fixes https://github.com/bitnami/containers/actions/runs/4204756764

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
