### PR TITLE
[bitnami/redmine] Add VIB tests

### DIFF
--- a/.vib/redmine/goss/goss.yaml
+++ b/.vib/redmine/goss/goss.yaml
@@ -1,0 +1,12 @@
+gossfile:
+  # Goss tests exclusive to the current container
+  ../../redmine/goss/redmine.yaml: {}
+  # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-binaries.yaml: {}
+  ../../common/goss/templates/check-broken-symlinks.yaml: {}
+  ../../common/goss/templates/check-ca-certs.yaml: {}
+  ../../common/goss/templates/check-directories.yaml: {}
+  ../../common/goss/templates/check-files.yaml: {}
+  ../../common/goss/templates/check-linked-libraries.yaml: {}
+  ../../common/goss/templates/check-sed-in-place.yaml: {}
+  ../../common/goss/templates/check-spdx.yaml: {}

--- a/.vib/redmine/goss/redmine.yaml
+++ b/.vib/redmine/goss/redmine.yaml
@@ -5,10 +5,6 @@ user:
   redmine:
     exists: true
 command:
-  # Redmine does not include a binary or file to obtain the version from
-  check-app-version:
-    exec: cat /opt/bitnami/redmine/.spdx-redmine.json | grep -q redmine-$APP_VERSION
-    exit-status: 0
   check-configured-databases:
     # Strips config file of comments and looks for adapters
     exec: yq --no-colors '... comments=""' /opt/bitnami/redmine/config/database.yml

--- a/.vib/redmine/goss/redmine.yaml
+++ b/.vib/redmine/goss/redmine.yaml
@@ -1,0 +1,18 @@
+group:
+  redmine:
+    exists: true
+user:
+  redmine:
+    exists: true
+command:
+  # Redmine does not include a binary or file to obtain the version from
+  check-app-version:
+    exec: cat /opt/bitnami/redmine/.spdx-redmine.json | grep -q redmine-$APP_VERSION
+    exit-status: 0
+  check-configured-databases:
+    # Strips config file of comments and looks for adapters
+    exec: yq --no-colors '... comments=""' /opt/bitnami/redmine/config/database.yml
+    exit-status: 0
+    stdout:
+      - /adapter.*mysql/
+      - /adapter.*postgresql/

--- a/.vib/redmine/goss/vars.yaml
+++ b/.vib/redmine/goss/vars.yaml
@@ -1,0 +1,24 @@
+binaries:
+  - gosu
+  - mysql
+  - psql
+  - ruby
+  - yq
+directories:
+  - mode: "0775"
+    paths:
+      - /bitnami/redmine
+      - /opt/bitnami/redmine
+      - /opt/bitnami/redmine/files
+      - /opt/bitnami/redmine/plugins
+      - /opt/bitnami/redmine/public/plugin_assets
+      - /opt/bitnami/redmine/log
+      - /opt/bitnami/redmine/tmp
+      - /opt/bitnami/redmine/config
+      - /opt/bitnami/redmine/db
+      - /opt/bitnami/redmine/.bundle
+files:
+  - mode: "0664"
+    paths:
+      - /opt/bitnami/redmine/config/configuration.yml
+root_dir: /opt/bitnami

--- a/.vib/redmine/vib-publish.json
+++ b/.vib/redmine/vib-publish.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{VIB_ENV_CONTAINER_URL}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyJ0YWlsIiwgIi1mIiwgIi9kZXYvbnVsbCJd"
   },
   "phases": {
     "package": {
@@ -63,9 +64,24 @@
               "url": "{VIB_ENV_PACKAGES_JSON_URL}",
               "path": "/",
               "authn": {
-                  "header": "Authorization",
-                  "token": "Bearer {VIB_ENV_GITHUB_TOKEN}"
-                }
+                "header": "Authorization",
+                "token": "Bearer {VIB_ENV_GITHUB_TOKEN}"
+              }
+            }
+          }
+        },
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "redmine/goss/goss.yaml",
+            "vars_file": "redmine/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-redmine"
+              }
             }
           }
         }

--- a/.vib/redmine/vib-verify.json
+++ b/.vib/redmine/vib-verify.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyJ0YWlsIiwgIi1mIiwgIi9kZXYvbnVsbCJd"
   },
   "phases": {
     "package": {
@@ -45,6 +46,21 @@
             "package_type": [
               "OS"
             ]
+          }
+        },
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "redmine/goss/goss.yaml",
+            "vars_file": "redmine/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-redmine"
+              }
+            }
           }
         }
       ]

--- a/bitnami/redmine/5/debian-11/docker-compose.yml
+++ b/bitnami/redmine/5/debian-11/docker-compose.yml
@@ -1,6 +1,5 @@
 version: '2'
 services:
-  # [TEST]
   mariadb:
     image: docker.io/bitnami/mariadb:10.6
     volumes:

--- a/bitnami/redmine/5/debian-11/docker-compose.yml
+++ b/bitnami/redmine/5/debian-11/docker-compose.yml
@@ -1,5 +1,6 @@
 version: '2'
 services:
+  # [TEST]
   mariadb:
     image: docker.io/bitnami/mariadb:10.6
     volumes:


### PR DESCRIPTION
Signed-off-by: FraPazGal <fdepaz@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

The main objective of this PR is to publish our Bitnami Redmine container using VMware Image Builder. In order to do that, several changes are included:

- Increasing the existing test coverage of the asset by adding Goss tests.
- Update verify and publish VIB pipeline's definitions.

### Benefits

- Ensuring higher quality of the container catalog.
- Increased pool of assets completely handled by VMware Image Builder.

### Possible drawbacks

Automated tests could introduce additional flakiness to the CI/CD. 

### Applicable issues

NA

Tested in:
- Recent action run: https://github.com/bitnami/containers/actions/runs/4553959570