### PR TITLE
[bitnami/harbor-jobservice] Add VIB tests

### DIFF
--- a/.vib/harbor-jobservice/goss/goss.yaml
+++ b/.vib/harbor-jobservice/goss/goss.yaml
@@ -1,0 +1,11 @@
+gossfile:
+  # Goss tests exclusive to the current container
+  ../../harbor-jobservice/goss/harbor-jobservice.yaml: {}
+  # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-binaries.yaml: {}
+  ../../common/goss/templates/check-broken-symlinks.yaml: {}
+  ../../common/goss/templates/check-ca-certs.yaml: {}
+  ../../common/goss/templates/check-directories.yaml: {}
+  ../../common/goss/templates/check-linked-libraries.yaml: {}
+  ../../common/goss/templates/check-sed-in-place.yaml: {}
+  ../../common/goss/templates/check-spdx.yaml: {}

--- a/.vib/harbor-jobservice/goss/harbor-jobservice.yaml
+++ b/.vib/harbor-jobservice/goss/harbor-jobservice.yaml
@@ -10,11 +10,9 @@ file:
     mode: "0775"
     owner: harbor
     filetype: directory
+  /opt/bitnami/harbor-jobservice/bin/swagger:
+    exists: false
 command:
-  # Ensure swagger binary doesn't exist
-  check-swagger-binary:
-    exec: ls /opt/bitnami/harbor-jobservice/bin/swagger 2>/dev/null
-    exit-status: 2
   # Ensure a set of directories exist and the non-root user has write privileges to them
   check-directories-exist-with-user:
     exec: ls -dl /etc/ssl/certs /etc/pki/tls/certs/ 2>/dev/null | grep "drwxrwxr-x.*harbor"

--- a/.vib/harbor-jobservice/goss/harbor-jobservice.yaml
+++ b/.vib/harbor-jobservice/goss/harbor-jobservice.yaml
@@ -1,0 +1,17 @@
+group:
+  daemon:
+    exists: true
+user:
+  daemon:
+    exists: true
+command:
+  check-system-cert-paths:
+    exec: if (test -d /etc/ssl/certs/ && (ls -ld /etc/ssl/certs/ | cut --delimiter=' ' --fields=3 | grep 'harbor') && (ls -ld /etc/ssl/certs/ | cut --delimiter=' ' --fields=1 | grep 'drwxrwxr-x')); then echo "Directory exists"; fi || if (test -d /etc/pki/tls/certs/ && (ls -ld /etc/pki/tls/certs/ | cut --delimiter=' ' --fields=3 | grep 'harbor') && (ls -ld /etc/pki/tls/certs/ | cut --delimiter=' ' --fields=1 | grep 'drwxrwxr-x')); then echo "Directory exists"; fi
+    exit-status: 0
+    stdout:
+      - "Directory exists"
+  check-permissions-system-certs:
+    exec: if (test -f /etc/ssl/certs/ca-certificates.crt && (ls -ld /etc/ssl/certs/ca-certificates.crt | cut --delimiter=' ' --fields=3 | grep 'harbor')); then echo "File exists"; fi || if (test -f /etc/pki/tls/certs/ca-bundle.crt && (ls -ld /etc/pki/tls/certs/ca-bundle.crt | cut --delimiter=' ' --fields=3 | grep 'harbor')); then echo "File exists"; fi || if (test -f /etc/pki/tls/certs/ca-bundle.trust.crt && (ls -ld /etc/pki/tls/certs/ca-bundle.trust.crt | cut --delimiter=' ' --fields=3 | grep 'harbor')); then echo "File exists"; fi
+    exit-status: 0
+    stdout:
+      - "File exists"

--- a/.vib/harbor-jobservice/goss/harbor-jobservice.yaml
+++ b/.vib/harbor-jobservice/goss/harbor-jobservice.yaml
@@ -6,12 +6,8 @@ user:
     exists: true
 command:
   check-system-cert-paths:
-    exec: if (test -d /etc/ssl/certs/ && (ls -ld /etc/ssl/certs/ | cut --delimiter=' ' --fields=3 | grep 'harbor') && (ls -ld /etc/ssl/certs/ | cut --delimiter=' ' --fields=1 | grep 'drwxrwxr-x')); then echo "Directory exists"; fi || if (test -d /etc/pki/tls/certs/ && (ls -ld /etc/pki/tls/certs/ | cut --delimiter=' ' --fields=3 | grep 'harbor') && (ls -ld /etc/pki/tls/certs/ | cut --delimiter=' ' --fields=1 | grep 'drwxrwxr-x')); then echo "Directory exists"; fi
+    exec: ls -dl /etc/ssl/certs /etc/pki/tls/certs/ 2>/dev/null | grep "drwxrwxr-x.*harbor"
     exit-status: 0
-    stdout:
-      - "Directory exists"
   check-permissions-system-certs:
     exec: if (test -f /etc/ssl/certs/ca-certificates.crt && (ls -ld /etc/ssl/certs/ca-certificates.crt | cut --delimiter=' ' --fields=3 | grep 'harbor')); then echo "File exists"; fi || if (test -f /etc/pki/tls/certs/ca-bundle.crt && (ls -ld /etc/pki/tls/certs/ca-bundle.crt | cut --delimiter=' ' --fields=3 | grep 'harbor')); then echo "File exists"; fi || if (test -f /etc/pki/tls/certs/ca-bundle.trust.crt && (ls -ld /etc/pki/tls/certs/ca-bundle.trust.crt | cut --delimiter=' ' --fields=3 | grep 'harbor')); then echo "File exists"; fi
     exit-status: 0
-    stdout:
-      - "File exists"

--- a/.vib/harbor-jobservice/goss/harbor-jobservice.yaml
+++ b/.vib/harbor-jobservice/goss/harbor-jobservice.yaml
@@ -4,10 +4,16 @@ group:
 user:
   harbor:
     exists: true
+file:
+  /var/log/jobs:
+    exists: true
+    mode: "0775"
+    owner: harbor
+    filetype: directory
 command:
   # Ensure a set of directories exist and the non-root user has write privileges to them
   check-directories-exist-with-user:
-    exec: ls -dl /etc/ssl/certs /etc/pki/tls/certs/ /var/log/jobs 2>/dev/null | grep "drwxrwxr-x.*harbor"
+    exec: ls -dl /etc/ssl/certs /etc/pki/tls/certs/ 2>/dev/null | grep "drwxrwxr-x.*harbor"
     exit-status: 0
   # Ensure permissions for Internal TLS
   check-permissions-system-certs:

--- a/.vib/harbor-jobservice/goss/harbor-jobservice.yaml
+++ b/.vib/harbor-jobservice/goss/harbor-jobservice.yaml
@@ -9,5 +9,5 @@ command:
     exec: ls -dl /etc/ssl/certs /etc/pki/tls/certs/ 2>/dev/null | grep "drwxrwxr-x.*harbor"
     exit-status: 0
   check-permissions-system-certs:
-    exec: if (test -f /etc/ssl/certs/ca-certificates.crt && (ls -ld /etc/ssl/certs/ca-certificates.crt | cut --delimiter=' ' --fields=3 | grep 'harbor')); then echo "File exists"; fi || if (test -f /etc/pki/tls/certs/ca-bundle.crt && (ls -ld /etc/pki/tls/certs/ca-bundle.crt | cut --delimiter=' ' --fields=3 | grep 'harbor')); then echo "File exists"; fi || if (test -f /etc/pki/tls/certs/ca-bundle.trust.crt && (ls -ld /etc/pki/tls/certs/ca-bundle.trust.crt | cut --delimiter=' ' --fields=3 | grep 'harbor')); then echo "File exists"; fi
+    exec: ls -l /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.trust.crt /etc/ssl/certs/ca-certificates.crt 2>/dev/null | grep ".*-rw-rw-r--"
     exit-status: 0

--- a/.vib/harbor-jobservice/goss/harbor-jobservice.yaml
+++ b/.vib/harbor-jobservice/goss/harbor-jobservice.yaml
@@ -5,8 +5,8 @@ user:
   harbor:
     exists: true
 command:
-  check-system-cert-paths:
-    exec: ls -dl /etc/ssl/certs /etc/pki/tls/certs/ 2>/dev/null | grep "drwxrwxr-x.*harbor"
+  check-directories-exist-with-user:
+    exec: ls -dl /etc/ssl/certs /etc/pki/tls/certs/ /var/log/jobs 2>/dev/null | grep "drwxrwxr-x.*harbor"
     exit-status: 0
   check-permissions-system-certs:
     exec: ls -l /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.trust.crt /etc/ssl/certs/ca-certificates.crt 2>/dev/null | grep ".*-rw-rw-r--"

--- a/.vib/harbor-jobservice/goss/harbor-jobservice.yaml
+++ b/.vib/harbor-jobservice/goss/harbor-jobservice.yaml
@@ -5,9 +5,11 @@ user:
   harbor:
     exists: true
 command:
+  # Ensure a set of directories exist and the non-root user has write privileges to them
   check-directories-exist-with-user:
     exec: ls -dl /etc/ssl/certs /etc/pki/tls/certs/ /var/log/jobs 2>/dev/null | grep "drwxrwxr-x.*harbor"
     exit-status: 0
+  # Ensure permissions for Internal TLS
   check-permissions-system-certs:
     exec: ls -l /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.trust.crt /etc/ssl/certs/ca-certificates.crt 2>/dev/null | grep ".*-rw-rw-r--"
     exit-status: 0

--- a/.vib/harbor-jobservice/goss/harbor-jobservice.yaml
+++ b/.vib/harbor-jobservice/goss/harbor-jobservice.yaml
@@ -1,8 +1,8 @@
 group:
-  daemon:
+  harbor:
     exists: true
 user:
-  daemon:
+  harbor:
     exists: true
 command:
   check-system-cert-paths:

--- a/.vib/harbor-jobservice/goss/harbor-jobservice.yaml
+++ b/.vib/harbor-jobservice/goss/harbor-jobservice.yaml
@@ -21,4 +21,5 @@ command:
     exit-status: 0
   # Ensure permissions for Internal TLS
   check-permissions-system-certs:
-    exec: ls -l /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle
+    exec: ls -l /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.trust.crt /etc/ssl/certs/ca-certificates.crt 2>/dev/null | grep ".*-rw-rw-r--"     
+    exit-status: 0

--- a/.vib/harbor-jobservice/goss/harbor-jobservice.yaml
+++ b/.vib/harbor-jobservice/goss/harbor-jobservice.yaml
@@ -11,11 +11,14 @@ file:
     owner: harbor
     filetype: directory
 command:
+  # Ensure swagger binary doesn't exist
+  check-swagger-binary:
+    exec: ls /opt/bitnami/harbor-jobservice/bin/swagger 2>/dev/null
+    exit-status: 2
   # Ensure a set of directories exist and the non-root user has write privileges to them
   check-directories-exist-with-user:
     exec: ls -dl /etc/ssl/certs /etc/pki/tls/certs/ 2>/dev/null | grep "drwxrwxr-x.*harbor"
     exit-status: 0
   # Ensure permissions for Internal TLS
   check-permissions-system-certs:
-    exec: ls -l /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.trust.crt /etc/ssl/certs/ca-certificates.crt 2>/dev/null | grep ".*-rw-rw-r--"
-    exit-status: 0
+    exec: ls -l /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle

--- a/.vib/harbor-jobservice/goss/vars.yaml
+++ b/.vib/harbor-jobservice/goss/vars.yaml
@@ -1,6 +1,5 @@
 binaries:
   - harbor_jobservice
-  - gosu
   - yq
 directories:
   - mode: "0775"

--- a/.vib/harbor-jobservice/goss/vars.yaml
+++ b/.vib/harbor-jobservice/goss/vars.yaml
@@ -2,7 +2,6 @@ binaries:
   - harbor_jobservice
   - yq
 directories:
-  - mode: "0755"
-    paths:
+  - paths:
       - /etc/jobservice
 root_dir: /opt/bitnami

--- a/.vib/harbor-jobservice/goss/vars.yaml
+++ b/.vib/harbor-jobservice/goss/vars.yaml
@@ -1,0 +1,9 @@
+binaries:
+  - harbor_jobservice
+  - gosu
+  - yq
+directories:
+  - mode: "0775"
+    paths:
+      - /var/log/jobs
+root_dir: /opt/bitnami

--- a/.vib/harbor-jobservice/goss/vars.yaml
+++ b/.vib/harbor-jobservice/goss/vars.yaml
@@ -6,5 +6,7 @@ directories:
   - mode: "0775"
     paths:
       - /var/log/jobs
+  - mode: "0755"
+    paths:
       - /etc/jobservice
 root_dir: /opt/bitnami

--- a/.vib/harbor-jobservice/goss/vars.yaml
+++ b/.vib/harbor-jobservice/goss/vars.yaml
@@ -2,9 +2,6 @@ binaries:
   - harbor_jobservice
   - yq
 directories:
-  - mode: "0775"
-    paths:
-      - /var/log/jobs
   - mode: "0755"
     paths:
       - /etc/jobservice

--- a/.vib/harbor-jobservice/goss/vars.yaml
+++ b/.vib/harbor-jobservice/goss/vars.yaml
@@ -6,4 +6,5 @@ directories:
   - mode: "0775"
     paths:
       - /var/log/jobs
+      - /etc/jobservice
 root_dir: /opt/bitnami

--- a/.vib/harbor-jobservice/vib-publish.json
+++ b/.vib/harbor-jobservice/vib-publish.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{VIB_ENV_CONTAINER_URL}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyJ0YWlsIiwgIi1mIiwgIi9kZXYvbnVsbCJd"
   },
   "phases": {
     "package": {
@@ -33,6 +34,21 @@
     },
     "verify": {
       "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "harbor-jobservice/goss/goss.yaml",
+            "vars_file": "harbor-jobservice/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-harbor-jobservice"
+              }
+            }
+          }
+        },
         {
           "action_id": "trivy",
           "params": {

--- a/.vib/harbor-jobservice/vib-verify.json
+++ b/.vib/harbor-jobservice/vib-verify.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyJ0YWlsIiwgIi1mIiwgIi9kZXYvbnVsbCJd"
   },
   "phases": {
     "package": {
@@ -29,6 +30,21 @@
     },
     "verify": {
       "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "harbor-jobservice/goss/goss.yaml",
+            "vars_file": "harbor-jobservice/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-harbor-jobservice"
+              }
+            }
+          }
+        },
         {
           "action_id": "trivy",
           "params": {

--- a/bitnami/harbor-jobservice/2/debian-11/docker-compose.yml
+++ b/bitnami/harbor-jobservice/2/debian-11/docker-compose.yml
@@ -2,7 +2,6 @@ version: '2'
 
 services:
   harbor-jobservice:
-    # New change
     image: docker.io/bitnami/harbor-jobservice:2
     ports:
       - 80:8080

--- a/bitnami/harbor-jobservice/2/debian-11/docker-compose.yml
+++ b/bitnami/harbor-jobservice/2/debian-11/docker-compose.yml
@@ -2,6 +2,7 @@ version: '2'
 
 services:
   harbor-jobservice:
+    # New change
     image: docker.io/bitnami/harbor-jobservice:2
     ports:
       - 80:8080


### PR DESCRIPTION
### Description of the change

The main objective of this PR is to publish our Bitnami Harbor-jobservice container using VMware Image Builder. In order to do that, several changes are included:

- Increasing the existing test coverage of the asset by adding Goss tests.
- Update verify and publish VIB pipeline's definitions.

### Benefits

- Ensuring higher quality of the container catalog.
- Increased pool of assets completely handled by VMware Image Builder.

### Possible drawbacks

Automated tests could introduce additional flakiness to the CI/CD.

### Applicable issues

NA

### Additional information

The binary "harbor_exporter" cannot be tested as it requires other components:
```
I have no name!@9b6df139926b:/opt/bitnami/harbor-jobservice/bin$ harbor_jobservice --help
2023-04-17T16:44:03Z [INFO] [/controller/artifact/annotation/parser.go:71]: the annotation parser to parser artifact annotation version v1alpha1 registered
2023-04-17T16:44:03Z [INFO] [/controller/artifact/processor/processor.go:59]: the processor to process media type application/vnd.wasm.config.v1+json registered
2023-04-17T16:44:03Z [INFO] [/controller/artifact/processor/processor.go:59]: the processor to process media type application/vnd.cncf.helm.config.v1+json registered
2023-04-17T16:44:03Z [INFO] [/controller/artifact/processor/processor.go:59]: the processor to process media type application/vnd.cnab.manifest.v1 registered
2023-04-17T16:44:03Z [INFO] [/controller/artifact/processor/processor.go:59]: the processor to process media type application/vnd.oci.image.index.v1+json registered
2023-04-17T16:44:03Z [INFO] [/controller/artifact/processor/processor.go:59]: the processor to process media type application/vnd.docker.distribution.manifest.list.v2+json registered
2023-04-17T16:44:03Z [INFO] [/controller/artifact/processor/processor.go:59]: the processor to process media type application/vnd.docker.distribution.manifest.v1+prettyjws registered
2023-04-17T16:44:03Z [INFO] [/controller/artifact/processor/processor.go:59]: the processor to process media type application/vnd.oci.image.config.v1+json registered
2023-04-17T16:44:03Z [INFO] [/controller/artifact/processor/processor.go:59]: the processor to process media type application/vnd.docker.container.image.v1+json registered
2023/04/17 16:44:03.124 [D]  init global config instance failed. If you do not use this, just ignore it.  open conf/app.conf: no such file or directory
2023-04-17T16:44:03Z [INFO] [/pkg/reg/adapter/native/adapter.go:36]: the factory for adapter docker-registry registered
2023-04-17T16:44:03Z [INFO] [/pkg/reg/adapter/aliacr/adapter.go:30]: the factory for adapter ali-acr registered
2023-04-17T16:44:03Z [INFO] [/pkg/reg/adapter/awsecr/adapter.go:44]: the factory for adapter aws-ecr registered
2023-04-17T16:44:03Z [INFO] [/pkg/reg/adapter/azurecr/adapter.go:29]: Factory for adapter azure-acr registered
2023-04-17T16:44:03Z [INFO] [/pkg/reg/adapter/dockerhub/adapter.go:26]: Factory for adapter docker-hub registered
2023-04-17T16:44:03Z [INFO] [/pkg/reg/adapter/dtr/adapter.go:22]: the factory of dtr adapter was registered
2023-04-17T16:44:03Z [INFO] [/pkg/reg/adapter/githubcr/adapter.go:29]: the factory for adapter github-ghcr registered
2023-04-17T16:44:03Z [INFO] [/pkg/reg/adapter/gitlab/adapter.go:18]: the factory for adapter gitlab registered
2023-04-17T16:44:03Z [INFO] [/pkg/reg/adapter/googlegcr/adapter.go:37]: the factory for adapter google-gcr registered
2023-04-17T16:44:03Z [INFO] [/pkg/reg/adapter/harbor/adaper.go:31]: the factory for adapter harbor registered
2023-04-17T16:44:03Z [INFO] [/pkg/reg/adapter/huawei/huawei_adapter.go:40]: the factory of Huawei adapter was registered
2023-04-17T16:44:03Z [INFO] [/pkg/reg/adapter/jfrog/adapter.go:42]: the factory of jfrog artifactory adapter was registered
2023-04-17T16:44:03Z [INFO] [/pkg/reg/adapter/quay/adapter.go:53]: the factory of Quay adapter was registered
2023-04-17T16:44:03Z [INFO] [/pkg/reg/adapter/tencentcr/adapter.go:41]: the factory for adapter tencent-tcr registered
2023-04-17T16:44:03Z [ERROR] [/lib/config/config.go:81]: failed to get config manager
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x1348830]

goroutine 1 [running]:
main.main()
	/bitnami/blacksmith-sandox/harbor-jobservice-2.8.0/src/github.com/goharbor/harbor/src/jobservice/main.go:41 +0x70
```
