### PR TITLE
[bitnami/mariadb-galara] Set innodb_autoinc_lock_mode=2

### DIFF
--- a/bitnami/mariadb-galera/10.10/debian-11/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
+++ b/bitnami/mariadb-galera/10.10/debian-11/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
@@ -344,6 +344,7 @@ wsrep_sst_auth=${DB_GALERA_DEFAULT_MARIABACKUP_USER}:${DB_GALERA_DEFAULT_MARIABA
 wsrep_cluster_name=${DB_GALERA_DEFAULT_CLUSTER_NAME}
 wsrep_node_name=${DB_GALERA_DEFAULT_NODE_NAME}
 wsrep_node_address=${DB_GALERA_DEFAULT_NODE_ADDRESS}
+innodb_autoinc_lock_mode=2
 
 [mariadb]
 plugin_load_add = auth_pam

--- a/bitnami/mariadb-galera/10.3/debian-11/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
+++ b/bitnami/mariadb-galera/10.3/debian-11/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
@@ -344,6 +344,7 @@ wsrep_sst_auth=${DB_GALERA_DEFAULT_MARIABACKUP_USER}:${DB_GALERA_DEFAULT_MARIABA
 wsrep_cluster_name=${DB_GALERA_DEFAULT_CLUSTER_NAME}
 wsrep_node_name=${DB_GALERA_DEFAULT_NODE_NAME}
 wsrep_node_address=${DB_GALERA_DEFAULT_NODE_ADDRESS}
+innodb_autoinc_lock_mode=2
 
 [mariadb]
 plugin_load_add = auth_pam

--- a/bitnami/mariadb-galera/10.4/debian-11/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
+++ b/bitnami/mariadb-galera/10.4/debian-11/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
@@ -344,6 +344,7 @@ wsrep_sst_auth=${DB_GALERA_DEFAULT_MARIABACKUP_USER}:${DB_GALERA_DEFAULT_MARIABA
 wsrep_cluster_name=${DB_GALERA_DEFAULT_CLUSTER_NAME}
 wsrep_node_name=${DB_GALERA_DEFAULT_NODE_NAME}
 wsrep_node_address=${DB_GALERA_DEFAULT_NODE_ADDRESS}
+innodb_autoinc_lock_mode=2
 
 [mariadb]
 plugin_load_add = auth_pam

--- a/bitnami/mariadb-galera/10.5/debian-11/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
+++ b/bitnami/mariadb-galera/10.5/debian-11/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
@@ -344,6 +344,7 @@ wsrep_sst_auth=${DB_GALERA_DEFAULT_MARIABACKUP_USER}:${DB_GALERA_DEFAULT_MARIABA
 wsrep_cluster_name=${DB_GALERA_DEFAULT_CLUSTER_NAME}
 wsrep_node_name=${DB_GALERA_DEFAULT_NODE_NAME}
 wsrep_node_address=${DB_GALERA_DEFAULT_NODE_ADDRESS}
+innodb_autoinc_lock_mode=2
 
 [mariadb]
 plugin_load_add = auth_pam

--- a/bitnami/mariadb-galera/10.6/debian-11/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
+++ b/bitnami/mariadb-galera/10.6/debian-11/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
@@ -344,6 +344,7 @@ wsrep_sst_auth=${DB_GALERA_DEFAULT_MARIABACKUP_USER}:${DB_GALERA_DEFAULT_MARIABA
 wsrep_cluster_name=${DB_GALERA_DEFAULT_CLUSTER_NAME}
 wsrep_node_name=${DB_GALERA_DEFAULT_NODE_NAME}
 wsrep_node_address=${DB_GALERA_DEFAULT_NODE_ADDRESS}
+innodb_autoinc_lock_mode=2
 
 [mariadb]
 plugin_load_add = auth_pam

--- a/bitnami/mariadb-galera/10.7/debian-11/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
+++ b/bitnami/mariadb-galera/10.7/debian-11/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
@@ -344,6 +344,7 @@ wsrep_sst_auth=${DB_GALERA_DEFAULT_MARIABACKUP_USER}:${DB_GALERA_DEFAULT_MARIABA
 wsrep_cluster_name=${DB_GALERA_DEFAULT_CLUSTER_NAME}
 wsrep_node_name=${DB_GALERA_DEFAULT_NODE_NAME}
 wsrep_node_address=${DB_GALERA_DEFAULT_NODE_ADDRESS}
+innodb_autoinc_lock_mode=2
 
 [mariadb]
 plugin_load_add = auth_pam

--- a/bitnami/mariadb-galera/10.8/debian-11/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
+++ b/bitnami/mariadb-galera/10.8/debian-11/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
@@ -344,6 +344,7 @@ wsrep_sst_auth=${DB_GALERA_DEFAULT_MARIABACKUP_USER}:${DB_GALERA_DEFAULT_MARIABA
 wsrep_cluster_name=${DB_GALERA_DEFAULT_CLUSTER_NAME}
 wsrep_node_name=${DB_GALERA_DEFAULT_NODE_NAME}
 wsrep_node_address=${DB_GALERA_DEFAULT_NODE_ADDRESS}
+innodb_autoinc_lock_mode=2
 
 [mariadb]
 plugin_load_add = auth_pam

--- a/bitnami/mariadb-galera/10.9/debian-11/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
+++ b/bitnami/mariadb-galera/10.9/debian-11/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
@@ -344,6 +344,7 @@ wsrep_sst_auth=${DB_GALERA_DEFAULT_MARIABACKUP_USER}:${DB_GALERA_DEFAULT_MARIABA
 wsrep_cluster_name=${DB_GALERA_DEFAULT_CLUSTER_NAME}
 wsrep_node_name=${DB_GALERA_DEFAULT_NODE_NAME}
 wsrep_node_address=${DB_GALERA_DEFAULT_NODE_ADDRESS}
+innodb_autoinc_lock_mode=2
 
 [mariadb]
 plugin_load_add = auth_pam


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

innodb_autoinc_lock_mode=2 is a manditory Galera setting and the default value for the system variable isn't 2.

All other mandatory galera required system variables are set, or are the default value.

### Benefits

Prevention of issues like #24155
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

None.
<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #24155

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
Galera documentation on required settings: https://mariadb.com/kb/en/configuring-mariadb-galera-cluster/#mandatory-options
