### PR TITLE
[bitnami/java] postunpack.sh should be copying the contents of JAVA_EXTRA_SECURITY_DIR, not the directory itself

### DIFF
--- a/bitnami/cassandra/4.0/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/cassandra/4.0/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/cassandra/4.0/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/cassandra/4.0/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/cassandra/4.1/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/cassandra/4.1/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/cassandra/4.1/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/cassandra/4.1/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/ejbca/7/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/ejbca/7/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/ejbca/7/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/ejbca/7/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/elasticsearch/7/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/elasticsearch/7/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/elasticsearch/7/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/elasticsearch/7/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/elasticsearch/8/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/elasticsearch/8/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/elasticsearch/8/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/elasticsearch/8/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/flink/1/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/flink/1/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/flink/1/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/flink/1/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/jasperreports/8/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/jasperreports/8/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/jasperreports/8/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/jasperreports/8/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/java/1.8/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/java/1.8/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/java/1.8/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/java/1.8/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/java/11/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/java/11/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/java/11/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/java/11/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/java/17/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/java/17/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/java/17/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/java/17/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/jenkins-agent/0/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/jenkins-agent/0/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/jenkins-agent/0/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/jenkins-agent/0/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/jenkins/2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/jenkins/2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/jenkins/2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/jenkins/2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/kafka/3.2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/kafka/3.2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/kafka/3.2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/kafka/3.2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/kafka/3.3/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/kafka/3.3/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/kafka/3.3/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/kafka/3.3/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/kafka/3.4/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/kafka/3.4/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/kafka/3.4/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/kafka/3.4/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/keycloak/20/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/keycloak/20/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/keycloak/20/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/keycloak/20/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/ksql/6.1/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/ksql/6.1/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/ksql/6.1/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/ksql/6.1/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/ksql/6.2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/ksql/6.2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/ksql/6.2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/ksql/6.2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/ksql/7.0/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/ksql/7.0/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/ksql/7.0/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/ksql/7.0/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/ksql/7.1/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/ksql/7.1/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/ksql/7.1/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/ksql/7.1/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/ksql/7.2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/ksql/7.2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/ksql/7.2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/ksql/7.2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/ksql/7.3/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/ksql/7.3/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/ksql/7.3/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/ksql/7.3/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/logstash/7/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/logstash/7/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/logstash/7/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/logstash/7/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/logstash/8/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/logstash/8/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/logstash/8/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/logstash/8/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/neo4j/4/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/neo4j/4/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/neo4j/4/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/neo4j/4/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/neo4j/5/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/neo4j/5/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/neo4j/5/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/neo4j/5/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/reportserver/4/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/reportserver/4/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/reportserver/4/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/reportserver/4/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/schema-registry/6.1/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/schema-registry/6.1/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/schema-registry/6.1/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/schema-registry/6.1/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/schema-registry/6.2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/schema-registry/6.2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/schema-registry/6.2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/schema-registry/6.2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/schema-registry/7.0/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/schema-registry/7.0/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/schema-registry/7.0/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/schema-registry/7.0/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/schema-registry/7.1/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/schema-registry/7.1/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/schema-registry/7.1/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/schema-registry/7.1/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/schema-registry/7.2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/schema-registry/7.2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/schema-registry/7.2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/schema-registry/7.2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/schema-registry/7.3/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/schema-registry/7.3/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/schema-registry/7.3/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/schema-registry/7.3/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/solr/8/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/solr/8/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/solr/8/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/solr/8/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/solr/9/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/solr/9/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/solr/9/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/solr/9/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/sonarqube/8/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/sonarqube/8/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/sonarqube/8/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/sonarqube/8/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/sonarqube/9/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/sonarqube/9/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/sonarqube/9/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/sonarqube/9/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/spark/3.2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/spark/3.2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/spark/3.2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/spark/3.2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/spark/3.3/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/spark/3.3/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/spark/3.3/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/spark/3.3/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/spring-cloud-dataflow-composed-task-runner/2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/spring-cloud-dataflow-composed-task-runner/2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/spring-cloud-dataflow-composed-task-runner/2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/spring-cloud-dataflow-composed-task-runner/2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/spring-cloud-dataflow/2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/spring-cloud-dataflow/2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/spring-cloud-dataflow/2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/spring-cloud-dataflow/2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/spring-cloud-skipper/2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/spring-cloud-skipper/2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/spring-cloud-skipper/2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/spring-cloud-skipper/2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/tensorflow-serving/2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/tensorflow-serving/2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/tensorflow-serving/2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/tensorflow-serving/2/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/tomcat/10.1/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/tomcat/10.1/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/tomcat/10.1/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/tomcat/10.1/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/tomcat/8.5/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/tomcat/8.5/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/tomcat/8.5/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/tomcat/8.5/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/tomcat/9.0/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/tomcat/9.0/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/tomcat/9.0/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/tomcat/9.0/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/wavefront-proxy/11/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/wavefront-proxy/11/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/wavefront-proxy/11/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/wavefront-proxy/11/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/wavefront-proxy/12/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/wavefront-proxy/12/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/wavefront-proxy/12/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/wavefront-proxy/12/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/wildfly/26/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/wildfly/26/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/wildfly/26/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/wildfly/26/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/wildfly/27/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/wildfly/27/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
+    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
 fi

--- a/bitnami/wildfly/27/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
+++ b/bitnami/wildfly/27/debian-11/rootfs/opt/bitnami/scripts/java/postunpack.sh
@@ -20,5 +20,5 @@ set -o pipefail
 
 if [[ -n "${JAVA_EXTRA_SECURITY_DIR:-}" ]] && ! is_dir_empty "$JAVA_EXTRA_SECURITY_DIR"; then
     info "Adding custom CAs to the Java security folder"
-    cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
+    cp -Lr "${JAVA_EXTRA_SECURITY_DIR}/." /opt/bitnami/java/lib/security
 fi


### PR DESCRIPTION
`java/postunpack.sh` should be coping just the contents of JAVA_EXTRA_SECURITY_DIR to `/opt/bitnami/java/lib/security` directory.

Instead, `java/postunpack.sh` copies the directory pointed to by JAVA_EXTRA_SECURITY_DIR as a subdir of `/opt/bitnami/java/lib/security` directory.

For example, using the default `JAVA_EXTRA_SECURITY_DIR` value "/bitnami/java/extra-security", create the file `rootfs/bitnami/java/extra-security/cacerts`, and build the image.  Rather than `/opt/bitnami/java/lib/security/cacerts` being replaced with the new file, a new subdir `/opt/bitnami/java/lib/security/extra-security` directory is created, with the new `cacerts` file under there.

### Description of the change

Change the relevant `cp` commands in all `java/postunpack.sh` in all image builders, from
```
   cp -Lr "$JAVA_EXTRA_SECURITY_DIR" /opt/bitnami/java/lib/security
```
to this, by added a `/.` to the end of the source argument:
```
   cp -Lr "$JAVA_EXTRA_SECURITY_DIR/." /opt/bitnami/java/lib/security
```

### Benefits

Functionality of this mechanism, as described in `bitname/java/README.md`, will work.

### Possible drawbacks

If somebody, somehow is successfully using this mechanism as it exists now, then this change will probably break them.

Like instead of pointing `JAVA_EXTRA_SECURITY_DIR` to a directory, they point it directly to a file, like say:
```
JAVA_EXTRA_SECURITY_DIR=bitnami/java/cacerts
```
This would currently work, primarily because there is no test if JAVA_EXTRA_SECURITY_DIR is actually a dir, just that it exists and is non-empty.  If the file exists, other test is that it's not empty, and `is_dir_empty()` from `scripts/libfs.sh`, returns false if passed a file.  From where this is called in postunpack.sh, a false response causes the cp command to be run.

If this PR is merged, then this change will break that, as "file/." still exists, but `is_dir_empty()` passed "somefile/."` returns true, and thus the file will no longer be copied.

With this PR though, this mechanism will match the documentation and the intended use case it describes.

### Applicable issues

- fixes #28666

### Additional information

🤔 