### PR TITLE
[bitnami/containers] Set bossd release ID

### DIFF
--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -82,3 +82,4 @@ jobs:
           VIB_ENV_REGISTRY_URL: "${{ secrets.PROD_MARKETPLACE_REGISTRY_URL }}"
           VIB_ENV_REGISTRY_USERNAME: "${{ steps.get-registry-credentials.outputs.marketplace_user }}"
           VIB_ENV_REGISTRY_PASSWORD: "${{ steps.get-registry-credentials.outputs.marketplace_passwd }}"
+          VIB_ENV_BOSSD_RELEASE_ID: "${{ secrets.BOSSD_RELEASE_ID }}"

--- a/.vib/acmesolver/vib-publish.json
+++ b/.vib/acmesolver/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/airflow-exporter/vib-publish.json
+++ b/.vib/airflow-exporter/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/airflow-scheduler/vib-publish.json
+++ b/.vib/airflow-scheduler/vib-publish.json
@@ -56,6 +56,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container"
             },

--- a/.vib/airflow-worker/vib-publish.json
+++ b/.vib/airflow-worker/vib-publish.json
@@ -56,6 +56,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container"
             },

--- a/.vib/airflow/vib-publish.json
+++ b/.vib/airflow/vib-publish.json
@@ -56,6 +56,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container"
             },

--- a/.vib/alertmanager/vib-publish.json
+++ b/.vib/alertmanager/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/apache-exporter/vib-publish.json
+++ b/.vib/apache-exporter/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/apache/vib-publish.json
+++ b/.vib/apache/vib-publish.json
@@ -73,6 +73,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/appsmith/vib-publish.json
+++ b/.vib/appsmith/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/argo-cd/vib-publish.json
+++ b/.vib/argo-cd/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/argo-workflow-cli/vib-publish.json
+++ b/.vib/argo-workflow-cli/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/argo-workflow-controller/vib-publish.json
+++ b/.vib/argo-workflow-controller/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/argo-workflow-exec/vib-publish.json
+++ b/.vib/argo-workflow-exec/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/aspnet-core/vib-publish.json
+++ b/.vib/aspnet-core/vib-publish.json
@@ -72,6 +72,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container"
             },

--- a/.vib/aws-cli/vib-publish.json
+++ b/.vib/aws-cli/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/azure-cli/vib-publish.json
+++ b/.vib/azure-cli/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/bitnami-shell/vib-publish.json
+++ b/.vib/bitnami-shell/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/blackbox-exporter/vib-publish.json
+++ b/.vib/blackbox-exporter/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/cainjector/vib-publish.json
+++ b/.vib/cainjector/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/cassandra-exporter/vib-publish.json
+++ b/.vib/cassandra-exporter/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/cassandra/vib-publish.json
+++ b/.vib/cassandra/vib-publish.json
@@ -72,6 +72,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container"
             },

--- a/.vib/cert-manager-webhook/vib-publish.json
+++ b/.vib/cert-manager-webhook/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/cert-manager/vib-publish.json
+++ b/.vib/cert-manager/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/chartmuseum/vib-publish.json
+++ b/.vib/chartmuseum/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/clickhouse/vib-publish.json
+++ b/.vib/clickhouse/vib-publish.json
@@ -56,6 +56,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container"
             },

--- a/.vib/cluster-autoscaler/vib-publish.json
+++ b/.vib/cluster-autoscaler/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/codeigniter/vib-publish.json
+++ b/.vib/codeigniter/vib-publish.json
@@ -73,6 +73,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/concourse/vib-publish.json
+++ b/.vib/concourse/vib-publish.json
@@ -56,6 +56,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container"
             },

--- a/.vib/configmap-reload/vib-publish.json
+++ b/.vib/configmap-reload/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/configurable-http-proxy/vib-publish.json
+++ b/.vib/configurable-http-proxy/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/consul-exporter/vib-publish.json
+++ b/.vib/consul-exporter/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/consul/vib-publish.json
+++ b/.vib/consul/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/contour-operator/vib-publish.json
+++ b/.vib/contour-operator/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/contour/vib-publish.json
+++ b/.vib/contour/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/cosign/vib-publish.json
+++ b/.vib/cosign/vib-publish.json
@@ -73,6 +73,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/couchdb/vib-publish.json
+++ b/.vib/couchdb/vib-publish.json
@@ -73,6 +73,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/dex/vib-publish.json
+++ b/.vib/dex/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/discourse/vib-publish.json
+++ b/.vib/discourse/vib-publish.json
@@ -56,6 +56,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container"
             },

--- a/.vib/dokuwiki/vib-publish.json
+++ b/.vib/dokuwiki/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/dotnet-sdk/vib-publish.json
+++ b/.vib/dotnet-sdk/vib-publish.json
@@ -72,6 +72,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container"
             },

--- a/.vib/dotnet/vib-publish.json
+++ b/.vib/dotnet/vib-publish.json
@@ -72,6 +72,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container"
             },

--- a/.vib/drupal-nginx/vib-publish.json
+++ b/.vib/drupal-nginx/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/drupal/vib-publish.json
+++ b/.vib/drupal/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/ejbca/vib-publish.json
+++ b/.vib/ejbca/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/elasticsearch-exporter/vib-publish.json
+++ b/.vib/elasticsearch-exporter/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/elasticsearch/vib-publish.json
+++ b/.vib/elasticsearch/vib-publish.json
@@ -73,6 +73,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/envoy/1.20/vib-publish.json
+++ b/.vib/envoy/1.20/vib-publish.json
@@ -56,6 +56,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container"
             },

--- a/.vib/envoy/vib-publish.json
+++ b/.vib/envoy/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/etcd/vib-publish.json
+++ b/.vib/etcd/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/express/vib-publish.json
+++ b/.vib/express/vib-publish.json
@@ -73,6 +73,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/external-dns/vib-publish.json
+++ b/.vib/external-dns/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/flink/vib-publish.json
+++ b/.vib/flink/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/fluent-bit/vib-publish.json
+++ b/.vib/fluent-bit/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/fluentd/vib-publish.json
+++ b/.vib/fluentd/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/fluxcd-helm-controller/vib-publish.json
+++ b/.vib/fluxcd-helm-controller/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/fluxcd-image-automation-controller/vib-publish.json
+++ b/.vib/fluxcd-image-automation-controller/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/fluxcd-image-reflector-controller/vib-publish.json
+++ b/.vib/fluxcd-image-reflector-controller/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/fluxcd-kustomize-controller/vib-publish.json
+++ b/.vib/fluxcd-kustomize-controller/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/fluxcd-notification-controller/vib-publish.json
+++ b/.vib/fluxcd-notification-controller/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/fluxcd-source-controller/vib-publish.json
+++ b/.vib/fluxcd-source-controller/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/geode/vib-publish.json
+++ b/.vib/geode/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/ghost/vib-publish.json
+++ b/.vib/ghost/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/git/vib-publish.json
+++ b/.vib/git/vib-publish.json
@@ -73,6 +73,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/gitea/vib-publish.json
+++ b/.vib/gitea/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/gitlab-runner-helper/vib-publish.json
+++ b/.vib/gitlab-runner-helper/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/gitlab-runner/vib-publish.json
+++ b/.vib/gitlab-runner/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/golang/vib-publish.json
+++ b/.vib/golang/vib-publish.json
@@ -73,6 +73,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/google-cloud-sdk/vib-publish.json
+++ b/.vib/google-cloud-sdk/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/gotrue/vib-publish.json
+++ b/.vib/gotrue/vib-publish.json
@@ -56,6 +56,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container"
             },

--- a/.vib/gradle/vib-publish.json
+++ b/.vib/gradle/vib-publish.json
@@ -73,6 +73,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/grafana-image-renderer/vib-publish.json
+++ b/.vib/grafana-image-renderer/vib-publish.json
@@ -56,6 +56,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container"
             },

--- a/.vib/grafana-loki/vib-publish.json
+++ b/.vib/grafana-loki/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/grafana-mimir/vib-publish.json
+++ b/.vib/grafana-mimir/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/grafana-operator/vib-publish.json
+++ b/.vib/grafana-operator/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/grafana-tempo-query/vib-publish.json
+++ b/.vib/grafana-tempo-query/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/grafana-tempo-vulture/vib-publish.json
+++ b/.vib/grafana-tempo-vulture/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/grafana-tempo/vib-publish.json
+++ b/.vib/grafana-tempo/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/grafana/vib-publish.json
+++ b/.vib/grafana/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/haproxy/vib-publish.json
+++ b/.vib/haproxy/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/harbor-adapter-trivy/vib-publish.json
+++ b/.vib/harbor-adapter-trivy/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/harbor-core/vib-publish.json
+++ b/.vib/harbor-core/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/harbor-exporter/vib-publish.json
+++ b/.vib/harbor-exporter/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/harbor-jobservice/vib-publish.json
+++ b/.vib/harbor-jobservice/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/harbor-notary-server/vib-publish.json
+++ b/.vib/harbor-notary-server/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/harbor-notary-signer/vib-publish.json
+++ b/.vib/harbor-notary-signer/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/harbor-portal/vib-publish.json
+++ b/.vib/harbor-portal/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/harbor-registry/vib-publish.json
+++ b/.vib/harbor-registry/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/harbor-registryctl/vib-publish.json
+++ b/.vib/harbor-registryctl/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/influxdb/vib-publish.json
+++ b/.vib/influxdb/vib-publish.json
@@ -72,6 +72,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container"
             },

--- a/.vib/jaeger/vib-publish.json
+++ b/.vib/jaeger/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/jasperreports/vib-publish.json
+++ b/.vib/jasperreports/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/java/vib-publish.json
+++ b/.vib/java/vib-publish.json
@@ -73,6 +73,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/jenkins-agent/vib-publish.json
+++ b/.vib/jenkins-agent/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/jenkins/vib-publish.json
+++ b/.vib/jenkins/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/jmx-exporter/vib-publish.json
+++ b/.vib/jmx-exporter/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/joomla/vib-publish.json
+++ b/.vib/joomla/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/jruby/vib-publish.json
+++ b/.vib/jruby/vib-publish.json
@@ -73,6 +73,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/jsonnet/vib-publish.json
+++ b/.vib/jsonnet/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/jupyter-base-notebook/vib-publish.json
+++ b/.vib/jupyter-base-notebook/vib-publish.json
@@ -56,6 +56,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container"
             },

--- a/.vib/jupyterhub/vib-publish.json
+++ b/.vib/jupyterhub/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/jwt-cli/vib-publish.json
+++ b/.vib/jwt-cli/vib-publish.json
@@ -56,6 +56,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container"
             },

--- a/.vib/kafka-exporter/vib-publish.json
+++ b/.vib/kafka-exporter/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/kafka/vib-publish.json
+++ b/.vib/kafka/vib-publish.json
@@ -73,6 +73,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/kapacitor/vib-publish.json
+++ b/.vib/kapacitor/vib-publish.json
@@ -56,6 +56,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container"
             },

--- a/.vib/keycloak-config-cli/vib-publish.json
+++ b/.vib/keycloak-config-cli/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/keycloak/vib-publish.json
+++ b/.vib/keycloak/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/kiam/vib-publish.json
+++ b/.vib/kiam/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/kibana/vib-publish.json
+++ b/.vib/kibana/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/kong-ingress-controller/vib-publish.json
+++ b/.vib/kong-ingress-controller/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/kong/vib-publish.json
+++ b/.vib/kong/vib-publish.json
@@ -56,6 +56,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container"
             },

--- a/.vib/ksql/vib-publish.json
+++ b/.vib/ksql/vib-publish.json
@@ -73,6 +73,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/kube-rbac-proxy/vib-publish.json
+++ b/.vib/kube-rbac-proxy/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/kube-state-metrics/vib-publish.json
+++ b/.vib/kube-state-metrics/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/kubeapps-apis/vib-publish.json
+++ b/.vib/kubeapps-apis/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/kubeapps-apprepository-controller/vib-publish.json
+++ b/.vib/kubeapps-apprepository-controller/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/kubeapps-asset-syncer/vib-publish.json
+++ b/.vib/kubeapps-asset-syncer/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/kubeapps-dashboard/vib-publish.json
+++ b/.vib/kubeapps-dashboard/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/kubeapps-kubeops/vib-publish.json
+++ b/.vib/kubeapps-kubeops/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/kubeapps-pinniped-proxy/vib-publish.json
+++ b/.vib/kubeapps-pinniped-proxy/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/kubectl/vib-publish.json
+++ b/.vib/kubectl/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/kubernetes-event-exporter/vib-publish.json
+++ b/.vib/kubernetes-event-exporter/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/laravel/vib-publish.json
+++ b/.vib/laravel/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/logstash/vib-publish.json
+++ b/.vib/logstash/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/magento/vib-publish.json
+++ b/.vib/magento/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/mariadb-galera/10.3/vib-publish.json
+++ b/.vib/mariadb-galera/10.3/vib-publish.json
@@ -72,6 +72,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container"
             },

--- a/.vib/mariadb-galera/10.4/vib-publish.json
+++ b/.vib/mariadb-galera/10.4/vib-publish.json
@@ -72,6 +72,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container"
             },

--- a/.vib/mariadb-galera/vib-publish.json
+++ b/.vib/mariadb-galera/vib-publish.json
@@ -73,6 +73,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/mariadb/10.3/vib-publish.json
+++ b/.vib/mariadb/10.3/vib-publish.json
@@ -72,6 +72,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container"
             },

--- a/.vib/mariadb/10.4/vib-publish.json
+++ b/.vib/mariadb/10.4/vib-publish.json
@@ -72,6 +72,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container"
             },

--- a/.vib/mariadb/vib-publish.json
+++ b/.vib/mariadb/vib-publish.json
@@ -73,6 +73,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/mastodon/vib-publish.json
+++ b/.vib/mastodon/vib-publish.json
@@ -53,6 +53,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container"
             },

--- a/.vib/matomo/vib-publish.json
+++ b/.vib/matomo/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/mediawiki/vib-publish.json
+++ b/.vib/mediawiki/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/memcached-exporter/vib-publish.json
+++ b/.vib/memcached-exporter/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/memcached/vib-publish.json
+++ b/.vib/memcached/vib-publish.json
@@ -73,6 +73,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/metallb-controller/vib-publish.json
+++ b/.vib/metallb-controller/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/metallb-speaker/vib-publish.json
+++ b/.vib/metallb-speaker/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/metrics-server/vib-publish.json
+++ b/.vib/metrics-server/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/minio-client/vib-publish.json
+++ b/.vib/minio-client/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/minio/vib-publish.json
+++ b/.vib/minio/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/mongodb-exporter/vib-publish.json
+++ b/.vib/mongodb-exporter/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/mongodb-sharded/vib-publish.json
+++ b/.vib/mongodb-sharded/vib-publish.json
@@ -72,6 +72,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container"
             },

--- a/.vib/mongodb/vib-publish.json
+++ b/.vib/mongodb/vib-publish.json
@@ -73,6 +73,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container"
             },

--- a/.vib/moodle/vib-publish.json
+++ b/.vib/moodle/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/multus-cni/vib-publish.json
+++ b/.vib/multus-cni/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/mxnet/vib-publish.json
+++ b/.vib/mxnet/vib-publish.json
@@ -56,6 +56,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container"
             },

--- a/.vib/mysql/vib-publish.json
+++ b/.vib/mysql/vib-publish.json
@@ -73,6 +73,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/mysqld-exporter/vib-publish.json
+++ b/.vib/mysqld-exporter/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/nats-exporter/vib-publish.json
+++ b/.vib/nats-exporter/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/nats/vib-publish.json
+++ b/.vib/nats/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/neo4j/vib-publish.json
+++ b/.vib/neo4j/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/nginx-exporter/vib-publish.json
+++ b/.vib/nginx-exporter/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/nginx-ingress-controller/vib-publish.json
+++ b/.vib/nginx-ingress-controller/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/nginx/vib-publish.json
+++ b/.vib/nginx/vib-publish.json
@@ -73,6 +73,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/node-exporter/vib-publish.json
+++ b/.vib/node-exporter/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/node/vib-publish.json
+++ b/.vib/node/vib-publish.json
@@ -73,6 +73,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/oauth2-proxy/vib-publish.json
+++ b/.vib/oauth2-proxy/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/odoo/13/vib-publish.json
+++ b/.vib/odoo/13/vib-publish.json
@@ -56,6 +56,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container"
             },

--- a/.vib/odoo/14/vib-publish.json
+++ b/.vib/odoo/14/vib-publish.json
@@ -56,6 +56,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container"
             },

--- a/.vib/odoo/vib-publish.json
+++ b/.vib/odoo/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/opencart/vib-publish.json
+++ b/.vib/opencart/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/openldap/vib-publish.json
+++ b/.vib/openldap/vib-publish.json
@@ -58,6 +58,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/openresty/vib-publish.json
+++ b/.vib/openresty/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/oras/vib-publish.json
+++ b/.vib/oras/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/osclass/vib-publish.json
+++ b/.vib/osclass/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/parse-dashboard/vib-publish.json
+++ b/.vib/parse-dashboard/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/parse/4/vib-publish.json
+++ b/.vib/parse/4/vib-publish.json
@@ -56,6 +56,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container"
             },

--- a/.vib/parse/vib-publish.json
+++ b/.vib/parse/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/percona-mysql/vib-publish.json
+++ b/.vib/percona-mysql/vib-publish.json
@@ -56,6 +56,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container"
             },

--- a/.vib/percona-xtrabackup/vib-publish.json
+++ b/.vib/percona-xtrabackup/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/pgbouncer/vib-publish.json
+++ b/.vib/pgbouncer/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/pgpool/vib-publish.json
+++ b/.vib/pgpool/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/php-fpm/vib-publish.json
+++ b/.vib/php-fpm/vib-publish.json
@@ -58,6 +58,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/phpbb/vib-publish.json
+++ b/.vib/phpbb/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/phpmyadmin/vib-publish.json
+++ b/.vib/phpmyadmin/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/pinniped/vib-publish.json
+++ b/.vib/pinniped/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/postgres-exporter/vib-publish.json
+++ b/.vib/postgres-exporter/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/postgresql-repmgr/vib-publish.json
+++ b/.vib/postgresql-repmgr/vib-publish.json
@@ -58,6 +58,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/postgresql/vib-publish.json
+++ b/.vib/postgresql/vib-publish.json
@@ -73,6 +73,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/postgrest/vib-publish.json
+++ b/.vib/postgrest/vib-publish.json
@@ -72,6 +72,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container"
             },

--- a/.vib/prestashop/vib-publish.json
+++ b/.vib/prestashop/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/prometheus-operator/vib-publish.json
+++ b/.vib/prometheus-operator/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/prometheus-rsocket-proxy/vib-publish.json
+++ b/.vib/prometheus-rsocket-proxy/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/prometheus/vib-publish.json
+++ b/.vib/prometheus/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/promtail/vib-publish.json
+++ b/.vib/promtail/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/pushgateway/vib-publish.json
+++ b/.vib/pushgateway/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/python/vib-publish.json
+++ b/.vib/python/vib-publish.json
@@ -73,6 +73,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/pytorch/vib-publish.json
+++ b/.vib/pytorch/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/rabbitmq-cluster-operator/vib-publish.json
+++ b/.vib/rabbitmq-cluster-operator/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/rabbitmq/3.9/vib-publish.json
+++ b/.vib/rabbitmq/3.9/vib-publish.json
@@ -56,6 +56,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container"
             },

--- a/.vib/rabbitmq/vib-publish.json
+++ b/.vib/rabbitmq/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/rails/vib-publish.json
+++ b/.vib/rails/vib-publish.json
@@ -72,6 +72,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container"
             },

--- a/.vib/rclone/vib-publish.json
+++ b/.vib/rclone/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/redis-cluster/vib-publish.json
+++ b/.vib/redis-cluster/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/redis-exporter/vib-publish.json
+++ b/.vib/redis-exporter/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/redis-sentinel/vib-publish.json
+++ b/.vib/redis-sentinel/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/redis/vib-publish.json
+++ b/.vib/redis/vib-publish.json
@@ -73,6 +73,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/redmine/vib-publish.json
+++ b/.vib/redmine/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container"
             },

--- a/.vib/reportserver/vib-publish.json
+++ b/.vib/reportserver/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/rmq-default-credential-updater/vib-publish.json
+++ b/.vib/rmq-default-credential-updater/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/rmq-messaging-topology-operator/vib-publish.json
+++ b/.vib/rmq-messaging-topology-operator/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/ruby/vib-publish.json
+++ b/.vib/ruby/vib-publish.json
@@ -73,6 +73,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/schema-registry/vib-publish.json
+++ b/.vib/schema-registry/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/sealed-secrets/vib-publish.json
+++ b/.vib/sealed-secrets/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/solr/vib-publish.json
+++ b/.vib/solr/vib-publish.json
@@ -58,6 +58,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/sonarqube/vib-publish.json
+++ b/.vib/sonarqube/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container"
             },

--- a/.vib/spark/vib-publish.json
+++ b/.vib/spark/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/spring-cloud-dataflow-composed-task-runner/vib-publish.json
+++ b/.vib/spring-cloud-dataflow-composed-task-runner/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/spring-cloud-dataflow-shell/vib-publish.json
+++ b/.vib/spring-cloud-dataflow-shell/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/spring-cloud-dataflow/vib-publish.json
+++ b/.vib/spring-cloud-dataflow/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/spring-cloud-skipper-shell/vib-publish.json
+++ b/.vib/spring-cloud-skipper-shell/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/spring-cloud-skipper/vib-publish.json
+++ b/.vib/spring-cloud-skipper/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/suitecrm/vib-publish.json
+++ b/.vib/suitecrm/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/supabase-postgres-meta/vib-publish.json
+++ b/.vib/supabase-postgres-meta/vib-publish.json
@@ -56,6 +56,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container"
             },

--- a/.vib/supabase-postgres/vib-publish.json
+++ b/.vib/supabase-postgres/vib-publish.json
@@ -56,6 +56,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container"
             },

--- a/.vib/supabase-realtime/vib-publish.json
+++ b/.vib/supabase-realtime/vib-publish.json
@@ -56,7 +56,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
-              "associated_bossd_release": "400400474",
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container"
             },

--- a/.vib/supabase-storage/vib-publish.json
+++ b/.vib/supabase-storage/vib-publish.json
@@ -56,6 +56,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container"
             },

--- a/.vib/supabase-studio/vib-publish.json
+++ b/.vib/supabase-studio/vib-publish.json
@@ -56,6 +56,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container"
             },

--- a/.vib/symfony/vib-publish.json
+++ b/.vib/symfony/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/telegraf/vib-publish.json
+++ b/.vib/telegraf/vib-publish.json
@@ -73,6 +73,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/tensorflow-resnet/vib-publish.json
+++ b/.vib/tensorflow-resnet/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/tensorflow-serving/vib-publish.json
+++ b/.vib/tensorflow-serving/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/thanos/vib-publish.json
+++ b/.vib/thanos/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/tomcat/vib-publish.json
+++ b/.vib/tomcat/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/trivy/vib-publish.json
+++ b/.vib/trivy/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/wavefront-hpa-adapter/vib-publish.json
+++ b/.vib/wavefront-hpa-adapter/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/wavefront-kubernetes-collector/vib-publish.json
+++ b/.vib/wavefront-kubernetes-collector/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/wavefront-prometheus-storage-adapter/vib-publish.json
+++ b/.vib/wavefront-prometheus-storage-adapter/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/wavefront-proxy/vib-publish.json
+++ b/.vib/wavefront-proxy/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/whereabouts/vib-publish.json
+++ b/.vib/whereabouts/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/wildfly/vib-publish.json
+++ b/.vib/wildfly/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/wordpress-nginx/vib-publish.json
+++ b/.vib/wordpress-nginx/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/wordpress/vib-publish.json
+++ b/.vib/wordpress/vib-publish.json
@@ -73,6 +73,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [

--- a/.vib/zookeeper/vib-publish.json
+++ b/.vib/zookeeper/vib-publish.json
@@ -57,6 +57,7 @@
             "additional_packages_file": "osspi-packages-amd64.json",
             "scan_type": "BASE_OS",
             "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
               "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
               "architecture_overrides": [


### PR DESCRIPTION
### Description of the change

Set bossd release directly in `osspi-application` step.

### Benefits

bossd release is always the for all the containers. This change reduce work and possible points of failure in the `osspi-application` step.

### Possible drawbacks

None identified

### Applicable issues

Some actions failed because the `osspi-application` couldn't retrieve the bossd information:
- https://github.com/bitnami/containers/actions/runs/4620750911
- https://github.com/bitnami/containers/actions/runs/4620036768
- https://github.com/bitnami/containers/actions/runs/4608886048


### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
