### PR TITLE
[bitnami/clickhouse] Fix the issue 26500

### DIFF
--- a/bitnami/clickhouse/README.md
+++ b/bitnami/clickhouse/README.md
@@ -167,11 +167,11 @@ ClickHouse can be configured via environment variables or using a configuration 
 
 ### Configuration overrides
 
-The configuration can easily be setup by mounting your own configuration overrides on the directory `/bitnami/clickhouse/conf/conf.d` or `/bitnami/clickhouse/conf/users.d`:
+The configuration can easily be setup by mounting your own configuration overrides on the directory `/bitnami/clickhouse/etc/conf.d` or `/bitnami/clickhouse/etc/users.d`:
 
 ```console
 docker run --name clickhouse \
-    --volume /path/to/override.xml:/bitnami/clickhouse/conf/conf.d/override.xml:ro \
+    --volume /path/to/override.xml:/bitnami/clickhouse/etc/conf.d/override.xml:ro \
     bitnami/clickhouse:latest
 ```
 


### PR DESCRIPTION
### Description of the change

The customization configuration path should be `/bitnami/clickhouse/etc`, not `/bitnami/clickhouse/conf`.

### Benefits

Fixed the documentation of bitnami/clickhouse.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues


- fixes #26500 

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
