### PR TITLE
[bitnami/containers] Use tag v0 for vmware-image-build-acion

### DIFF
--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -63,7 +63,7 @@ jobs:
           echo "::add-mask::${marketplace_passwd}"
           echo "marketplace_user=${marketplace_user}" >> $GITHUB_OUTPUT
           echo "marketplace_passwd=${marketplace_passwd}" >> $GITHUB_OUTPUT
-      - uses: vmware-labs/vmware-image-builder-action@main
+      - uses: vmware-labs/vmware-image-builder-action@v0
         name: 'Publish ${{ matrix.container.name }}: ${{ matrix.container.tag }}'
         with:
           pipeline: ${{ matrix.container.dsl_path }}/vib-publish.json

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -100,7 +100,7 @@ jobs:
             # Container folder doesn't exists we are assuming a deprecation
             echo "result=skip" >> $GITHUB_OUTPUT
           fi
-      - uses: vmware-labs/vmware-image-builder-action@main
+      - uses: vmware-labs/vmware-image-builder-action@v0
         name: Verify
         if: ${{ steps.get-container-metadata.outputs.result == 'ok' }}
         with:


### PR DESCRIPTION
### Description of the change

Use `v0` tag for vmware-image-build-acion

### Benefits

We can keep using the latest released version (instead of main branch) and revert if needed to a fixed version easily.

### Possible drawbacks

None identified.

### Applicable issues

Currently, some of the [automated PRs are failing](https://github.com/bitnami/containers/pulls/bitnami-bot) due to recent changes in main branch.