### PR TITLE
[bitnami/harbor-registryctl] Add VIB tests

### DIFF
--- a/.vib/harbor-registryctl/goss/goss.yaml
+++ b/.vib/harbor-registryctl/goss/goss.yaml
@@ -1,6 +1,6 @@
 gossfile:
   # Goss tests exclusive to the current container
-  ../../harbor-registryctl/goss/harbor-registryctl.yaml: { }
+  ../../harbor-registryctl/goss/harbor-registryctl.yaml: {}
   # Load scripts from .vib/common/goss/templates
   ../../common/goss/templates/check-binaries.yaml: {}
   ../../common/goss/templates/check-broken-symlinks.yaml: {}

--- a/.vib/harbor-registryctl/goss/goss.yaml
+++ b/.vib/harbor-registryctl/goss/goss.yaml
@@ -1,0 +1,11 @@
+gossfile:
+  # Goss tests exclusive to the current container
+  ../../harbor-registryctl/goss/harbor-registryctl.yaml: { }
+  # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-binaries.yaml: {}
+  ../../common/goss/templates/check-broken-symlinks.yaml: {}
+  ../../common/goss/templates/check-ca-certs.yaml: {}
+  ../../common/goss/templates/check-directories.yaml: {}
+  ../../common/goss/templates/check-linked-libraries.yaml: {}
+  ../../common/goss/templates/check-sed-in-place.yaml: {}
+  ../../common/goss/templates/check-spdx.yaml: {}

--- a/.vib/harbor-registryctl/goss/goss.yaml
+++ b/.vib/harbor-registryctl/goss/goss.yaml
@@ -2,6 +2,7 @@ gossfile:
   # Goss tests exclusive to the current container
   ../../harbor-registryctl/goss/harbor-registryctl.yaml: {}
   # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-app-version.yaml: {}
   ../../common/goss/templates/check-binaries.yaml: {}
   ../../common/goss/templates/check-broken-symlinks.yaml: {}
   ../../common/goss/templates/check-ca-certs.yaml: {}

--- a/.vib/harbor-registryctl/goss/harbor-registryctl.yaml
+++ b/.vib/harbor-registryctl/goss/harbor-registryctl.yaml
@@ -15,11 +15,9 @@ file:
     mode: "0775"
     owner: harbor
     filetype: directory
+  /opt/bitnami/harbor-registryctl/bin/swagger:
+    exists: false
 command:
-  # Ensure swagger binary doesn't exist
-  check-swagger-binary:
-    exec: ls /opt/bitnami/harbor-registryctl/bin/swagger 2>/dev/null
-    exit-status: 2
   # Ensure a set of directories exist and the non-root user has write privileges to them
   check-directories-exist-with-user:
     exec: ls -dl /etc/ssl/certs /etc/pki/tls/certs/ 2>/dev/null | grep "drwxrwxr-x.*harbor"

--- a/.vib/harbor-registryctl/goss/harbor-registryctl.yaml
+++ b/.vib/harbor-registryctl/goss/harbor-registryctl.yaml
@@ -13,3 +13,11 @@ command:
   check-permissions-system-certs:
     exec: ls -l /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.trust.crt /etc/ssl/certs/ca-certificates.crt 2>/dev/null | grep ".*-rw-rw-r--.*harbor"
     exit-status: 0
+  check-harbor-registryctl-binary:
+    exec: harbor_registryctl --help
+    exit-status: 0
+  check-app-version:
+    exec: registry --version | grep -o "[0-9]*\.[0-9]*\.[0-9]"
+    exit-status: 0
+    stdout:
+      - {{ .Env.APP_VERSION }}

--- a/.vib/harbor-registryctl/goss/harbor-registryctl.yaml
+++ b/.vib/harbor-registryctl/goss/harbor-registryctl.yaml
@@ -4,10 +4,21 @@ group:
 user:
   harbor:
     exists: true
+file:
+  /var/lib/registry:
+    exists: true
+    mode: "0775"
+    owner: harbor
+    filetype: directory
+  /storage:
+    exists: true
+    mode: "0775"
+    owner: harbor
+    filetype: directory
 command:
   # Ensure a set of directories exist and the non-root user has write privileges to them
   check-directories-exist-with-user:
-    exec: ls -dl /etc/ssl/certs /etc/pki/tls/certs/ /var/lib/registry /storage 2>/dev/null | grep "drwxrwxr-x.*harbor"
+    exec: ls -dl /etc/ssl/certs /etc/pki/tls/certs/ 2>/dev/null | grep "drwxrwxr-x.*harbor"
     exit-status: 0
   # Ensure permissions for Internal TLS
   check-permissions-system-certs:

--- a/.vib/harbor-registryctl/goss/harbor-registryctl.yaml
+++ b/.vib/harbor-registryctl/goss/harbor-registryctl.yaml
@@ -1,0 +1,15 @@
+group:
+  harbor:
+    exists: true
+user:
+  harbor:
+    exists: true
+command:
+  # Ensure a set of directories exist and the non-root user has write privileges to them
+  check-directories-exist-with-user:
+    exec: ls -dl /etc/ssl/certs /etc/pki/tls/certs/ /var/lib/registry /storage 2>/dev/null | grep "drwxrwxr-x.*harbor"
+    exit-status: 0
+  # Ensure permissions for Internal TLS
+  check-permissions-system-certs:
+    exec: ls -l /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.trust.crt /etc/ssl/certs/ca-certificates.crt 2>/dev/null | grep ".*-rw-rw-r--.*harbor"
+    exit-status: 0

--- a/.vib/harbor-registryctl/goss/harbor-registryctl.yaml
+++ b/.vib/harbor-registryctl/goss/harbor-registryctl.yaml
@@ -16,6 +16,10 @@ file:
     owner: harbor
     filetype: directory
 command:
+  # Ensure swagger binary doesn't exist
+  check-swagger-binary:
+    exec: ls /opt/bitnami/harbor-registryctl/bin/swagger 2>/dev/null
+    exit-status: 2
   # Ensure a set of directories exist and the non-root user has write privileges to them
   check-directories-exist-with-user:
     exec: ls -dl /etc/ssl/certs /etc/pki/tls/certs/ 2>/dev/null | grep "drwxrwxr-x.*harbor"

--- a/.vib/harbor-registryctl/goss/harbor-registryctl.yaml
+++ b/.vib/harbor-registryctl/goss/harbor-registryctl.yaml
@@ -31,8 +31,3 @@ command:
   check-harbor-registryctl-binary:
     exec: harbor_registryctl --help
     exit-status: 0
-  check-app-version:
-    exec: registry --version | grep -o "[0-9]*\.[0-9]*\.[0-9]"
-    exit-status: 0
-    stdout:
-      - {{ .Env.APP_VERSION }}

--- a/.vib/harbor-registryctl/goss/vars.yaml
+++ b/.vib/harbor-registryctl/goss/vars.yaml
@@ -1,0 +1,9 @@
+binaries:
+  - yq
+  - harbor-registry
+  - harbor_registryctl
+directories:
+  - paths:
+      - /etc/registry
+      - /etc/registryctl
+root_dir: /opt/bitnami

--- a/.vib/harbor-registryctl/goss/vars.yaml
+++ b/.vib/harbor-registryctl/goss/vars.yaml
@@ -6,4 +6,7 @@ directories:
   - paths:
       - /etc/registry
       - /etc/registryctl
+version:
+  bin_name: registry
+  flag: --version
 root_dir: /opt/bitnami

--- a/.vib/harbor-registryctl/goss/vars.yaml
+++ b/.vib/harbor-registryctl/goss/vars.yaml
@@ -1,6 +1,6 @@
 binaries:
   - yq
-  - harbor-registry
+  - registry
   - harbor_registryctl
 directories:
   - paths:

--- a/.vib/harbor-registryctl/vib-publish.json
+++ b/.vib/harbor-registryctl/vib-publish.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{VIB_ENV_CONTAINER_URL}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyJ0YWlsIiwgIi1mIiwgIi9kZXYvbnVsbCJd"
   },
   "phases": {
     "package": {
@@ -33,6 +34,21 @@
     },
     "verify": {
       "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "harbor-registryctl/goss/goss.yaml",
+            "vars_file": "harbor-registryctl/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-harbor-registryctl"
+              }
+            }
+          }
+        },
         {
           "action_id": "trivy",
           "params": {

--- a/.vib/harbor-registryctl/vib-verify.json
+++ b/.vib/harbor-registryctl/vib-verify.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyJ0YWlsIiwgIi1mIiwgIi9kZXYvbnVsbCJd"
   },
   "phases": {
     "package": {
@@ -29,6 +30,21 @@
     },
     "verify": {
       "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "harbor-registryctl/goss/goss.yaml",
+            "vars_file": "harbor-registryctl/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-harbor-registryctl"
+              }
+            }
+          }
+        },
         {
           "action_id": "trivy",
           "params": {

--- a/bitnami/harbor-registryctl/2/debian-11/docker-compose.yml
+++ b/bitnami/harbor-registryctl/2/debian-11/docker-compose.yml
@@ -2,7 +2,6 @@ version: '2'
 
 services:
   harbor-registryctl:
-    # New change
     image: docker.io/bitnami/harbor-registryctl:2
     ports:
       - 80:8080

--- a/bitnami/harbor-registryctl/2/debian-11/docker-compose.yml
+++ b/bitnami/harbor-registryctl/2/debian-11/docker-compose.yml
@@ -2,6 +2,7 @@ version: '2'
 
 services:
   harbor-registryctl:
+    # New change
     image: docker.io/bitnami/harbor-registryctl:2
     ports:
       - 80:8080


### PR DESCRIPTION
### Description of the change

The main objective of this PR is to publish our Bitnami Harbor-registryctl container using VMware Image Builder. In order to do that, several changes are included:

- Increasing the existing test coverage of the asset by adding Goss tests.
- Update verify and publish VIB pipeline's definitions.

### Benefits

- Ensuring higher quality of the container catalog.
- Increased pool of assets completely handled by VMware Image Builder.

### Possible drawbacks

Automated tests could introduce additional flakiness to the CI/CD.

### Applicable issues

NA
