### PR TITLE
[bitnami/keycloak] remove dp password posting, when debug mode is enabled

### DIFF
--- a/bitnami/keycloak/21/debian-11/rootfs/opt/bitnami/scripts/libkeycloak.sh
+++ b/bitnami/keycloak/21/debian-11/rootfs/opt/bitnami/scripts/libkeycloak.sh
@@ -135,7 +135,6 @@ keycloak_configure_database() {
     if [[ "${KEYCLOAK_DATABASE_VENDOR}" == "postgresql" ]]; then
         keycloak_conf_set "db" "postgres"
         keycloak_conf_set "db-username" "$KEYCLOAK_DATABASE_USER"
-        keycloak_conf_set "db-password" "$KEYCLOAK_DATABASE_PASSWORD"
         keycloak_conf_set "db-url" "jdbc:postgresql://${KEYCLOAK_DATABASE_HOST}:${KEYCLOAK_DATABASE_PORT}/${KEYCLOAK_DATABASE_NAME}?currentSchema=${KEYCLOAK_DATABASE_SCHEMA}${jdbc_params}"
     else
         keycloak_conf_set "db" "$KEYCLOAK_DATABASE_VENDOR"


### PR DESCRIPTION
What my change does?
It removes the log output of dp-password when debug on image is set

What are the limitations?
It is not possible to see the used password in the logs anymore.

Description of the change

It removes the log output of dp-password when debug on image is set.

Benefits

It is no longer possible to see the db-password inside the log output.

Possible drawbacks

It is harder to retrieve the password for debug purposes.

Additional information

Why Im changing this?
At my current project, we want to live the GitOps approach. So I used Bitnami Sealed Secrets to seal my DB-password. Then I found the real decrypted password in the log file. So I searched why and how this happened. I found the deleted line in the shell script.

If a suspect enables the debug mode in git repository and can see the logs, the password is stolen. It is also possible that the db-password is sent to some observeability tool...

If ur an admin and really need to debug, just ssh into the container and retrieve the pw there.

I decided against masking the password.

If there are any questions, feel free to ask.