### PR TITLE
[bitnami/redis-exporter] Add VIB tests

### DIFF
--- a/.vib/redis-exporter/goss/goss.yaml
+++ b/.vib/redis-exporter/goss/goss.yaml
@@ -1,0 +1,9 @@
+gossfile:
+  # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-app-version.yaml: {}
+  ../../common/goss/templates/check-binaries.yaml: {}
+  ../../common/goss/templates/check-broken-symlinks.yaml: {}
+  ../../common/goss/templates/check-ca-certs.yaml: {}
+  ../../common/goss/templates/check-linked-libraries.yaml: {}
+  ../../common/goss/templates/check-sed-in-place.yaml: {}
+  ../../common/goss/templates/check-spdx.yaml: {}

--- a/.vib/redis-exporter/goss/vars.yaml
+++ b/.vib/redis-exporter/goss/vars.yaml
@@ -1,0 +1,6 @@
+binaries:
+  - redis_exporter
+root_dir: /opt/bitnami
+version:
+  bin_name: redis_exporter
+  flag: -version

--- a/.vib/redis-exporter/vib-publish.json
+++ b/.vib/redis-exporter/vib-publish.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{VIB_ENV_CONTAINER_URL}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyJ0YWlsIiwgIi1mIiwgIi9kZXYvbnVsbCJd"
   },
   "phases": {
     "package": {
@@ -77,9 +78,24 @@
               "url": "{VIB_ENV_PACKAGES_JSON_URL}",
               "path": "/{VIB_ENV_PATH}",
               "authn": {
-                  "header": "Authorization",
-                  "token": "Bearer {VIB_ENV_GITHUB_TOKEN}"
-                }
+                "header": "Authorization",
+                "token": "Bearer {VIB_ENV_GITHUB_TOKEN}"
+              }
+            }
+          }
+        },
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "redis-exporter/goss/goss.yaml",
+            "vars_file": "redis-exporter/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-redis-exporter"
+              }
             }
           }
         }

--- a/.vib/redis-exporter/vib-verify.json
+++ b/.vib/redis-exporter/vib-verify.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyJ0YWlsIiwgIi1mIiwgIi9kZXYvbnVsbCJd"
   },
   "phases": {
     "package": {
@@ -45,6 +46,21 @@
             "package_type": [
               "OS"
             ]
+          }
+        },
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "redis-exporter/goss/goss.yaml",
+            "vars_file": "redis-exporter/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-redis-exporter"
+              }
+            }
           }
         }
       ]

--- a/bitnami/redis-exporter/1/debian-11/docker-compose.yml
+++ b/bitnami/redis-exporter/1/debian-11/docker-compose.yml
@@ -1,6 +1,5 @@
 version: '2'
 
 services:
-  # [TEST]
   redis-exporter:
     image: docker.io/bitnami/redis-exporter:1

--- a/bitnami/redis-exporter/1/debian-11/docker-compose.yml
+++ b/bitnami/redis-exporter/1/debian-11/docker-compose.yml
@@ -1,5 +1,6 @@
 version: '2'
 
 services:
+  # [TEST]
   redis-exporter:
     image: docker.io/bitnami/redis-exporter:1


### PR DESCRIPTION
Signed-off-by: FraPazGal <fdepaz@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

The main objective of this PR is to publish our Bitnami NGINX Exporter container using VMware Image Builder. In order to do that, several changes are included:

- Increasing the existing test coverage of the asset by adding Goss tests.
- Update verify and publish VIB pipeline's definitions.

### Benefits

- Ensuring higher quality of the container catalog.
- Increased pool of assets completely handled by VMware Image Builder.

### Possible drawbacks

Automated tests could introduce additional flakiness to the CI/CD. 

### Applicable issues

NA

Tested in:
- Recent action run: https://github.com/bitnami/containers/actions/runs/4724122932