### PR TITLE
[bitnami/mongodb] Disabled voting rights for mongodb hidden nodes

### DIFF
--- a/bitnami/mongodb/5.0/debian-11/rootfs/opt/bitnami/scripts/libmongodb.sh
+++ b/bitnami/mongodb/5.0/debian-11/rootfs/opt/bitnami/scripts/libmongodb.sh
@@ -939,7 +939,7 @@ mongodb_is_hidden_node_pending() {
     debug "Adding hidden node ${node}:${port}"
     result=$(
         mongodb_execute_print_output "$MONGODB_INITIAL_PRIMARY_ROOT_USER" "$MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD" "admin" "$MONGODB_INITIAL_PRIMARY_HOST" "$MONGODB_INITIAL_PRIMARY_PORT_NUMBER" <<EOF
-rs.add({host: '$node:$port', hidden: true, priority: 0})
+rs.add({host: '$node:$port', hidden: true, priority: 0, votes: 0})
 EOF
     )
     # Error code 103 is considered OK.

--- a/bitnami/mongodb/6.0/debian-11/rootfs/opt/bitnami/scripts/libmongodb.sh
+++ b/bitnami/mongodb/6.0/debian-11/rootfs/opt/bitnami/scripts/libmongodb.sh
@@ -939,7 +939,7 @@ mongodb_is_hidden_node_pending() {
     debug "Adding hidden node ${node}:${port}"
     result=$(
         mongodb_execute_print_output "$MONGODB_INITIAL_PRIMARY_ROOT_USER" "$MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD" "admin" "$MONGODB_INITIAL_PRIMARY_HOST" "$MONGODB_INITIAL_PRIMARY_PORT_NUMBER" <<EOF
-rs.add({host: '$node:$port', hidden: true, priority: 0})
+rs.add({host: '$node:$port', hidden: true, priority: 0, votes: 0})
 EOF
     )
     # Error code 103 is considered OK.


### PR DESCRIPTION
### Description of the change

This PR disabled voting rights for hidden nodes 

### Benefits

Active majority is maintained with active replicaset

### Possible drawbacks

NA

### Applicable issues



### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
