### PR TITLE
[bitnami/minio] Fix the image startup problem

### DIFF
--- a/bitnami/minio/2023/debian-11/rootfs/opt/bitnami/scripts/libminioclient.sh
+++ b/bitnami/minio/2023/debian-11/rootfs/opt/bitnami/scripts/libminioclient.sh
@@ -14,7 +14,7 @@
 #   Boolean
 minio_client_bucket_exists() {
     local -r bucket_name="${1:?bucket required}"
-    if minio_client_execute ls "${bucket_name}" >/dev/null 2>&1; then
+    if minio_client_execute stat "${bucket_name}" >/dev/null 2>&1; then
         true
     else
         false


### PR DESCRIPTION
Image startup scans all the first-level directories of bucket through mc ls to determine whether bucket exists or skips. In a normal scenario, this is not a problem, but when there are a large number of files in the first-level directory of bucket, it will become a disaster. In my scene, there are millions or even tens of millions of files in a first-level directory under bucket. When the image is restarted, it will take up a lot of disk io. If the underlying use is file storage such as nas, this will be more intolerable

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
