### PR TITLE
[bitnami/containers] Use latest changes from labeler action

### DIFF
--- a/.github/workflows/assign-asset-label.yml
+++ b/.github/workflows/assign-asset-label.yml
@@ -43,6 +43,6 @@ jobs:
             }
       - name: Labeling
         if: ${{ steps.get-asset.outputs.result == 'ok' }}
-        uses: fmulero/labeler@main
+        uses: fmulero/labeler@1.1.0
         with:
           add-labels: "${{ steps.get-asset.outputs.name }}"

--- a/.github/workflows/assign-asset-label.yml
+++ b/.github/workflows/assign-asset-label.yml
@@ -43,6 +43,6 @@ jobs:
             }
       - name: Labeling
         if: ${{ steps.get-asset.outputs.result == 'ok' }}
-        uses: fmulero/labeler@1.0.5
+        uses: fmulero/labeler@main
         with:
           add-labels: "${{ steps.get-asset.outputs.name }}"

--- a/.github/workflows/moving-cards.yml
+++ b/.github/workflows/moving-cards.yml
@@ -57,43 +57,43 @@ jobs:
       - name: Triage labeling
         # Only if moved into triage
         if: ${{ github.event.project_card.column_id == env.TRIAGE_COLUMN_ID }}
-        uses: fmulero/labeler@main
+        uses: fmulero/labeler@1.1.0
         with:
           add-labels: triage
           remove-labels: on-hold, in-progress, solved
       - name: From Bitnami labeling
         if: ${{ github.event.project_card.column_id == env.BITNAMI_COLUMN_ID }}
-        uses: fmulero/labeler@main
+        uses: fmulero/labeler@1.1.0
         with:
           add-labels: ${{ (needs.get-issue.outputs.author == 'bitnami-bot' && needs.get-issue.outputs.type == 'pull_request') && 'automated, auto-merge' || 'bitnami' }}
           remove-labels: on-hold, in-progress, triage, solved
       - name: Verify labeling
         # Only if moved into bitnami column and the PR is ready for review
-        # Consecutive calls were fixed in fmulero/labeler@main, see https://github.com/fmulero/labeler/pull/2
+        # Consecutive calls were fixed in fmulero/labeler@1.1.0, see https://github.com/fmulero/labeler/pull/2
         if: |
           github.event.project_card.column_id == env.BITNAMI_COLUMN_ID &&
           needs.get-issue.outputs.type == 'pull_request' && needs.get-issue.outputs.draft == 'false'
-        uses: fmulero/labeler@main
+        uses: fmulero/labeler@1.1.0
         with:
           repo-token: ${{ secrets.BITNAMI_BOT_TOKEN }}
           add-labels: verify
       - name: Build Maintenance labeling
         if: ${{ github.event.project_card.column_id == env.BUILD_MAINTENANCE_COLUMN_ID }}
-        uses: fmulero/labeler@main
+        uses: fmulero/labeler@1.1.0
         with:
           add-labels: review-required
           remove-labels: auto-merge
       - name: On hold labeling
         # Only if moved into on hold
         if: ${{ github.event.project_card.column_id == env.ON_HOLD_COLUMN_ID  }}
-        uses: fmulero/labeler@main
+        uses: fmulero/labeler@1.1.0
         with:
           add-labels: on-hold
           remove-labels: triage, in-progress, solved
       - name: In progress labeling
         # Only if moved into In progress
         if: ${{ github.event.project_card.column_id == env.IN_PROGRESS_COLUMN_ID  }}
-        uses: fmulero/labeler@main
+        uses: fmulero/labeler@1.1.0
         with:
           add-labels: in-progress
           remove-labels: on-hold, triage, solved
@@ -102,7 +102,7 @@ jobs:
         if: |
           github.event.project_card.column_id == env.SOLVED_COLUMN_ID &&
           (needs.get-issue.outputs.author != 'bitnami-bot')
-        uses: fmulero/labeler@main
+        uses: fmulero/labeler@1.1.0
         with:
           add-labels: solved
           # Triage is not on the list to know how many issues/PRs are solved

--- a/.github/workflows/moving-cards.yml
+++ b/.github/workflows/moving-cards.yml
@@ -57,43 +57,43 @@ jobs:
       - name: Triage labeling
         # Only if moved into triage
         if: ${{ github.event.project_card.column_id == env.TRIAGE_COLUMN_ID }}
-        uses: fmulero/labeler@1.0.5
+        uses: fmulero/labeler@main
         with:
           add-labels: triage
           remove-labels: on-hold, in-progress, solved
       - name: From Bitnami labeling
         if: ${{ github.event.project_card.column_id == env.BITNAMI_COLUMN_ID }}
-        uses: fmulero/labeler@1.0.5
+        uses: fmulero/labeler@main
         with:
           add-labels: ${{ (needs.get-issue.outputs.author == 'bitnami-bot' && needs.get-issue.outputs.type == 'pull_request') && 'automated, auto-merge' || 'bitnami' }}
           remove-labels: on-hold, in-progress, triage, solved
       - name: Verify labeling
         # Only if moved into bitnami column and the PR is ready for review
-        # Consecutive calls were fixed in fmulero/labeler@1.0.5, see https://github.com/fmulero/labeler/pull/2
+        # Consecutive calls were fixed in fmulero/labeler@main, see https://github.com/fmulero/labeler/pull/2
         if: |
           github.event.project_card.column_id == env.BITNAMI_COLUMN_ID &&
           needs.get-issue.outputs.type == 'pull_request' && needs.get-issue.outputs.draft == 'false'
-        uses: fmulero/labeler@1.0.5
+        uses: fmulero/labeler@main
         with:
           repo-token: ${{ secrets.BITNAMI_BOT_TOKEN }}
           add-labels: verify
       - name: Build Maintenance labeling
         if: ${{ github.event.project_card.column_id == env.BUILD_MAINTENANCE_COLUMN_ID }}
-        uses: fmulero/labeler@1.0.5
+        uses: fmulero/labeler@main
         with:
           add-labels: review-required
           remove-labels: auto-merge
       - name: On hold labeling
         # Only if moved into on hold
         if: ${{ github.event.project_card.column_id == env.ON_HOLD_COLUMN_ID  }}
-        uses: fmulero/labeler@1.0.5
+        uses: fmulero/labeler@main
         with:
           add-labels: on-hold
           remove-labels: triage, in-progress, solved
       - name: In progress labeling
         # Only if moved into In progress
         if: ${{ github.event.project_card.column_id == env.IN_PROGRESS_COLUMN_ID  }}
-        uses: fmulero/labeler@1.0.5
+        uses: fmulero/labeler@main
         with:
           add-labels: in-progress
           remove-labels: on-hold, triage, solved
@@ -102,7 +102,7 @@ jobs:
         if: |
           github.event.project_card.column_id == env.SOLVED_COLUMN_ID &&
           (needs.get-issue.outputs.author != 'bitnami-bot')
-        uses: fmulero/labeler@1.0.5
+        uses: fmulero/labeler@main
         with:
           add-labels: solved
           # Triage is not on the list to know how many issues/PRs are solved

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -51,13 +51,12 @@ jobs:
       # a card for the automated PRs only when it is needed.
       - name: From Bitnami labeling
         if: ${{steps.get-issue.outputs.author == 'bitnami-bot' && steps.get-issue.outputs.type == 'pull_request'}}
-        uses: fmulero/labeler@1.0.5
+        uses: fmulero/labeler@main
         with:
           add-labels: 'automated, auto-merge'
-          remove-labels: on-hold, in-progress, triage, solved
       - name: Verify labeling
         if: ${{steps.get-issue.outputs.author == 'bitnami-bot' && steps.get-issue.outputs.type == 'pull_request'}}
-        uses: fmulero/labeler@1.0.5
+        uses: fmulero/labeler@main
         with:
           # Bitnami bot token is required to trigger CI workflows
           repo-token: ${{ secrets.BITNAMI_BOT_TOKEN }}

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -51,12 +51,12 @@ jobs:
       # a card for the automated PRs only when it is needed.
       - name: From Bitnami labeling
         if: ${{steps.get-issue.outputs.author == 'bitnami-bot' && steps.get-issue.outputs.type == 'pull_request'}}
-        uses: fmulero/labeler@main
+        uses: fmulero/labeler@1.1.0
         with:
           add-labels: 'automated, auto-merge'
       - name: Verify labeling
         if: ${{steps.get-issue.outputs.author == 'bitnami-bot' && steps.get-issue.outputs.type == 'pull_request'}}
-        uses: fmulero/labeler@main
+        uses: fmulero/labeler@1.1.0
         with:
           # Bitnami bot token is required to trigger CI workflows
           repo-token: ${{ secrets.BITNAMI_BOT_TOKEN }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Take advantage of the latest changes in the labeler action. We are mainly interested on [this change](https://github.com/fmulero/labeler/pull/3).
Remove an unnecessary `remove-labels` parameter in labeler action during triage.

### Benefits

With those changes, the action will fail clearly if API rate limit is reached and the user can retry the actions failed.
Removing the `remove-labels` parameter from the labeler action in the triage workflow, we remove one unnecessary GitHub API request.

### Possible drawbacks

None identified.

