### PR TITLE
[bitnami/wordpress] Add support for setting WordPress options

### DIFF
--- a/bitnami/wordpress/6/debian-11/rootfs/opt/bitnami/scripts/libwordpress.sh
+++ b/bitnami/wordpress/6/debian-11/rootfs/opt/bitnami/scripts/libwordpress.sh
@@ -349,6 +349,7 @@ wordpress_initialize() {
             # Enable friendly URLs / permalinks (using historic Bitnami defaults)
             wp_execute rewrite structure '/%year%/%monthnum%/%day%/%postname%/'
             ! is_empty_value "$WORDPRESS_SMTP_HOST" && wordpress_configure_smtp
+            ! is_empty_value "$WORDPRESS_OPTIONS" && wordpress_set_options
         else
             info "An already initialized WordPress database was provided, configuration will be skipped"
             wp_execute core update-db
@@ -579,6 +580,28 @@ if ( !defined( 'WP_CLI' ) ) {
 	});
 }
 EOF
+}
+
+########################
+# Set wordpress options
+# Globals:
+#   *
+# Arguments:
+#   None
+# Returns:
+#   None
+########################
+wordpress_set_options() {
+  read -r -a options_to_set <<<"$(echo "$WORDPRESS_OPTIONS" | tr ',;' ' ')"
+  if [[ "${#options_to_set[@]}" -gt 0 ]]; then
+    info "Setting options"
+    for OPTIONVALUE in ${options_to_set[*]}; do
+      OPTION=$(echo "$OPTIONVALUE" | cut -d "=" -f 1)
+      VALUE=$(echo "$OPTIONVALUE" | cut -d "=" -f 2)
+      debug "Setting option ${OPTION} to value ${VALUE}"
+      wp_execute option set --format=json "$OPTION" "$VALUE"
+    done
+  fi
 }
 
 ########################

--- a/bitnami/wordpress/README.md
+++ b/bitnami/wordpress/README.md
@@ -246,6 +246,7 @@ Available environment variables:
 - `WORDPRESS_SKIP_BOOTSTRAP`: Skip the WordPress installation wizard. This is necessary when providing a database with existing WordPress data. Default: **no**
 - `WORDPRESS_AUTO_UPDATE_LEVEL`: Level of auto-updates to allow for the WordPress core installation. Valid values: `major`, `minor`, `none`. Default: **none**
 - `WORDPRESS_ENABLE_REVERSE_PROXY`: Enable WordPress support for reverse proxy headers. Default: **no**
+- `WORDPRESS_OPTIONS`: Set WordPress options after initialization. A comma separted list of option=value entries. The value format has to be JSON. No defaults.
 
 #### Salt and keys configuration
 


### PR DESCRIPTION
### Description of the change

This adds support for setting WordPress options after initialization

### Benefits

This change aims at providing better WordPress automation

### Possible drawbacks

None to my knowledge.

### Applicable issues

- fixes #24871

### Additional information

This PR is in a priliminary stage and basically describes my solution to #24871. I'm happy to change. Also, is there any testsuite available that I can modify?
