### PR TITLE
[bitnami/redis] Added dependency for running official Redis module

### DIFF
--- a/bitnami/redis/6.2/debian-11/Dockerfile
+++ b/bitnami/redis/6.2/debian-11/Dockerfile
@@ -19,7 +19,7 @@ ENV HOME="/" \
 COPY prebuildfs /
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Install required system packages and dependencies
-RUN install_packages ca-certificates curl libssl1.1 procps
+RUN install_packages ca-certificates curl libssl1.1 procps libgomp1
 RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ && \
     COMPONENTS=( \
       "wait-for-port-1.0.6-2-linux-${OS_ARCH}-debian-11" \

--- a/bitnami/redis/7.0/debian-11/Dockerfile
+++ b/bitnami/redis/7.0/debian-11/Dockerfile
@@ -19,7 +19,7 @@ ENV HOME="/" \
 COPY prebuildfs /
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Install required system packages and dependencies
-RUN install_packages ca-certificates curl libssl1.1 procps
+RUN install_packages ca-certificates curl libssl1.1 procps libgomp1
 RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ && \
     COMPONENTS=( \
       "wait-for-port-1.0.6-2-linux-${OS_ARCH}-debian-11" \


### PR DESCRIPTION
RedisGraph requires OpenMP for C in order to run, which is not part of the current `bitnami/redis` image.

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Include the `libgomp1` package (Debian) in the base `bitnami/redis` image to enable the use of RedisGraph without requiring the need to maintain a separate image.

### Benefits

The RedisGraph module is supported out of the box when using `bitnami/redis` image.
Extends the number of Redis modules that can be run as part of the `bitnami/redis` image to match the modules included in `redis/redis-stack-server`.

### Possible drawbacks

Additional apt package, however, its dependency tree is relatively small and does not depend on any exotic packages, only `gcc-10-base` and `libc6` ([Debian Bullseye libgomp1](https://packages.debian.org/bullseye/libgomp1)).

### Applicable issues

N/A

### Additional information

The change can be tested by running the following docker command assuming that the `redisgraph.so` binary exists:

```bash
cd [6.2|7.0]/debian-11
docker build -t bitnami/redis:redisgraph -f Dockerfile .
docker run -it --rm --name bitnami-redis-modules -v /path/to/redisgraph.so:/opt/bitnami/redis/modules/redisgraph.so bitnami/redis:redisgraph /bin/bash
# inside the bitnami/redis container run the following command
bash run.sh --loadmodule /opt/bitnami/redis/modules/redisgraph.so

# should produce line
Module 'graph' loaded from /opt/bitnami/redis/modules/redisgraph.so
```