### PR TITLE
[bitnami/containers] Prevent card self assignment

### DIFF
--- a/.github/workflows/moving-cards.yml
+++ b/.github/workflows/moving-cards.yml
@@ -110,7 +110,6 @@ jobs:
     needs:
       - get-issue
     # The job shouldn't run for solved cards
-    if: ${{ github.event.project_card.column_id != env.SOLVED_COLUMN_ID }}
     steps:
       - name: Repo checkout
         uses: actions/checkout@v3
@@ -122,7 +121,7 @@ jobs:
           path: .github/workflows/
       - name: Assign to a person to work on it
         # Assign when there is nobody assigned or the card is new
-        if: ${{ needs.get-issue.outputs.assignees == '[]' || github.event.action == 'created' }}
+        if: ${{ github.event.project_card.column_id != env.SOLVED_COLUMN_ID && (needs.get-issue.outputs.assignees == '[]' || github.event.action == 'created') }}
         uses: pozil/auto-assign-issue@v1.11.0
         with:
           numOfAssignee: 1

--- a/.github/workflows/moving-cards.yml
+++ b/.github/workflows/moving-cards.yml
@@ -5,12 +5,9 @@ on:
     types:
       - created
       - moved
-
 permissions:
-  repository-projects: read
   issues: write
   pull-requests: write
-
 jobs:
   get-issue:
     runs-on: ubuntu-latest
@@ -112,9 +109,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - get-issue
-    # The job shouldn't run for solved cards or new PRs created by bitnami-bot
-    if: |
-      (github.event.action != 'created' || needs.get-issue.outputs.type != 'pull_request' || needs.get-issue.outputs.author != 'bitnami-bot')
+    # The job shouldn't run for solved cards
+    if: ${{ github.event.project_card.column_id != env.SOLVED_COLUMN_ID }}
     steps:
       - name: Repo checkout
         uses: actions/checkout@v3
@@ -126,21 +122,23 @@ jobs:
           path: .github/workflows/
       - name: Assign to a person to work on it
         # Assign when there is nobody assigned or the card is new
-        if: ${{ github.event.project_card.column_id != env.SOLVED_COLUMN_ID && (needs.get-issue.outputs.assignees == '[]' || github.event.action == 'created') }}
-        uses: pozil/auto-assign-issue@v1.9.0
+        if: ${{ needs.get-issue.outputs.assignees == '[]' || github.event.action == 'created' }}
+        uses: pozil/auto-assign-issue@v1.11.0
         with:
           numOfAssignee: 1
           teams: ${{ github.event.project_card.column_id == env.BITNAMI_COLUMN_ID && env.SUPPORT_TEAM_NAME || (github.event.project_card.column_id == env.BUILD_MAINTENANCE_COLUMN_ID && env.BUILD_MAINTAINERS_TEAM_NAME || env.TRIAGE_TEAM_NAME) }}
           repo-token: ${{ secrets.BITNAMI_BOT_TOKEN }}
+          allowSelfAssign: false
       - name: Reassign when moved into 'In progress' from 'Triage'
         # Reassigned when moved into In progress FROM Triage
         if: |
           github.event.action == 'moved' && needs.get-issue.outputs.assignees != '[]' &&
           github.event.project_card.column_id == env.IN_PROGRESS_COLUMN_ID &&
           github.event.changes.column_id.from == env.TRIAGE_COLUMN_ID
-        uses: pozil/auto-assign-issue@v1.9.0
+        uses: pozil/auto-assign-issue@v1.11.0
         with:
           numOfAssignee: 1
           removePreviousAssignees: true
           teams: ${{ env.SUPPORT_TEAM_NAME }}
           repo-token: ${{ secrets.BITNAMI_BOT_TOKEN }}
+          allowSelfAssign: false


### PR DESCRIPTION
### Description of the change

* Upgrade [auto-assign-issue](https://github.com/pozil/auto-assign-issue) action dependency.
* Set flag `allowSelfAssign=false`.
* Remove condition to avoid PRs created by bitnami-bot

### Benefits

* PRs 'From Bitnami' shouldn't be assigned to the author.
* PRs in build-maintenance will be automatically assigned

### Possible drawbacks

None identified

### Additional information

Same PR in bitnami/charts https://github.com/bitnami/charts/pull/15770

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
