### PR TITLE
[bitnami/containers] Reduce GitHub API requests

### DIFF
--- a/.github/workflows/assign-asset-label.yml
+++ b/.github/workflows/assign-asset-label.yml
@@ -15,11 +15,11 @@ jobs:
         name: Get modified assets
         env:
           DIFF_URL: "${{github.event.pull_request.diff_url}}"
-          TEMP_DIR: "${{runner.temp}}"
+          TEMP_FILE: "${{runner.temp}}/pr-${{github.event.number}}.diff"
         run: |
           # This request doesn't consume API calls.
-          curl -Lkso $TEMP_DIR/PR.diff $DIFF_URL
-          files_changed="$(sed -nr 's/[\-\+]{3} [ab]\/(.*)/\1/p' $TEMP_DIR/PR.diff | sort | uniq)"
+          curl -Lkso $TEMP_FILE $DIFF_URL
+          files_changed="$(sed -nr 's/[\-\+]{3} [ab]\/(.*)/\1/p' $TEMP_FILE | sort | uniq)"
           # Adding || true to avoid "Process exited with code 1" errors
           assets=($(echo "$files_changed" | xargs dirname | sed -nr "s|bitnami/([^/]*).*|\1|p" | sort | uniq || true))
 

--- a/.github/workflows/assign-asset-label.yml
+++ b/.github/workflows/assign-asset-label.yml
@@ -13,12 +13,13 @@ jobs:
     steps:
       - id: get-asset
         name: Get modified assets
+        env:
+          DIFF_URL: "${{github.event.pull_request.diff_url}}"
+          TEMP_DIR: "${{runner.temp}}"
         run: |
-          # Using the Github API to detect the files changed as git merge-base stops working when the branch is behind
-          # and jitterbit/get-changed-files does not support pull_request_target
-          URL="https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files"
-          files_changed_data=$(curl -s --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' -X GET -G "$URL")
-          files_changed="$(echo $files_changed_data | jq -r '.[] | .filename')"
+          # This request doesn't consume API calls.
+          curl -Lkso $TEMP_DIR/PR.diff $DIFF_URL
+          files_changed="$(sed -nr 's/[\-\+]{3} [ab]\/(.*)/\1/p' $TEMP_DIR/PR.diff | sort | uniq)"
           # Adding || true to avoid "Process exited with code 1" errors
           assets=($(echo "$files_changed" | xargs dirname | sed -nr "s|bitnami/([^/]*).*|\1|p" | sort | uniq || true))
 

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -35,11 +35,11 @@ jobs:
         name: Get modified containers
         env:
           DIFF_URL: "${{github.event.pull_request.diff_url}}"
-          TEMP_DIR: "${{runner.temp}}"
+          TEMP_FILE: "${{runner.temp}}/pr-${{github.event.number}}.diff"
         run: |
           # This request doesn't consume API calls.
-          curl -Lkso $TEMP_DIR/PR.diff $DIFF_URL
-          files_changed="$(sed -nr 's/[\-\+]{3} [ab]\/(.*)/\1/p' $TEMP_DIR/PR.diff | sort | uniq)"
+          curl -Lkso $TEMP_FILE $DIFF_URL
+          files_changed="$(sed -nr 's/[\-\+]{3} [ab]\/(.*)/\1/p' $TEMP_FILE | sort | uniq)"
           # Adding || true to avoid "Process exited with code 1" errors
           flavors=($(echo "$files_changed" | xargs dirname | grep -o "^bitnami/[^/]*/[^/]*/[^/]*" | sort | uniq || true))
           assets=($(echo "$files_changed" | xargs dirname | sed -nr "s|bitnami/([^/]*)/.*|\1|p" | sort | uniq || true))

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -33,12 +33,13 @@ jobs:
     steps:
       - id: get-containers
         name: Get modified containers
+        env:
+          DIFF_URL: "${{github.event.pull_request.diff_url}}"
+          TEMP_DIR: "${{runner.temp}}"
         run: |
-          # Using the Github API to detect the files changed as git merge-base stops working when the branch is behind
-          # and jitterbit/get-changed-files does not support pull_request_target
-          URL="https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files"
-          files_changed_data=$(curl -s --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' -X GET -G "$URL")
-          files_changed="$(echo $files_changed_data | jq -r '.[] | .filename')"
+          # This request doesn't consume API calls.
+          curl -Lkso $TEMP_DIR/PR.diff $DIFF_URL
+          files_changed="$(sed -nr 's/[\-\+]{3} [ab]\/(.*)/\1/p' $TEMP_DIR/PR.diff | sort | uniq)"
           # Adding || true to avoid "Process exited with code 1" errors
           flavors=($(echo "$files_changed" | xargs dirname | grep -o "^bitnami/[^/]*/[^/]*/[^/]*" | sort | uniq || true))
           assets=($(echo "$files_changed" | xargs dirname | sed -nr "s|bitnami/([^/]*)/.*|\1|p" | sort | uniq || true))

--- a/.github/workflows/move-closed-issues.yml
+++ b/.github/workflows/move-closed-issues.yml
@@ -18,18 +18,12 @@ jobs:
       - name: Send to the Solved column
         id: send-solved
         uses: peter-evans/create-or-update-project-card@v2
+        # Send to solve only the issues and PRs created by users or the automated PRs with human review required
+        if: |
+          (github.event.issue != null && github.event.issue.user.login != 'bitnami-bot') ||
+          (github.event.issue == null && (github.event.pull_request.user.login != 'bitnami-bot' || contains(github.event.pull_request.labels.*.name, 'review-required')))
         with:
           project-name: Support
           column-name: 'Solved'
           token: "${{ secrets.BITNAMI_BOT_TOKEN }}"
           issue-number: ${{ github.event_name != 'issues' && github.event.number || github.event.issue.number }}
-      - name: Remove cards from automated PRs
-        if: |
-          (github.event.issue != null && github.event.issue.user.login == 'bitnami-bot') ||
-          (github.event.issue == null && github.event.pull_request.user.login == 'bitnami-bot')
-        uses: actions/github-script@v6
-        with:
-          script: |
-            github.rest.projects.deleteCard({
-              card_id: ${{ steps.send-solved.outputs.card-id }}
-            });

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -9,6 +9,9 @@ on:
     types:
       - reopened
       - opened
+permissions:
+  issues: write
+  pull-requests: write
 # Avoid concurrency over the same issue
 concurrency:
   group: card-movement-${{ github.event_name != 'issues' && github.event.number || github.event.issue.number }}
@@ -31,9 +34,12 @@ jobs:
         run: |
           author="${{ github.event.issue != null && github.event.issue.user.login || github.event.pull_request.user.login }}"
           number="${{ github.event_name != 'issues' && github.event.number || github.event.issue.number }}"
+          type="${{ github.event_name != 'issues' && 'pull_request' || 'issue' }}"
           echo "author=${author}" >> $GITHUB_OUTPUT
           echo "number=${number}" >> $GITHUB_OUTPUT
+          echo "type=${type}" >> $GITHUB_OUTPUT
       - name: Send to the board
+        if: ${{steps.get-issue.outputs.author != 'bitnami-bot' || steps.get-issue.outputs.type != 'pull_request'}}
         uses: peter-evans/create-or-update-project-card@v2
         with:
           project-name: Support
@@ -41,3 +47,18 @@ jobs:
           column-name: ${{ (contains(fromJson(env.BITNAMI_TEAM), steps.get-issue.outputs.author)) && 'From Bitnami' || 'Triage' }}
           token: "${{ secrets.BITNAMI_BOT_TOKEN }}"
           issue-number: ${{ steps.get-issue.outputs.number }}
+      # The project API is not efficient and requires several requests to create the project card. For that reason we decided to create
+      # a card for the automated PRs only when it is needed.
+      - name: From Bitnami labeling
+        if: ${{steps.get-issue.outputs.author == 'bitnami-bot' && steps.get-issue.outputs.type == 'pull_request'}}
+        uses: fmulero/labeler@1.0.5
+        with:
+          add-labels: 'automated, auto-merge'
+          remove-labels: on-hold, in-progress, triage, solved
+      - name: Verify labeling
+        if: ${{steps.get-issue.outputs.author == 'bitnami-bot' && steps.get-issue.outputs.type == 'pull_request'}}
+        uses: fmulero/labeler@1.0.5
+        with:
+          # Bitnami bot token is required to trigger CI workflows
+          repo-token: ${{ secrets.BITNAMI_BOT_TOKEN }}
+          add-labels: verify


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Modify workflows involved in automated PRs to reduce the number of requests to the GitHub API. With these changes we remove 10 API requests for each automated PR.

### Benefits

Reduce errors due to the API rate limit.

### Possible drawbacks

None identified
