### PR TITLE
[bitnami/mastodon] Fix Import functionality for user data

### DIFF
--- a/bitnami/mastodon/4/debian-11/Dockerfile
+++ b/bitnami/mastodon/4/debian-11/Dockerfile
@@ -19,7 +19,7 @@ ENV HOME="/" \
 COPY prebuildfs /
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Install required system packages and dependencies
-RUN install_packages acl ca-certificates curl ffmpeg imagemagick libbsd0 libbz2-1.0 libcom-err2 libcrypt1 libedit2 libffi7 libgcc-s1 libgmp10 libgnutls30 libgssapi-krb5-2 libhogweed6 libicu67 libidn11 libidn2-0 libk5crypto3 libkeyutils1 libkrb5-3 libkrb5support0 libldap-2.4-2 liblzma5 libmd0 libncursesw6 libnettle8 libnsl2 libp11-kit0 libpq5 libreadline-dev libreadline8 libsasl2-2 libsqlite3-0 libssl-dev libssl1.1 libstdc++6 libtasn1-6 libtinfo6 libtirpc3 libunistring2 libuuid1 libxml2 libxslt1.1 procps sqlite3 zlib1g
+RUN install_packages acl ca-certificates curl ffmpeg file imagemagick libbsd0 libbz2-1.0 libcom-err2 libcrypt1 libedit2 libffi7 libgcc-s1 libgmp10 libgnutls30 libgssapi-krb5-2 libhogweed6 libicu67 libidn11 libidn2-0 libk5crypto3 libkeyutils1 libkrb5-3 libkrb5support0 libldap-2.4-2 liblzma5 libmd0 libncursesw6 libnettle8 libnsl2 libp11-kit0 libpq5 libreadline-dev libreadline8 libsasl2-2 libsqlite3-0 libssl-dev libssl1.1 libstdc++6 libtasn1-6 libtinfo6 libtirpc3 libunistring2 libuuid1 libxml2 libxslt1.1 procps sqlite3 zlib1g
 RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ && \
     COMPONENTS=( \
       "python-3.8.16-7-linux-${OS_ARCH}-debian-11" \


### PR DESCRIPTION
The official mastodon image includes file and bitnami/mastodon does not. This leads to import failing for users because the file command is not found:

Command :: file -b --mime '/tmp/86c8109f207a6432520364460861301b20230316-11-iru96r.csv'

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Add the file binary to the docker image for bitnami/mastodon.  This binary is required for user data import to work.

### Benefits

This allows Import of 

- Followers list
- Block list
- Mute list
- Domain Blocking lists
- Bookmarks

### Possible drawbacks

None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

To reproduce the problem:

- Create a functioning mastodon instance
- From a logged in account go to Preferences->Import and Export->Export
- Export one or more CSV files (Add a follower and export the Follows CSV)
- Import that same CSV file.  It will fail with a message in the UI "has contents that are not what they are reported to be"

The fix is to provide the file binary which is used to verify that the uploaded CSV file is actually a CSV file.  If you exec into the container file is not part of the container image so paperclip fails to execute the binary and the CSV file is rejected.

This pull request fixes this by adding file to the list of installed apt package in the bitnami/mastodon Dockerfile.
