### PR TITLE
[bitnami/*] Fix linked libraries test

### DIFF
--- a/.vib/common/goss/templates/check-linked-libraries.yaml
+++ b/.vib/common/goss/templates/check-linked-libraries.yaml
@@ -10,6 +10,6 @@ command:
     {{ if contains "exclude_paths:" (.Vars | toString) }}
         {{ $exclude_paths = (.Vars.linked_libraries.exclude_paths | join "|") }}
     {{ end }}
-    exec: export BITNAMI_ROOT_DIR={{ .Vars.root_dir }}{{ if $exclude_paths }} && export EXCLUDE_PATHS='{{ $exclude_paths }}'{{ end }} && ./common/goss/scripts/check-linked-libraries.sh
+    exec: export BITNAMI_ROOT_DIR={{ .Vars.root_dir }} && export EXCLUDE_PATHS='{{ $exclude_paths }}' && ./common/goss/scripts/check-linked-libraries.sh
     timeout: 20000
     exit-status: 0


### PR DESCRIPTION
### Description of the change

Fix undefined variable error that caused test to fail when `exclude_paths` was not defined.

### Benefits

Test work again

### Possible drawbacks

None.

### Applicable issues

NA

### Additional information

Related to:

- https://github.com/bitnami/containers/pull/26805
- https://github.com/bitnami/containers/pull/26806
- https://github.com/bitnami/containers/pull/26810
- https://github.com/bitnami/containers/pull/26812
- https://github.com/bitnami/containers/pull/26813
- https://github.com/bitnami/containers/pull/26814
- https://github.com/bitnami/containers/pull/26816
- https://github.com/bitnami/containers/pull/26817
