### PR TITLE
[bitnami/sonarqube] Remove ARM achitecture

### DIFF
--- a/.vib/sonarqube/vib-publish.json
+++ b/.vib/sonarqube/vib-publish.json
@@ -18,8 +18,7 @@
               }
             },
             "architectures": [
-              "linux/amd64",
-              "linux/arm64"
+              "linux/amd64"
             ]
           }
         },


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Remove support for ARM64.

### Benefits

SonarQube binary doesn't include ARM launchers/wrappers, so we can not support ARM64 at the moment.


### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- Related to #26480

