### PR TITLE
[bitnami/redis] Revert "fix: only check passphrase file if set (#1062)"

### DIFF
--- a/bitnami/redis/6.2/debian-11/rootfs/opt/bitnami/scripts/libredis.sh
+++ b/bitnami/redis/6.2/debian-11/rootfs/opt/bitnami/scripts/libredis.sh
@@ -220,9 +220,6 @@ redis_validate() {
         elif [[ ! -f "$REDIS_TLS_KEY_FILE" ]]; then
             print_validation_error "The private key file in the specified path ${REDIS_TLS_KEY_FILE} does not exist"
         fi
-        if [[ -n "$REDIS_TLS_KEY_FILE_PASS" ]] && [[ ! -f "$REDIS_TLS_KEY_FILE_PASS" ]]; then
-            print_validation_error "The passphrase for the private key file in the specified path ${REDIS_TLS_KEY_FILE_PASS} does not exist"
-        fi
         if [[ -z "$REDIS_TLS_CA_FILE" ]]; then
             print_validation_error "You must provide a CA X.509 certificate in order to use TLS"
         elif [[ ! -f "$REDIS_TLS_CA_FILE" ]]; then

--- a/bitnami/redis/7.0/debian-11/rootfs/opt/bitnami/scripts/libredis.sh
+++ b/bitnami/redis/7.0/debian-11/rootfs/opt/bitnami/scripts/libredis.sh
@@ -220,9 +220,6 @@ redis_validate() {
         elif [[ ! -f "$REDIS_TLS_KEY_FILE" ]]; then
             print_validation_error "The private key file in the specified path ${REDIS_TLS_KEY_FILE} does not exist"
         fi
-        if [[ -n "$REDIS_TLS_KEY_FILE_PASS" ]] && [[ ! -f "$REDIS_TLS_KEY_FILE_PASS" ]]; then
-            print_validation_error "The passphrase for the private key file in the specified path ${REDIS_TLS_KEY_FILE_PASS} does not exist"
-        fi
         if [[ -z "$REDIS_TLS_CA_FILE" ]]; then
             print_validation_error "You must provide a CA X.509 certificate in order to use TLS"
         elif [[ ! -f "$REDIS_TLS_CA_FILE" ]]; then


### PR DESCRIPTION
This reverts commit 7ee30014420015a517d4e8d5d32aafd4e5a2faec.

### Description of the change

Commit 7ee30014420015a517d4e8d5d32aafd4e5a2faec added checking REDIS_TLS_KEY_FILE_PASS as file path :

```
if [[ -n "$REDIS_TLS_KEY_FILE_PASS" ]] && [[ ! -f "$REDIS_TLS_KEY_FILE_PASS" ]]; then
            print_validation_error "The passphrase for the private key file in the specified path ${REDIS_TLS_KEY_FILE_PASS} does not exist"
fi
```

REDIS_TLS_KEY_FILE_PASS is used to set "tls-key-file-pass" for redis.  It's a passphrase, not a file. 

### Benefits

After reverts commit 7ee30014420015a517d4e8d5d32aafd4e5a2faec,  TLS key file passphrase can be configured correctly by using environment variable REDIS_TLS_KEY_FILE_PASS.

Fixes #25764

