### PR TITLE
[bitnami/redis-cluster] fix nodes.conf not found

### DIFF
--- a/bitnami/redis-cluster/6.2/debian-11/rootfs/opt/bitnami/scripts/librediscluster.sh
+++ b/bitnami/redis-cluster/6.2/debian-11/rootfs/opt/bitnami/scripts/librediscluster.sh
@@ -204,7 +204,7 @@ redis_cluster_update_ips() {
     read -ra nodes <<< "$(tr ',;' ' ' <<< "${REDIS_NODES}")"
     declare -A host_2_ip_array # Array to map hosts and IPs
     # Update the IPs when a number of nodes > quorum change their IPs
-    if [[ ! -f "${REDIS_DATA_DIR}/nodes.sh" ]]; then
+    if [[ ! -f "${REDIS_DATA_DIR}/nodes.sh" || ! -f "${REDIS_DATA_DIR}/nodes.conf" ]]; then
         # It is the first initialization so store the nodes
         for node in "${nodes[@]}"; do
             read -r -a host_and_port <<< "$(to_host_and_port "$node")"

--- a/bitnami/redis-cluster/7.0/debian-11/rootfs/opt/bitnami/scripts/librediscluster.sh
+++ b/bitnami/redis-cluster/7.0/debian-11/rootfs/opt/bitnami/scripts/librediscluster.sh
@@ -204,7 +204,7 @@ redis_cluster_update_ips() {
     read -ra nodes <<< "$(tr ',;' ' ' <<< "${REDIS_NODES}")"
     declare -A host_2_ip_array # Array to map hosts and IPs
     # Update the IPs when a number of nodes > quorum change their IPs
-    if [[ ! -f "${REDIS_DATA_DIR}/nodes.sh" ]]; then
+    if [[ ! -f "${REDIS_DATA_DIR}/nodes.sh" || ! -f "${REDIS_DATA_DIR}/nodes.conf" ]]; then
         # It is the first initialization so store the nodes
         for node in "${nodes[@]}"; do
             read -r -a host_and_port <<< "$(to_host_and_port "$node")"


### PR DESCRIPTION

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

There is an issue in the redis-cluster docker image where the entrypoint script does not succeed when the container is restarted in a specific timing.

When the container is stopped after the entrypoint scripts are completed and before the redis server starts, nodes.sh is created but nodes.conf is missing. This prevents the entrypoint to successfully complete on next restart. The redis-cluster will fail to start forever when this happens. This change fixes this behavior by checking the existence of nodes.conf in the entrypoint scripts.

### Benefits

This change makes it more likely that the redis-cluster is successfully assembled when it is installed.

### Possible drawbacks

N/A 
