### PR TITLE
Ignore comments in databases section

### DIFF
--- a/bitnami/pgbouncer/1/debian-11/rootfs/opt/bitnami/scripts/libpgbouncer.sh
+++ b/bitnami/pgbouncer/1/debian-11/rootfs/opt/bitnami/scripts/libpgbouncer.sh
@@ -205,7 +205,7 @@ pgbouncer_initialize() {
         if ! is_empty_value "$PGBOUNCER_CONNECT_QUERY"; then
             database_value+=" connect_query='${PGBOUNCER_CONNECT_QUERY}'"
         fi
-        ini-file set --section "databases" --key "$PGBOUNCER_DATABASE" --value "$database_value" "$PGBOUNCER_CONF_FILE"
+        ini-file set --ignore-inline-comments --section "databases" --key "$PGBOUNCER_DATABASE" --value "$database_value" "$PGBOUNCER_CONF_FILE"
 
         i=0;
         while true; VAR_NAME="PGBOUNCER_DSN_${i}";
@@ -214,7 +214,7 @@ pgbouncer_initialize() {
                 break;
             else
                 dsn=${!VAR_NAME};
-                ini-file set --section databases --key "$(echo "$dsn" | cut -d = -f 1)" --value "$(echo "$dsn" | cut -d = -f 2-)" "$PGBOUNCER_CONF_FILE";
+                ini-file set --ignore-inline-comments --section databases --key "$(echo "$dsn" | cut -d = -f 1)" --value "$(echo "$dsn" | cut -d = -f 2-)" "$PGBOUNCER_CONF_FILE";
                 i=$(( "$i" + 1 ));
             fi;
         done;


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Removes backtick wrapping from pgbouncer database section configuration

### Benefits

Supports SQL connect queries containing a semicolon

### Possible drawbacks

Might break some comments in the generated file, which by default has none.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #25997 

### Additional information

It seems like https://github.com/bitnami/ini-file or `go-ini` may need updating as a better fix. I've sen conflicting information on if comments should be allowed after the start of a line - like a suffix comment.