### PR TITLE
[bitnami/alertmanager] Add VIB tests

### DIFF
--- a/.vib/alertmanager/goss/alertmanager.yaml
+++ b/.vib/alertmanager/goss/alertmanager.yaml
@@ -1,0 +1,4 @@
+command:
+  check-app-run:
+    exec: timeout --preserve-status 5 /opt/bitnami/alertmanager/bin/alertmanager --config.file=/opt/bitnami/alertmanager/conf/config.yml --storage.path=/opt/bitnami/alertmanager/data
+    exit-status: 0

--- a/.vib/alertmanager/goss/alertmanager.yaml
+++ b/.vib/alertmanager/goss/alertmanager.yaml
@@ -1,9 +1,0 @@
-command:
-  check-app-version:
-    exec: alertmanager --version | grep -o -m 1 "[0-9]*\.[0-9]*\.[0-9]"
-    exit-status: 0
-    stdout:
-      - {{ .Env.APP_VERSION }}
-  check-binary-run:
-    exec: amtool --help
-    exit-status: 0

--- a/.vib/alertmanager/goss/alertmanager.yaml
+++ b/.vib/alertmanager/goss/alertmanager.yaml
@@ -1,0 +1,9 @@
+command:
+  check-app-version:
+    exec: alertmanager --version | grep -o -m 1 "[0-9]*\.[0-9]*\.[0-9]
+    exit-status: 0
+    stdout:
+      - { { .Env.APP_VERSION } }
+  check-binary-run:
+    exec: amtool --help
+    exit-status: 0

--- a/.vib/alertmanager/goss/alertmanager.yaml
+++ b/.vib/alertmanager/goss/alertmanager.yaml
@@ -1,9 +1,9 @@
 command:
   check-app-version:
-    exec: alertmanager --version | grep -o -m 1 "[0-9]*\.[0-9]*\.[0-9]
+    exec: alertmanager --version | grep -o -m 1 "[0-9]*\.[0-9]*\.[0-9]"
     exit-status: 0
     stdout:
-      - { { .Env.APP_VERSION } }
+      - {{ .Env.APP_VERSION }}
   check-binary-run:
     exec: amtool --help
     exit-status: 0

--- a/.vib/alertmanager/goss/goss.yaml
+++ b/.vib/alertmanager/goss/goss.yaml
@@ -6,7 +6,6 @@ gossfile:
   ../../common/goss/templates/check-binaries.yaml: {}
   ../../common/goss/templates/check-broken-symlinks.yaml: {}
   ../../common/goss/templates/check-ca-certs.yaml: {}
-  ../../common/goss/templates/check-files.yaml: {}
   ../../common/goss/templates/check-linked-libraries.yaml: {}
   ../../common/goss/templates/check-sed-in-place.yaml: {}
   ../../common/goss/templates/check-spdx.yaml: {}

--- a/.vib/alertmanager/goss/goss.yaml
+++ b/.vib/alertmanager/goss/goss.yaml
@@ -1,10 +1,11 @@
 gossfile:
+  # Goss tests exclusive to the current container
+  ../../alertmanager/goss/alertmanager.yaml: { }
   # Load scripts from .vib/common/goss/templates
   ../../common/goss/templates/check-app-version.yaml: {}
   ../../common/goss/templates/check-binaries.yaml: {}
   ../../common/goss/templates/check-broken-symlinks.yaml: {}
   ../../common/goss/templates/check-ca-certs.yaml: {}
-  ../../common/goss/templates/check-directories.yaml: {}
   ../../common/goss/templates/check-files.yaml: {}
   ../../common/goss/templates/check-linked-libraries.yaml: {}
   ../../common/goss/templates/check-sed-in-place.yaml: {}

--- a/.vib/alertmanager/goss/goss.yaml
+++ b/.vib/alertmanager/goss/goss.yaml
@@ -8,5 +8,5 @@ gossfile:
   ../../common/goss/templates/check-directories.yaml: {}
   ../../common/goss/templates/check-files.yaml: {}
   ../../common/goss/templates/check-linked-libraries.yaml: {}
-  ../../common/goss/templates/check-spdx.yaml: {}
   ../../common/goss/templates/check-sed-in-place.yaml: {}
+  ../../common/goss/templates/check-spdx.yaml: {}

--- a/.vib/alertmanager/goss/goss.yaml
+++ b/.vib/alertmanager/goss/goss.yaml
@@ -1,6 +1,6 @@
 gossfile:
   # Goss tests exclusive to the current container
-  ../../alertmanager/goss/alertmanager.yaml: { }
+  ../../alertmanager/goss/alertmanager.yaml: {}
   # Load scripts from .vib/common/goss/templates
   ../../common/goss/templates/check-binaries.yaml: {}
   ../../common/goss/templates/check-broken-symlinks.yaml: {}

--- a/.vib/alertmanager/goss/goss.yaml
+++ b/.vib/alertmanager/goss/goss.yaml
@@ -1,7 +1,6 @@
 gossfile:
-  # Goss tests exclusive to the current container
-  ../../alertmanager/goss/alertmanager.yaml: {}
   # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-app-version.yaml: {}
   ../../common/goss/templates/check-binaries.yaml: {}
   ../../common/goss/templates/check-broken-symlinks.yaml: {}
   ../../common/goss/templates/check-ca-certs.yaml: {}

--- a/.vib/alertmanager/goss/goss.yaml
+++ b/.vib/alertmanager/goss/goss.yaml
@@ -1,0 +1,12 @@
+gossfile:
+  # Goss tests exclusive to the current container
+  ../../alertmanager/goss/alertmanager.yaml: { }
+  # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-binaries.yaml: {}
+  ../../common/goss/templates/check-broken-symlinks.yaml: {}
+  ../../common/goss/templates/check-ca-certs.yaml: {}
+  ../../common/goss/templates/check-directories.yaml: {}
+  ../../common/goss/templates/check-files.yaml: {}
+  ../../common/goss/templates/check-linked-libraries.yaml: {}
+  ../../common/goss/templates/check-spdx.yaml: {}
+  ../../common/goss/templates/check-sed-in-place.yaml: {}

--- a/.vib/alertmanager/goss/vars.yaml
+++ b/.vib/alertmanager/goss/vars.yaml
@@ -1,9 +1,6 @@
 binaries:
   - alertmanager
   - amtool
-files:
-  - paths:
-      - /opt/bitnami/alertmanager/conf/config.yml
 version:
   bin_name: alertmanager
   flag: --version

--- a/.vib/alertmanager/goss/vars.yaml
+++ b/.vib/alertmanager/goss/vars.yaml
@@ -1,10 +1,6 @@
 binaries:
   - alertmanager
   - amtool
-directories:
-  - paths:
-      - /opt/bitnami/alertmanager
-      - /opt/bitnami/alertmanager/conf
 files:
   - paths:
       - /opt/bitnami/alertmanager/conf/config.yml

--- a/.vib/alertmanager/goss/vars.yaml
+++ b/.vib/alertmanager/goss/vars.yaml
@@ -8,4 +8,7 @@ directories:
 files:
   - paths:
       - /opt/bitnami/alertmanager/conf/config.yml
+version:
+  bin_name: alertmanager
+  flag: --version
 root_dir: /opt/bitnami

--- a/.vib/alertmanager/goss/vars.yaml
+++ b/.vib/alertmanager/goss/vars.yaml
@@ -1,0 +1,11 @@
+binaries:
+  - alertmanager
+  - amtool
+directories:
+  - paths:
+      - /opt/bitnami/alertmanager
+      - /opt/bitnami/alertmanager/conf
+files:
+  - paths:
+      - /opt/bitnami/alertmanager/conf/config.yml
+root_dir: /opt/bitnami

--- a/.vib/alertmanager/vib-publish.json
+++ b/.vib/alertmanager/vib-publish.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{VIB_ENV_CONTAINER_URL}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyJ0YWlsIiwgIi1mIiwgIi9kZXYvbnVsbCJd"
   },
   "phases": {
     "package": {
@@ -33,6 +34,21 @@
     },
     "verify": {
       "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "alertmanager/goss/goss.yaml",
+            "vars_file": "alertmanager/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-alertmanager"
+              }
+            }
+          }
+        },
         {
           "action_id": "trivy",
           "params": {

--- a/.vib/alertmanager/vib-verify.json
+++ b/.vib/alertmanager/vib-verify.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyJ0YWlsIiwgIi1mIiwgIi9kZXYvbnVsbCJd"
   },
   "phases": {
     "package": {
@@ -29,6 +30,21 @@
     },
     "verify": {
       "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "alertmanager/goss/goss.yaml",
+            "vars_file": "alertmanager/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-alertmanager"
+              }
+            }
+          }
+        },
         {
           "action_id": "trivy",
           "params": {

--- a/bitnami/alertmanager/0/debian-11/docker-compose.yml
+++ b/bitnami/alertmanager/0/debian-11/docker-compose.yml
@@ -2,7 +2,6 @@ version: '2'
 
 services:
   alertmanager:
-    # New change
     image: docker.io/bitnami/alertmanager:0
     ports:
       - '9093:9093'

--- a/bitnami/alertmanager/0/debian-11/docker-compose.yml
+++ b/bitnami/alertmanager/0/debian-11/docker-compose.yml
@@ -2,6 +2,7 @@ version: '2'
 
 services:
   alertmanager:
+    # New change
     image: docker.io/bitnami/alertmanager:0
     ports:
       - '9093:9093'


### PR DESCRIPTION
### Description of the change

The main objective of this PR is to publish our Bitnami Alertmanager container using VMware Image Builder. In order to do that, several changes are included:

- Increasing the existing test coverage of the asset by adding Goss tests.
- Update verify and publish VIB pipeline's definitions.

### Benefits

- Ensuring higher quality of the container catalog.
- Increased pool of assets completely handled by VMware Image Builder.

### Possible drawbacks

Automated tests could introduce additional flakiness to the CI/CD.

### Applicable issues

NA

### Additional information

The following command isn't tested:
```
/opt/bitnami/alertmanager/bin/alertmanager --config.file=/opt/bitnami/alertmanager/conf/config.yml --storage.path=/opt/bitnami/alertmanager/data
```
since it doesn't finish and it stays running all the time.
