### PR TITLE
[bitnami/*] Remove gosu tests

### DIFF
--- a/.vib/apache/goss/vars.yaml
+++ b/.vib/apache/goss/vars.yaml
@@ -1,6 +1,5 @@
 binaries:
   - httpd
-  - gosu
   - render-template
 files:
   - paths:

--- a/.vib/cassandra/goss/vars.yaml
+++ b/.vib/cassandra/goss/vars.yaml
@@ -3,7 +3,6 @@ binaries:
   - cqlsh
   - python
   - java
-  - gosu
   - yq
 files:
   - mode: "0755"

--- a/.vib/codeigniter/goss/vars.yaml
+++ b/.vib/codeigniter/goss/vars.yaml
@@ -1,7 +1,6 @@
 binaries:
   - composer
   - php-fpm
-  - gosu
   - mysql
 directories:
   - mode: "0775"

--- a/.vib/consul/goss/vars.yaml
+++ b/.vib/consul/goss/vars.yaml
@@ -1,6 +1,5 @@
 binaries:
   - consul
-  - gosu
   - render-template
 directories:
   - mode: "0775"

--- a/.vib/couchdb/goss/vars.yaml
+++ b/.vib/couchdb/goss/vars.yaml
@@ -2,7 +2,6 @@ binaries:
   - couchdb
   - couchjs
   - erl
-  - gosu
   - ini-file
   - wait-for-port
 directories:

--- a/.vib/elasticsearch/goss/vars.yaml
+++ b/.vib/elasticsearch/goss/vars.yaml
@@ -1,6 +1,5 @@
 binaries:
   - elasticsearch
-  - gosu
   - java
   - yq
 directories:

--- a/.vib/express/goss/vars.yaml
+++ b/.vib/express/goss/vars.yaml
@@ -1,6 +1,5 @@
 binaries:
   - express
-  - gosu
   - node
   - python
   - wait-for-port

--- a/.vib/git/goss/vars.yaml
+++ b/.vib/git/goss/vars.yaml
@@ -1,6 +1,5 @@
 binaries:
   - git
-  - gosu
 root_dir: /opt/bitnami
 version:
   bin_name: git

--- a/.vib/gitlab-runner-helper/goss/vars.yaml
+++ b/.vib/gitlab-runner-helper/goss/vars.yaml
@@ -1,7 +1,6 @@
 binaries:
   - gitlab-runner-helper
   - gitlab-runner-build
-  - gosu
 root_dir: /opt/bitnami
 version:
   bin_name: gitlab-runner-helper

--- a/.vib/gitlab-runner/goss/vars.yaml
+++ b/.vib/gitlab-runner/goss/vars.yaml
@@ -1,6 +1,5 @@
 binaries:
   - gitlab-runner
-  - gosu
 root_dir: /opt/bitnami
 version:
   bin_name: gitlab-runner

--- a/.vib/influxdb/goss/vars.yaml
+++ b/.vib/influxdb/goss/vars.yaml
@@ -1,7 +1,6 @@
 binaries:
   - influx
   - influxd
-  - gosu
   - wait-for-port
 directories:
   - mode: "0775"

--- a/.vib/java/goss/vars.yaml
+++ b/.vib/java/goss/vars.yaml
@@ -1,6 +1,5 @@
 binaries:
   - java
-  - gosu
 files:
   - paths:
       - /opt/bitnami/java/legal/java.base/LICENSE

--- a/.vib/jenkins-agent/goss/vars.yaml
+++ b/.vib/jenkins-agent/goss/vars.yaml
@@ -1,5 +1,4 @@
 binaries:
-  - gosu
   - java
 directories:
   - mode: "0775"

--- a/.vib/kafka/goss/vars.yaml
+++ b/.vib/kafka/goss/vars.yaml
@@ -1,5 +1,4 @@
 binaries:
-  - gosu
   - java
   - kafka-server-start.sh
   - render-template

--- a/.vib/ksql/goss/vars.yaml
+++ b/.vib/ksql/goss/vars.yaml
@@ -1,5 +1,4 @@
 binaries:
-  - gosu
   - java
   - ksql
 directories:

--- a/.vib/laravel/goss/vars.yaml
+++ b/.vib/laravel/goss/vars.yaml
@@ -1,5 +1,4 @@
 binaries:
-  - gosu
   - php
   - node
   - python

--- a/.vib/mariadb-galera/goss/vars.yaml
+++ b/.vib/mariadb-galera/goss/vars.yaml
@@ -2,7 +2,6 @@ binaries:
   - mysql
   - mysqld
   - ini-file
-  - gosu
 files:
   - mode: "0660"
     paths:

--- a/.vib/mariadb/goss/vars.yaml
+++ b/.vib/mariadb/goss/vars.yaml
@@ -1,5 +1,4 @@
 binaries:
-  - gosu
   - ini-file
   - mysql
 directories:

--- a/.vib/memcached/goss/vars.yaml
+++ b/.vib/memcached/goss/vars.yaml
@@ -1,5 +1,4 @@
 binaries:
-  - gosu
   - memcached
 directories:
   - mode: "0775"

--- a/.vib/mongodb-sharded/goss/vars.yaml
+++ b/.vib/mongodb-sharded/goss/vars.yaml
@@ -4,7 +4,6 @@ binaries:
   - yq
   - wait-for-port
   - render-template
-  - gosu
 files:
   - mode: "0664"
     paths:

--- a/.vib/mongodb/goss/vars.yaml
+++ b/.vib/mongodb/goss/vars.yaml
@@ -1,5 +1,4 @@
 binaries:
-  - gosu
   - mongod
   - mongosh
   - render-template

--- a/.vib/mysql/goss/vars.yaml
+++ b/.vib/mysql/goss/vars.yaml
@@ -1,5 +1,4 @@
 binaries:
-  - gosu
   - ini-file
   - mysql
   - mysql_config

--- a/.vib/nginx/goss/vars.yaml
+++ b/.vib/nginx/goss/vars.yaml
@@ -1,5 +1,4 @@
 binaries:
-  - gosu
   - nginx
   - render-template
 config_opts:

--- a/.vib/openldap/goss/vars.yaml
+++ b/.vib/openldap/goss/vars.yaml
@@ -2,7 +2,6 @@ backends:
   - mdb
   - monitor
 binaries:
-  - gosu
   - ldapsearch
   - slapd
 directories:

--- a/.vib/openresty/goss/vars.yaml
+++ b/.vib/openresty/goss/vars.yaml
@@ -1,5 +1,4 @@
 binaries:
-  - gosu
   - openresty
 directories:
   - mode: "0775"

--- a/.vib/percona-mysql/goss/vars.yaml
+++ b/.vib/percona-mysql/goss/vars.yaml
@@ -1,5 +1,4 @@
 binaries:
-  - gosu
   - ini-file
   - mysql
   - mysqld

--- a/.vib/pgbouncer/goss/vars.yaml
+++ b/.vib/pgbouncer/goss/vars.yaml
@@ -1,5 +1,4 @@
 binaries:
-  - gosu
   - ini-file
   - psql
   - pgbouncer

--- a/.vib/postgresql-repmgr/goss/vars.yaml
+++ b/.vib/postgresql-repmgr/goss/vars.yaml
@@ -1,5 +1,5 @@
 binaries:
-  - gosu
+
   - psql
   - pg_dump
   - pg_dumpall

--- a/.vib/postgresql-repmgr/goss/vars.yaml
+++ b/.vib/postgresql-repmgr/goss/vars.yaml
@@ -1,5 +1,4 @@
 binaries:
-
   - psql
   - pg_dump
   - pg_dumpall

--- a/.vib/postgresql/goss/vars.yaml
+++ b/.vib/postgresql/goss/vars.yaml
@@ -1,5 +1,4 @@
 binaries:
-
   - postgres
   - psql
   - pg_dump

--- a/.vib/postgresql/goss/vars.yaml
+++ b/.vib/postgresql/goss/vars.yaml
@@ -1,5 +1,5 @@
 binaries:
-  - gosu
+
   - postgres
   - psql
   - pg_dump

--- a/.vib/rails/goss/vars.yaml
+++ b/.vib/rails/goss/vars.yaml
@@ -1,5 +1,4 @@
 binaries:
-  - gosu
   - mysql
   - node
   - python

--- a/.vib/redis/goss/vars.yaml
+++ b/.vib/redis/goss/vars.yaml
@@ -1,5 +1,4 @@
 binaries:
-  - gosu
   - redis-cli
   - redis-server
   - wait-for-port

--- a/.vib/redmine/goss/vars.yaml
+++ b/.vib/redmine/goss/vars.yaml
@@ -1,5 +1,5 @@
 binaries:
-  - gosu
+
   - mysql
   - psql
   - ruby

--- a/.vib/redmine/goss/vars.yaml
+++ b/.vib/redmine/goss/vars.yaml
@@ -1,5 +1,4 @@
 binaries:
-
   - mysql
   - psql
   - ruby

--- a/.vib/reportserver/goss/vars.yaml
+++ b/.vib/reportserver/goss/vars.yaml
@@ -1,5 +1,4 @@
 binaries:
-  - gosu
   - java
   - mysql
   - render-template

--- a/.vib/solr/goss/vars.yaml
+++ b/.vib/solr/goss/vars.yaml
@@ -1,5 +1,4 @@
 binaries:
-  - gosu
   - java
   - solr
 directories:

--- a/.vib/sonarqube/goss/vars.yaml
+++ b/.vib/sonarqube/goss/vars.yaml
@@ -1,5 +1,4 @@
 binaries:
-  - gosu
   - java
   - psql
 directories:

--- a/.vib/tomcat/goss/vars.yaml
+++ b/.vib/tomcat/goss/vars.yaml
@@ -1,5 +1,4 @@
 binaries:
-  - gosu
   - java
   - render-template
 directories:

--- a/.vib/wordpress/goss/vars.yaml
+++ b/.vib/wordpress/goss/vars.yaml
@@ -1,6 +1,5 @@
 binaries:
   - apachectl
-  - gosu
   - mariadb
   - php
   - render-template

--- a/.vib/zookeeper/goss/vars.yaml
+++ b/.vib/zookeeper/goss/vars.yaml
@@ -1,5 +1,4 @@
 binaries:
-  - gosu
   - java
   - wait-for-port
   - zkServer.sh


### PR DESCRIPTION
### Description of the change

Remove specifics checks for `gosu` now that we are about to deprecate this tool from our images.

### Benefits

The tests do not fail.

### Possible drawbacks

None.

### Applicable issues

NA

### Additional information

NA
