### PR TITLE
[bitnami/mysql] Fix the `initialize-insecure` command not using the `MYSQL_EXTRA_FLAGS`

### DIFF
--- a/bitnami/mysql/8.0/debian-11/rootfs/opt/bitnami/scripts/libmysql.sh
+++ b/bitnami/mysql/8.0/debian-11/rootfs/opt/bitnami/scripts/libmysql.sh
@@ -723,6 +723,8 @@ mysql_stop() {
 mysql_install_db() {
     local command="${DB_BIN_DIR}/mysql_install_db"
     local -a args=("--defaults-file=${DB_CONF_FILE}" "--basedir=${DB_BASE_DIR}" "--datadir=${DB_DATA_DIR}")
+    read -r -a db_extra_flags <<< "$(mysql_extra_flags)"
+    [[ "${#db_extra_flags[@]}" -gt 0 ]] && args+=("${db_extra_flags[@]}")
     am_i_root && args=("${args[@]}" "--user=$DB_DAEMON_USER")
     if [[ "$DB_FLAVOR" = "mariadb" ]]; then
         args+=("--auth-root-authentication-method=normal")


### PR DESCRIPTION
### Description of the change

Add `MYSQL_EXTRA_FLAGS` environment variable to the args of `mysqld --initialize-insecure`,

### Benefits

```yaml
services:
  mysql:
    image: docker.io/bitnami/mysql:8.0-fix
    container_name: mysql
    ports:
      - 3306:3306
    environment:
      MYSQL_EXTRA_FLAGS: '--lower-case-table-names=1'
      MYSQL_ROOT_PASSWORD: root
```

### Possible drawbacks


### Applicable issues


- fixes #16211

### Additional information
