### PR TITLE
[bitnami/redmine] adds ca_file and openssl_verify_mode for smtp config

### DIFF
--- a/bitnami/redmine/5/debian-11/rootfs/opt/bitnami/scripts/libredmine.sh
+++ b/bitnami/redmine/5/debian-11/rootfs/opt/bitnami/scripts/libredmine.sh
@@ -171,6 +171,8 @@ redmine_initialize() {
             redmine_conf_set "default.email_delivery.smtp_settings.password" "$REDMINE_SMTP_PASSWORD"
             # Remove 'USER@' part from e-mail address and use as domain
             redmine_conf_set "default.email_delivery.smtp_settings.domain" "${REDMINE_SMTP_USER//*@/}"
+            redmine_conf_set "default.email_delivery.smtp_settings.openssl_verify_mode" "$REDMINE_SMTP_OPENSSL_VERIFY_MODE"
+            redmine_conf_set "default.email_delivery.smtp_settings.ca_file" "$REDMINE_SMTP_CA_FILE"
             if [[ "$REDMINE_SMTP_PROTOCOL" = "tls" ]]; then
                 redmine_conf_set "default.email_delivery.smtp_settings.enable_starttls_auto" "true" "bool"
             else

--- a/bitnami/redmine/5/debian-11/rootfs/opt/bitnami/scripts/redmine-env.sh
+++ b/bitnami/redmine/5/debian-11/rootfs/opt/bitnami/scripts/redmine-env.sh
@@ -40,6 +40,8 @@ redmine_env_vars=(
     REDMINE_SMTP_PASSWORD
     REDMINE_SMTP_PROTOCOL
     REDMINE_SMTP_AUTH
+    REDMINE_SMTP_OPENSSL_VERIFY_MODE
+    REDMINE_SMTP_CA_FILE
     REDMINE_DATABASE_TYPE
     REDMINE_DATABASE_HOST
     REDMINE_DATABASE_PORT_NUMBER
@@ -119,6 +121,11 @@ REDMINE_SMTP_PROTOCOL="${REDMINE_SMTP_PROTOCOL:-"${SMTP_PROTOCOL:-}"}"
 export REDMINE_SMTP_PROTOCOL="${REDMINE_SMTP_PROTOCOL:-}" # only used during the first initialization
 REDMINE_SMTP_AUTH="${REDMINE_SMTP_AUTH:-"${SMTP_AUTHENTICATION:-}"}"
 export REDMINE_SMTP_AUTH="${REDMINE_SMTP_AUTH:-login}" # only used during the first initialization
+REDMINE_SMTP_OPENSSL_VERIFY_MODE="${REDMINE_SMTP_OPENSSL_VERIFY_MODE:-"${SMTP_OPENSSL_VERIFY_MODE:-}"}"
+export REDMINE_SMTP_OPENSSL_VERIFY_MODE="${REDMINE_SMTP_OPENSSL_VERIFY_MODE:-peer}" # only used during the first initialization
+REDMINE_SMTP_CA_FILE="${REDMINE_SMTP_CA_FILE:-"${SMTP_CA_FILE:-}"}"
+export REDMINE_SMTP_CA_FILE="${REDMINE_SMTP_CA_FILE:-/etc/ssl/certs/ca-certificates.crt}" # only used during the first initialization
+
 
 # Database configuration
 export REDMINE_DATABASE_TYPE="${REDMINE_DATABASE_TYPE:-mariadb}" # only used during the first initialization

--- a/bitnami/redmine/README.md
+++ b/bitnami/redmine/README.md
@@ -276,6 +276,8 @@ To configure Redmine to send email using SMTP you can set the following environm
 - `REDMINE_SMTP_PASSWORD`: SMTP account password.
 - `REDMINE_SMTP_PROTOCOL`: If specified, SMTP protocol to use. Allowed values: *tls*, *ssl*. No default.
 - `REDMINE_SMTP_AUTH`: SMTP authentication method. Allowed values: *login*, *plain*, *cram_md5*. Default: **login**.
+- `REDMINE_SMTP_CA_FILE`: Path to the SMTP CA file. Default: **/etc/ssl/certs/ca-certificates.crt**.
+- `REDMINE_SMTP_VERIFY_MODE`: SMTP sets the level of verification for the SSL certificate presented by the server. Allowed values: *none*, *peer*. Default: **peer**.
 
 #### Examples
 


### PR DESCRIPTION


<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

The change adds smtp configuration to set CA certificate file and to disable TLS certificate verification via environment variable.

### Benefits

- Enable to setup the openssl verification mode to be none or peer via environment variable
- Enable to setup a custom CA certificate file via environment variable

See source code: https://github.com/mikel/mail/blob/199a76bed3fc518508b46135691914a1cfd8bff8/lib/mail/network/delivery_methods/smtp.rb#L184-L187

### Possible drawbacks

Not figured out yet.

### Applicable issues

If you are using self-signed certificate, you might face the error: `certificate verify failed (unable to get local issuer certificate)`. You can disable verification by setting the `SMTP_OPENSSL_VERIFY_MODE=none`.

### Additional information

Not recommended to set `SMTP_OPENSSL_VERIFY_MODE=none` for production use because it exposes the client to potential security risks such as Man-in-the-Middle (MitM) attacks.
