### PR TITLE
[bitnami/kafka] Fix conversion of PEM cert chain to multi-line string

### DIFF
--- a/bitnami/kafka/3.2/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/bitnami/kafka/3.2/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -557,7 +557,7 @@ kafka_configure_ssl() {
     ! is_empty_value "$KAFKA_CERTIFICATE_PASSWORD" && configure_both ssl.key.password "$KAFKA_CERTIFICATE_PASSWORD"
     if [[ "$KAFKA_TLS_TYPE" = "PEM" ]]; then
         file_to_multiline_property() {
-            awk 'NR > 1{print line" \\"}{line=$0;}END{print $0" "}' <"${1:?missing file}"
+            awk 'NR > 1{print line"\\n\\"}{line=$0;}END{print $0" "}' <"${1:?missing file}"
         }
         remove_previous_cert_value() {
             local key="${1:?missing key}"

--- a/bitnami/kafka/3.3/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/bitnami/kafka/3.3/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -557,7 +557,7 @@ kafka_configure_ssl() {
     ! is_empty_value "$KAFKA_CERTIFICATE_PASSWORD" && configure_both ssl.key.password "$KAFKA_CERTIFICATE_PASSWORD"
     if [[ "$KAFKA_TLS_TYPE" = "PEM" ]]; then
         file_to_multiline_property() {
-            awk 'NR > 1{print line" \\"}{line=$0;}END{print $0" "}' <"${1:?missing file}"
+            awk 'NR > 1{print line"\\n\\"}{line=$0;}END{print $0" "}' <"${1:?missing file}"
         }
         remove_previous_cert_value() {
             local key="${1:?missing key}"

--- a/bitnami/kafka/3.4/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/bitnami/kafka/3.4/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -557,7 +557,7 @@ kafka_configure_ssl() {
     ! is_empty_value "$KAFKA_CERTIFICATE_PASSWORD" && configure_both ssl.key.password "$KAFKA_CERTIFICATE_PASSWORD"
     if [[ "$KAFKA_TLS_TYPE" = "PEM" ]]; then
         file_to_multiline_property() {
-            awk 'NR > 1{print line" \\"}{line=$0;}END{print $0" "}' <"${1:?missing file}"
+            awk 'NR > 1{print line"\\n\\"}{line=$0;}END{print $0" "}' <"${1:?missing file}"
         }
         remove_previous_cert_value() {
             local key="${1:?missing key}"


### PR DESCRIPTION
### Description of the change

The libkafka.sh script's kafka_configure_ssl() function contains functionality to convert a file to a multi-line string. This is used to inline PEM files into the kafka server.properties.

The current transformation appends a ` \` to each line of the input file. However, the regular expression used by kafka's DefaultSslEngineFactory$PemParser.pemEntries() method when starting up the broker only matches the *last* certificate in a PEM file that has been inlined this way. This leads to the broker omitting any intermediary certificates when configured with e.g. a server certificate chain as described in https://github.com/bitnami/charts/issues/14600.

### Benefits

The transformation function has been changed to append `\n\` to each line of the file. This results in the regular expression properly matching each of the certificates contained in the certificate chain. This type of multi-line encoding is also the one used (and verified) in kafka's DefaultSslEngineFactoryTest.

### Applicable issues

Together with https://github.com/bitnami/charts/pull/15941 this fixes https://github.com/bitnami/charts/issues/14600.
