### PR TITLE
fix(pgbouncer): ini-set ignore-inline-comments

### DIFF
--- a/bitnami/pgbouncer/1/debian-11/rootfs/opt/bitnami/scripts/libpgbouncer.sh
+++ b/bitnami/pgbouncer/1/debian-11/rootfs/opt/bitnami/scripts/libpgbouncer.sh
@@ -267,7 +267,7 @@ pgbouncer_initialize() {
             local key value
             key="$(awk -F: '{print $1}' <<<"$pair")"
             value="$(awk -F: '{print $2}' <<<"$pair")"
-            ! is_empty_value "${value}" && ini-file set --section "pgbouncer" --key "${key}" --value "${value}" "$PGBOUNCER_CONF_FILE"
+            ! is_empty_value "${value}" && ini-file set --ignore-inline-comments --section "pgbouncer" --key "${key}" --value "${value}" "$PGBOUNCER_CONF_FILE"
         done
         if [[ "$PGBOUNCER_CLIENT_TLS_SSLMODE" != "disable" ]]; then
             ini-file set --section "pgbouncer" --key "client_tls_cert_file" --value "$PGBOUNCER_CLIENT_TLS_CERT_FILE" "$PGBOUNCER_CONF_FILE"


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Ignore ini-file inline comments in pgbouncer.ini when setting up pgbouncer.ini

### Benefits

Less errors in server logs when pgbouncer options contains semicolons.

### Possible drawbacks

Can't find any.

### Additional information

I use following option to preserve role in connection to postgresql server.
```
PGBOUNCER_SERVER_RESET_QUERY="RESET ALL; DEALLOCATE ALL; CLOSE ALL; UNLISTEN *; SELECT pg_advisory_unlock_all(); DISCARD PLANS; DISCARD SEQUENCES; DISCARD TEMP;" 
```
As it contains semicolons, the ini-file tool adds backticks to the value in pgbouncer.ini
```
server_reset_query=`RESET ALL; DEALLOCATE ALL; CLOSE ALL; UNLISTEN *; SELECT pg_advisory_unlock_all(); DISCARD PLANS; DISCARD SEQUENCES; DISCARD TEMP;`
```
This leads to lots of errors in postgresql logs like
```
2023-04-15 12:00:07 UTC:10.50.26.45(42768):v-k8s-user-yoa59pGd4pJ7KGt5Xxzb-1681559074@db:[28518]:STATEMENT: `RESET ALL; DEALLOCATE ALL; CLOSE ALL; UNLISTEN *; SELECT pg_advisory_unlock_all(); DISCARD PLANS; DISCARD SEQUENCES; DISCARD TEMP;`
2023-04-15 12:00:07 UTC:10.50.32.95(57318):v-k8s-user-anrjUPk3Q62lyREdcQyM-1681472711@db:[27879]:ERROR: syntax error at or near "`" at character 1
```

This described in https://github.com/bitnami/ini-file/issues/7
I've tested this locally, and this PR fixes the issue.