### PR TITLE
[bitnami/grafana-image-renderer] Add VIB tests

### DIFF
--- a/.vib/grafana-image-renderer/goss/goss.yaml
+++ b/.vib/grafana-image-renderer/goss/goss.yaml
@@ -1,10 +1,11 @@
 gossfile:
   # Goss tests exclusive to the current container
-  ../../grafana-image-renderer/goss/grafana-image-renderer.yaml: { }
+  ../../grafana-image-renderer/goss/grafana-image-renderer.yaml: {}
   # Load scripts from .vib/common/goss/templates
   ../../common/goss/templates/check-binaries.yaml: {}
   ../../common/goss/templates/check-broken-symlinks.yaml: {}
   ../../common/goss/templates/check-ca-certs.yaml: {}
+  ../../common/goss/templates/check-directories.yaml: {}
   ../../common/goss/templates/check-files.yaml: {}
   ../../common/goss/templates/check-linked-libraries.yaml: {}
   ../../common/goss/templates/check-sed-in-place.yaml: {}

--- a/.vib/grafana-image-renderer/goss/goss.yaml
+++ b/.vib/grafana-image-renderer/goss/goss.yaml
@@ -1,0 +1,11 @@
+gossfile:
+  # Goss tests exclusive to the current container
+  ../../grafana-image-renderer/goss/grafana-image-renderer.yaml: { }
+  # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-binaries.yaml: {}
+  ../../common/goss/templates/check-broken-symlinks.yaml: {}
+  ../../common/goss/templates/check-ca-certs.yaml: {}
+  ../../common/goss/templates/check-files.yaml: {}
+  ../../common/goss/templates/check-linked-libraries.yaml: {}
+  ../../common/goss/templates/check-sed-in-place.yaml: {}
+  ../../common/goss/templates/check-spdx.yaml: {}

--- a/.vib/grafana-image-renderer/goss/grafana-image-renderer.yaml
+++ b/.vib/grafana-image-renderer/goss/grafana-image-renderer.yaml
@@ -1,0 +1,6 @@
+group:
+  daemon:
+    exists: true
+user:
+  daemon:
+    exists: true

--- a/.vib/grafana-image-renderer/goss/grafana-image-renderer.yaml
+++ b/.vib/grafana-image-renderer/goss/grafana-image-renderer.yaml
@@ -1,6 +1,6 @@
-group:
-  daemon:
-    exists: true
-user:
-  daemon:
-    exists: true
+command:
+  check-app-version:
+    exec: grep -A2 '"version"' /opt/bitnami/grafana-image-renderer/plugin.json | grep -o "[0-9]*\.[0-9]*\.[0-9]"
+    exit-status: 0
+    stdout:
+      - {{ .Env.APP_VERSION }}

--- a/.vib/grafana-image-renderer/goss/grafana-image-renderer.yaml
+++ b/.vib/grafana-image-renderer/goss/grafana-image-renderer.yaml
@@ -4,3 +4,6 @@ command:
     exit-status: 0
     stdout:
       - {{ .Env.APP_VERSION }}
+  check-build-app:
+    exec: timeout --preserve-status 3 node /opt/bitnami/grafana-image-renderer/build/app.js server --config=/opt/bitnami/grafana-image-renderer/conf/config.json
+    exit-status: 143

--- a/.vib/grafana-image-renderer/goss/vars.yaml
+++ b/.vib/grafana-image-renderer/goss/vars.yaml
@@ -2,8 +2,7 @@ binaries:
   - node
   - python
 directories:
-  - mode: "0755"
-    paths:
+  - paths:
       - /opt/bitnami/grafana-image-renderer/build
       - /opt/bitnami/grafana-image-renderer/node_modules
       - /opt/bitnami/grafana-image-renderer/proto

--- a/.vib/grafana-image-renderer/goss/vars.yaml
+++ b/.vib/grafana-image-renderer/goss/vars.yaml
@@ -1,0 +1,8 @@
+binaries:
+  - grafana-image-renderer
+  - node
+  - python
+files:
+  - paths:
+      - /opt/bitnami/grafana-image-renderer/conf/config.json
+root_dir: /opt/bitnami

--- a/.vib/grafana-image-renderer/goss/vars.yaml
+++ b/.vib/grafana-image-renderer/goss/vars.yaml
@@ -1,8 +1,14 @@
 binaries:
-  - grafana-image-renderer
   - node
   - python
+directories:
+  - mode: "0755"
+    paths:
+      - /opt/bitnami/grafana-image-renderer/build
+      - /opt/bitnami/grafana-image-renderer/node_modules
+      - /opt/bitnami/grafana-image-renderer/proto
 files:
   - paths:
       - /opt/bitnami/grafana-image-renderer/conf/config.json
+      - /opt/bitnami/grafana-image-renderer/plugin.json
 root_dir: /opt/bitnami

--- a/.vib/grafana-image-renderer/vib-publish.json
+++ b/.vib/grafana-image-renderer/vib-publish.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{VIB_ENV_CONTAINER_URL}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyJ0YWlsIiwgIi1mIiwgIi9kZXYvbnVsbCJd"
   },
   "phases": {
     "package": {
@@ -32,6 +33,21 @@
     },
     "verify": {
       "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "grafana-image-renderer/goss/goss.yaml",
+            "vars_file": "grafana-image-renderer/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-grafana-image-renderer"
+              }
+            }
+          }
+        },
         {
           "action_id": "trivy",
           "params": {

--- a/.vib/grafana-image-renderer/vib-verify.json
+++ b/.vib/grafana-image-renderer/vib-verify.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyJ0YWlsIiwgIi1mIiwgIi9kZXYvbnVsbCJd"
   },
   "phases": {
     "package": {
@@ -29,6 +30,21 @@
     },
     "verify": {
       "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "grafana-image-renderer/goss/goss.yaml",
+            "vars_file": "grafana-image-renderer/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-grafana-image-renderer"
+              }
+            }
+          }
+        },
         {
           "action_id": "trivy",
           "params": {

--- a/bitnami/grafana-image-renderer/3/debian-11/docker-compose.yml
+++ b/bitnami/grafana-image-renderer/3/debian-11/docker-compose.yml
@@ -2,6 +2,7 @@ version: '2'
 
 services:
   grafana-image-renderer:
+    # New change
     image: docker.io/bitnami/grafana-image-renderer:3
     ports:
       - '8080:8080'

--- a/bitnami/grafana-image-renderer/3/debian-11/docker-compose.yml
+++ b/bitnami/grafana-image-renderer/3/debian-11/docker-compose.yml
@@ -2,7 +2,6 @@ version: '2'
 
 services:
   grafana-image-renderer:
-    # New change
     image: docker.io/bitnami/grafana-image-renderer:3
     ports:
       - '8080:8080'


### PR DESCRIPTION
### Description of the change

The main objective of this PR is to publish our Bitnami Grafana-image-renderer container using VMware Image Builder. In order to do that, several changes are included:

- Increasing the existing test coverage of the asset by adding Goss tests.
- Update verify and publish VIB pipeline's definitions.

### Benefits

- Ensuring higher quality of the container catalog.
- Increased pool of assets completely handled by VMware Image Builder.

### Possible drawbacks

Automated tests could introduce additional flakiness to the CI/CD.

### Applicable issues

NA

### Additional information

It isn't checked that there are no .pem files after the compilation step since in that step no .pem files are found according to the logs.
