### PR TITLE
[bitnami/couchdb] Add VIB tests

### DIFF
--- a/.vib/couchdb/goss/couchdb.yaml
+++ b/.vib/couchdb/goss/couchdb.yaml
@@ -1,0 +1,16 @@
+file:
+  # Checks default config for erlang is set
+  {{ .Vars.root_dir }}/couchdb/etc/vm.args:
+    exists: true
+    filetype: file
+    contains:
+      - /-kernel.*inet_dist_listen_min.*9100/
+command:
+  check-library-path:
+    exec: echo $LD_LIBRARY_PATH
+    stdout:
+      - /opt/bitnami/common/lib
+    exit-status: 0
+  check-libmozjs:
+    exec: ls /opt/bitnami/common/lib | grep libmozjs
+    exit-status: 0

--- a/.vib/couchdb/goss/couchdb.yaml
+++ b/.vib/couchdb/goss/couchdb.yaml
@@ -1,6 +1,6 @@
 file:
   # Checks default config for erlang is set
-  {{ .Vars.root_dir }}/couchdb/etc/vm.args:
+  /opt/bitnami/couchdb/etc/vm.args:
     exists: true
     filetype: file
     contains:

--- a/.vib/couchdb/goss/goss.yaml
+++ b/.vib/couchdb/goss/goss.yaml
@@ -1,0 +1,12 @@
+gossfile:
+  # Goss tests exclusive to the current container
+  ../../couchdb/goss/couchdb.yaml: {}
+  # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-app-version.yaml: {}
+  ../../common/goss/templates/check-binaries.yaml: {}
+  ../../common/goss/templates/check-broken-symlinks.yaml: {}
+  ../../common/goss/templates/check-ca-certs.yaml: {}
+  ../../common/goss/templates/check-directories.yaml: {}
+  ../../common/goss/templates/check-linked-libraries.yaml: {}
+  ../../common/goss/templates/check-sed-in-place.yaml: {}
+  ../../common/goss/templates/check-spdx.yaml: {}

--- a/.vib/couchdb/goss/vars.yaml
+++ b/.vib/couchdb/goss/vars.yaml
@@ -4,6 +4,7 @@ binaries:
   - erl
   - gosu
   - ini-file
+  - wait-for-port
 directories:
   - mode: "0775"
     paths:

--- a/.vib/couchdb/goss/vars.yaml
+++ b/.vib/couchdb/goss/vars.yaml
@@ -1,0 +1,18 @@
+binaries:
+  - couchdb
+  - couchjs
+  - erl
+  - gosu
+  - ini-file
+directories:
+  - mode: "0775"
+    paths:
+      - /bitnami/couchdb/data
+      - /opt/bitnami/couchdb/etc
+  - paths:
+      - /opt/bitnami/couchdb/etc/default.d
+      - /opt/bitnami/common/lib
+root_dir: /opt/bitnami
+version:
+  bin_name: couchjs
+  flag: -V

--- a/.vib/couchdb/vib-publish.json
+++ b/.vib/couchdb/vib-publish.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{VIB_ENV_CONTAINER_URL}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyJ0YWlsIiwgIi1mIiwgIi9kZXYvbnVsbCJd"
   },
   "phases": {
     "package": {
@@ -33,6 +34,21 @@
     },
     "verify": {
       "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "couchdb/goss/goss.yaml",
+            "vars_file": "couchdb/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-couchdb"
+              }
+            }
+          }
+        },
         {
           "action_id": "trivy",
           "params": {

--- a/.vib/couchdb/vib-verify.json
+++ b/.vib/couchdb/vib-verify.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyJ0YWlsIiwgIi1mIiwgIi9kZXYvbnVsbCJd"
   },
   "phases": {
     "package": {
@@ -29,6 +30,21 @@
     },
     "verify": {
       "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "couchdb/goss/goss.yaml",
+            "vars_file": "couchdb/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-couchdb"
+              }
+            }
+          }
+        },
         {
           "action_id": "trivy",
           "params": {

--- a/bitnami/couchdb/3/debian-11/docker-compose.yml
+++ b/bitnami/couchdb/3/debian-11/docker-compose.yml
@@ -1,5 +1,6 @@
 version: '2'
 services:
+  # [TEST]
   couchdb:
     image: docker.io/bitnami/couchdb:3
     environment:

--- a/bitnami/couchdb/3/debian-11/docker-compose.yml
+++ b/bitnami/couchdb/3/debian-11/docker-compose.yml
@@ -1,6 +1,5 @@
 version: '2'
 services:
-  # [TEST]
   couchdb:
     image: docker.io/bitnami/couchdb:3
     environment:


### PR DESCRIPTION
Signed-off-by: FraPazGal <fdepaz@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

The main objective of this PR is to publish our Bitnami CouchDB container using VMware Image Builder. In order to do that, several changes are included:

- Increasing the existing test coverage of the asset by adding Goss tests.
- Update verify and publish VIB pipeline's definitions.

### Benefits

- Ensuring higher quality of the container catalog.
- Increased pool of assets completely handled by VMware Image Builder.

### Possible drawbacks

Automated tests could introduce additional flakiness to the CI/CD. 

### Applicable issues

NA

### Additional information

None

Tested in:
- Recent action run: https://github.com/bitnami/containers/actions/runs/4374310596