### PR TITLE
[bitnami/nats-exporter] Add VIB tests

### DIFF
--- a/.vib/nats-exporter/goss/goss.yaml
+++ b/.vib/nats-exporter/goss/goss.yaml
@@ -1,0 +1,9 @@
+gossfile:
+  # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-app-version.yaml: {}
+  ../../common/goss/templates/check-binaries.yaml: {}
+  ../../common/goss/templates/check-broken-symlinks.yaml: {}
+  ../../common/goss/templates/check-ca-certs.yaml: {}
+  ../../common/goss/templates/check-linked-libraries.yaml: {}
+  ../../common/goss/templates/check-sed-in-place.yaml: {}
+  ../../common/goss/templates/check-spdx.yaml: {}

--- a/.vib/nats-exporter/goss/vars.yaml
+++ b/.vib/nats-exporter/goss/vars.yaml
@@ -1,0 +1,6 @@
+binaries:
+  - prometheus-nats-exporter
+root_dir: /opt/bitnami
+version:
+  bin_name: prometheus-nats-exporter
+  flag: -version

--- a/.vib/nats-exporter/vib-publish.json
+++ b/.vib/nats-exporter/vib-publish.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{VIB_ENV_CONTAINER_URL}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyJ0YWlsIiwgIi1mIiwgIi9kZXYvbnVsbCJd"
   },
   "phases": {
     "package": {
@@ -77,9 +78,24 @@
               "url": "{VIB_ENV_PACKAGES_JSON_URL}",
               "path": "/{VIB_ENV_PATH}",
               "authn": {
-                  "header": "Authorization",
-                  "token": "Bearer {VIB_ENV_GITHUB_TOKEN}"
-                }
+                "header": "Authorization",
+                "token": "Bearer {VIB_ENV_GITHUB_TOKEN}"
+              }
+            }
+          }
+        },
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "nats-exporter/goss/goss.yaml",
+            "vars_file": "nats-exporter/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-nats-exporter"
+              }
             }
           }
         }

--- a/.vib/nats-exporter/vib-verify.json
+++ b/.vib/nats-exporter/vib-verify.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyJ0YWlsIiwgIi1mIiwgIi9kZXYvbnVsbCJd"
   },
   "phases": {
     "package": {
@@ -45,6 +46,21 @@
             "package_type": [
               "OS"
             ]
+          }
+        },
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "nats-exporter/goss/goss.yaml",
+            "vars_file": "nats-exporter/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-nats-exporter"
+              }
+            }
           }
         }
       ]

--- a/bitnami/nats-exporter/0/debian-11/docker-compose.yml
+++ b/bitnami/nats-exporter/0/debian-11/docker-compose.yml
@@ -1,5 +1,6 @@
 version: '2'
 services:
+  # [TEST]
   nats-exporter:
     image: docker.io/bitnami/nats-exporter:0
     ports:

--- a/bitnami/nats-exporter/0/debian-11/docker-compose.yml
+++ b/bitnami/nats-exporter/0/debian-11/docker-compose.yml
@@ -1,6 +1,5 @@
 version: '2'
 services:
-  # [TEST]
   nats-exporter:
     image: docker.io/bitnami/nats-exporter:0
     ports:


### PR DESCRIPTION
Signed-off-by: FraPazGal <fdepaz@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

The main objective of this PR is to publish our Bitnami NATS Exporter container using VMware Image Builder. In order to do that, several changes are included:

- Increasing the existing test coverage of the asset by adding Goss tests.
- Update verify and publish VIB pipeline's definitions.

### Benefits

- Ensuring higher quality of the container catalog.
- Increased pool of assets completely handled by VMware Image Builder.

### Possible drawbacks

Automated tests could introduce additional flakiness to the CI/CD. 

### Applicable issues

NA

Tested in:
- Recent action run: https://github.com/bitnami/containers/actions/runs/4723915016