### PR TITLE
[bitnami/rails] ARM not supported

### DIFF
--- a/.vib/rails/vib-publish.json
+++ b/.vib/rails/vib-publish.json
@@ -19,8 +19,7 @@
               }
             },
             "architectures": [
-              "linux/amd64",
-              "linux/arm64"
+              "linux/amd64"
             ]
           }
         },
@@ -74,19 +73,7 @@
             "scan_type": "BASE_OS",
             "osm": {
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
-              "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
-              "architecture_overrides": [
-                {
-                  "architecture": "linux/amd64",
-                  "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
-                  "additional_packages_file": "osspi-packages-amd64.json"
-                },
-                {
-                  "architecture": "linux/arm64",
-                  "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container-arm64",
-                  "additional_packages_file": "osspi-packages-arm64.json"
-                }
-              ]
+              "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container"
             },
             "resources": {
               "url": "{VIB_ENV_PACKAGES_JSON_URL}",


### PR DESCRIPTION
### Description of the change

Remove ARM support.

### Benefits

Prevent pipeline failures. ARM is not supported in our rails container at the moment.

### Possible drawbacks

None.

### Additional information

There is an internal task to include ARM support.
