### PR TITLE
Fix fetching `REDIS_MASTER_HOST` via `REDIS_SENTINEL_HOST`

### DIFF
--- a/bitnami/redis/6.2/debian-11/rootfs/opt/bitnami/scripts/libredis.sh
+++ b/bitnami/redis/6.2/debian-11/rootfs/opt/bitnami/scripts/libredis.sh
@@ -265,7 +265,7 @@ redis_configure_replication() {
             local -a sentinel_info_command=("redis-cli" "-h" "${REDIS_SENTINEL_HOST}" "-p" "${REDIS_SENTINEL_PORT_NUMBER}")
             is_boolean_yes "$REDIS_TLS_ENABLED" && sentinel_info_command+=("--tls" "--cert" "${REDIS_TLS_CERT_FILE}" "--key" "${REDIS_TLS_KEY_FILE}" "--cacert" "${REDIS_TLS_CA_FILE}")
             sentinel_info_command+=("sentinel" "get-master-addr-by-name" "${REDIS_SENTINEL_MASTER_NAME}")
-            read -r -a REDIS_SENTINEL_INFO <<< "$("${sentinel_info_command[@]}")"
+            read -r -a REDIS_SENTINEL_INFO <<< "$("${sentinel_info_command[@]}" | tr '\n' ' ')"
             REDIS_MASTER_HOST=${REDIS_SENTINEL_INFO[0]}
             REDIS_MASTER_PORT_NUMBER=${REDIS_SENTINEL_INFO[1]}
         fi

--- a/bitnami/redis/7.0/debian-11/rootfs/opt/bitnami/scripts/libredis.sh
+++ b/bitnami/redis/7.0/debian-11/rootfs/opt/bitnami/scripts/libredis.sh
@@ -265,7 +265,7 @@ redis_configure_replication() {
             local -a sentinel_info_command=("redis-cli" "-h" "${REDIS_SENTINEL_HOST}" "-p" "${REDIS_SENTINEL_PORT_NUMBER}")
             is_boolean_yes "$REDIS_TLS_ENABLED" && sentinel_info_command+=("--tls" "--cert" "${REDIS_TLS_CERT_FILE}" "--key" "${REDIS_TLS_KEY_FILE}" "--cacert" "${REDIS_TLS_CA_FILE}")
             sentinel_info_command+=("sentinel" "get-master-addr-by-name" "${REDIS_SENTINEL_MASTER_NAME}")
-            read -r -a REDIS_SENTINEL_INFO <<< "$("${sentinel_info_command[@]}")"
+            read -r -a REDIS_SENTINEL_INFO <<< "$("${sentinel_info_command[@]}" | tr '\n' ' ')"
             REDIS_MASTER_HOST=${REDIS_SENTINEL_INFO[0]}
             REDIS_MASTER_PORT_NUMBER=${REDIS_SENTINEL_INFO[1]}
         fi


### PR DESCRIPTION
This fixes a problem, which occurs when in a Sentinel setup, `REDIS_MASTER_HOST`is not set explicitely, but retrieved using `REDIS_SENTINEL_HOST`. Previously, parsing Sentinel's output failed because the master host name and port were on separate lines, which the script did not expect. After this patch, those separate lines are concatenated and the script's expectations are fullfilled.

Please note: I haven't patched `libredis.sh` in the `redis-cluster` container, since there is no setup I know of in which Redis Cluster is used with Sentinel.  

Fixes: #29020