### PR TITLE
[bitnami/suitecrm] SQL syntax error in mysql init script

### DIFF
--- a/bitnami/suitecrm/7/debian-11/rootfs/opt/bitnami/scripts/libmysqlclient.sh
+++ b/bitnami/suitecrm/7/debian-11/rootfs/opt/bitnami/scripts/libmysqlclient.sh
@@ -580,9 +580,9 @@ mysql_ensure_user_exists() {
         auth_string="identified via pam using '$DB_FLAVOR'"
     elif [[ -n "$password" ]]; then
         if [[ -n "$auth_plugin" ]]; then
-            auth_string="identified with $auth_plugin by \"$password\""
+            auth_string="identified with $auth_plugin by '$password'"
         else
-            auth_string="identified by \"$password\""
+            auth_string="identified by '$password'"
         fi
     fi
     debug "creating database user \'$user\'"

--- a/bitnami/suitecrm/8/debian-11/rootfs/opt/bitnami/scripts/libmysqlclient.sh
+++ b/bitnami/suitecrm/8/debian-11/rootfs/opt/bitnami/scripts/libmysqlclient.sh
@@ -586,9 +586,9 @@ mysql_ensure_user_exists() {
         auth_string="identified via pam using '$DB_FLAVOR'"
     elif [[ -n "$password" ]]; then
         if [[ -n "$auth_plugin" ]]; then
-            auth_string="identified with $auth_plugin by \"$password\""
+            auth_string="identified with $auth_plugin by '$password'"
         else
-            auth_string="identified by \"$password\""
+            auth_string="identified by '$password'"
         fi
     fi
     debug "creating database user \'$user\'"


### PR DESCRIPTION
MySQL v8 throws a SQL syntax error when $password is surrounded by double quotes.

### Description of the change

This fixes a SQL syntax error affecting the setup/initialisation of MySQL database for SuiteCRM.

The change makes the setup scripts execute `create user if not exists '<redacted>'@'%' identified by '<redacted>';` instead of `create user if not exists '<redacted>'@'%' identified by "<redacted>";`, which causes instances of MySQL v8 to throw a syntax error.

### Benefits

Hopefully, fixes the bootstrapping of MySQL database and user for SuiteCRM to connect to.

### Possible drawbacks

None I can think of. AFAIK use of single quotes (`'`) to denote string values instead of `"` is indeed correct SQL syntax. The latter is interpreted as identifiers in MySQL (column names, etc.) and not string values.

### Applicable issues

- fixes https://github.com/bitnami/containers/issues/30004

### Additional information

This change has only been tested, connecting to a freshly provisioned, managed MySQL v8 instance (on DigitalOcean).

I've tried to set up `bitnami/mysql` locally to try and replicate the issue but was unsuccessful in connecting the containers over network (Docker Compose).

I could patch and test the change the Docker-compose run by using the following build dockerfile in conjuction with a Docker compose definition:

```
# FROM bitnami/suitecrm:7.11.20
FROM bitnami/suitecrm:8.2.4

## Patch init script
RUN sed -i 's|auth_string="identified by \\"$password\\"|auth_string="identified by \x27$password\x27 |' /opt/bitnami/scripts/libmysqlclient.sh
```
