### PR TITLE
[bitnami/keycloak] Upgrade java version in keycloak image from 11 to 17

### DIFF
--- a/bitnami/keycloak/20/debian-11/Dockerfile
+++ b/bitnami/keycloak/20/debian-11/Dockerfile
@@ -24,7 +24,7 @@ RUN install_packages ca-certificates curl krb5-user libaio1 procps zlib1g
 RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ && \
     COMPONENTS=( \
       "wait-for-port-1.0.6-1-linux-${OS_ARCH}-debian-11" \
-      "java-11.0.18-10-2-linux-${OS_ARCH}-debian-11" \
+      "java-17.0.6-10-2-linux-${OS_ARCH}-debian-11" \
       "keycloak-20.0.5-1-linux-${OS_ARCH}-debian-11" \
       "gosu-1.16.0-2-linux-${OS_ARCH}-debian-11" \
     ) && \


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Install java version java-17.0.6-10-2 instead of the previous java-11.0.18-10-2 in the docker image

### Benefits
Keycloak extensions built with a newer version of java can be loaded by the container. 
Additionally, keycloak has deprecated support for java 11, and plans to no longer support it with version 22 https://www.keycloak.org/docs/latest/release_notes/index.html#java-11-support-for-keycloak-server-deprecated

### Possible drawbacks

none

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
