### PR TITLE
[bitnami/openresty] Add VIB tests

### DIFF
--- a/.vib/openresty/goss/goss.yaml
+++ b/.vib/openresty/goss/goss.yaml
@@ -1,0 +1,11 @@
+gossfile:
+  # Goss tests exclusive to the current container
+  ../../openresty/goss/openresty.yaml: {}
+  # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-binaries.yaml: {}
+  ../../common/goss/templates/check-broken-symlinks.yaml: {}
+  ../../common/goss/templates/check-ca-certs.yaml: {}
+  ../../common/goss/templates/check-directories.yaml: {}
+  ../../common/goss/templates/check-linked-libraries.yaml: {}
+  ../../common/goss/templates/check-sed-in-place.yaml: {}
+  ../../common/goss/templates/check-spdx.yaml: {}

--- a/.vib/openresty/goss/openresty.yaml
+++ b/.vib/openresty/goss/openresty.yaml
@@ -15,6 +15,7 @@ file:
     exists: true
     filetype: symlink
     linked-to: /dev/stderr
+  # Check custom configuration
   /opt/bitnami/openresty/nginx/conf/nginx.conf:
     exists: true
     filetype: file

--- a/.vib/openresty/goss/openresty.yaml
+++ b/.vib/openresty/goss/openresty.yaml
@@ -1,0 +1,44 @@
+file:
+  /opt/bitnami/openresty/nginx/html:
+    exists: true
+    filetype: symlink
+    linked-to: /app
+  /opt/bitnami/openresty/nginx/conf/bitnami/certs:
+    exists: true
+    filetype: symlink
+    linked-to: /certs
+  /opt/bitnami/openresty/nginx/logs/access.log:
+    exists: true
+    filetype: symlink
+    linked-to: /dev/stdout
+  /opt/bitnami/openresty/nginx/logs/error.log:
+    exists: true
+    filetype: symlink
+    linked-to: /dev/stderr
+  /opt/bitnami/openresty/nginx/conf/nginx.conf:
+    exists: true
+    filetype: file
+    contains:
+      - /listen.*8080/
+  /opt/bitnami/openresty/nginx/conf/fastcgi_params:
+    exists: true
+    filetype: file
+    contains:
+      - /fastcgi_param.*HTTP_PROXY.*""/
+command:
+  # Revisions are displayed as "x.y.z.r" instead of "x.y.z-r"
+  check-app-version:
+    exec: openresty -v 2>&1 | grep $(echo $APP_VERSION | tr '-' '.')
+    exit-status: 0
+  check-config:
+    exec: openresty -t 2>&1
+    exit-status: 0
+    stdout:
+      - /syntax.*ok/
+      - /test.*successful/
+  check-compilation-options:
+    exec: openresty -V 2>&1
+    exit-status: 0
+    stdout:
+      - pcre-jit
+      - compat

--- a/.vib/openresty/goss/vars.yaml
+++ b/.vib/openresty/goss/vars.yaml
@@ -1,0 +1,17 @@
+binaries:
+  - gosu
+  - openresty
+directories:
+  - mode: "0775"
+    paths:
+      - /bitnami/openresty
+      - /opt/bitnami/openresty/nginx/conf
+      - /opt/bitnami/openresty/nginx/conf/nginx/server_blocks
+      - /opt/bitnami/openresty/nginx/conf/bitnami
+      - /opt/bitnami/openresty/nginx/conf/bitnami/certs
+      - /opt/bitnami/openresty/nginx/logs
+      - /opt/bitnami/openresty/nginx/tmp
+      - /opt/bitnami/openresty/site
+      - /docker-entrypoint-initdb.d
+      - /home/openresty
+root_dir: /opt/bitnami

--- a/.vib/openresty/vib-publish.json
+++ b/.vib/openresty/vib-publish.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{VIB_ENV_CONTAINER_URL}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyJ0YWlsIiwgIi1mIiwgIi9kZXYvbnVsbCJd"
   },
   "phases": {
     "package": {
@@ -77,9 +78,24 @@
               "url": "{VIB_ENV_PACKAGES_JSON_URL}",
               "path": "/{VIB_ENV_PATH}",
               "authn": {
-                  "header": "Authorization",
-                  "token": "Bearer {VIB_ENV_GITHUB_TOKEN}"
-                }
+                "header": "Authorization",
+                "token": "Bearer {VIB_ENV_GITHUB_TOKEN}"
+              }
+            }
+          }
+        },
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "openresty/goss/goss.yaml",
+            "vars_file": "openresty/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-openresty"
+              }
             }
           }
         }

--- a/.vib/openresty/vib-verify.json
+++ b/.vib/openresty/vib-verify.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyJ0YWlsIiwgIi1mIiwgIi9kZXYvbnVsbCJd"
   },
   "phases": {
     "package": {
@@ -45,6 +46,21 @@
             "package_type": [
               "OS"
             ]
+          }
+        },
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "openresty/goss/goss.yaml",
+            "vars_file": "openresty/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-openresty"
+              }
+            }
           }
         }
       ]

--- a/bitnami/openresty/1.21/debian-11/docker-compose.yml
+++ b/bitnami/openresty/1.21/debian-11/docker-compose.yml
@@ -1,7 +1,6 @@
 version: '2'
 
 services:
-  # [TEST]
   openresty:
     image: docker.io/bitnami/openresty:1.21
     ports:

--- a/bitnami/openresty/1.21/debian-11/docker-compose.yml
+++ b/bitnami/openresty/1.21/debian-11/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '2'
 
 services:
+  # [TEST]
   openresty:
     image: docker.io/bitnami/openresty:1.21
     ports:


### PR DESCRIPTION
Signed-off-by: FraPazGal <fdepaz@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

The main objective of this PR is to publish our Bitnami OpenResty container using VMware Image Builder. In order to do that, several changes are included:

- Increasing the existing test coverage of the asset by adding Goss tests.
- Update verify and publish VIB pipeline's definitions.

### Benefits

- Ensuring higher quality of the container catalog.
- Increased pool of assets completely handled by VMware Image Builder.

### Possible drawbacks

Automated tests could introduce additional flakiness to the CI/CD. 

### Applicable issues

NA

Tested in:
- Recent action run: https://github.com/bitnami/containers/actions/runs/4658806667