### PR TITLE
[bitnami/chartmuseum] Add VIB tests

### DIFF
--- a/.vib/chartmuseum/goss/chartmuseum.yaml
+++ b/.vib/chartmuseum/goss/chartmuseum.yaml
@@ -4,11 +4,6 @@ group:
 user:
   harbor:
     exists: true
-file:
-  /bitnami/data:
-    exists: true
-    mode: "0775"
-    filetype: directory
 command:
   # Ensure a set of directories exist and the non-root user has write privileges to them
   check-directories-exist-with-user:

--- a/.vib/chartmuseum/goss/chartmuseum.yaml
+++ b/.vib/chartmuseum/goss/chartmuseum.yaml
@@ -8,12 +8,11 @@ file:
   /bitnami/data:
     exists: true
     mode: "0775"
-    owner: harbor
     filetype: directory
 command:
   # Ensure a set of directories exist and the non-root user has write privileges to them
   check-directories-exist-with-user:
-    exec: ls -dl /etc/ssl/certs /etc/pki/tls/certs/ 2>/dev/null | grep "drwxrwxr-x.*harbor"
+    exec: ls -dl /etc/ssl/certs /etc/pki/tls/certs/ 2>/dev/null | grep "drwxrwxr-x"
     exit-status: 0
   check-app-version:
     exec: chartmuseum --version | grep -o "[0-9]*\.[0-9]*\.[0-9]"

--- a/.vib/chartmuseum/goss/chartmuseum.yaml
+++ b/.vib/chartmuseum/goss/chartmuseum.yaml
@@ -1,0 +1,22 @@
+group:
+  harbor:
+    exists: true
+user:
+  harbor:
+    exists: true
+file:
+  /bitnami/data:
+    exists: true
+    mode: "0775"
+    owner: harbor
+    filetype: directory
+command:
+  # Ensure a set of directories exist and the non-root user has write privileges to them
+  check-directories-exist-with-user:
+    exec: ls -dl /etc/ssl/certs /etc/pki/tls/certs/ 2>/dev/null | grep "drwxrwxr-x.*harbor"
+    exit-status: 0
+  check-app-version:
+    exec: chartmuseum --version | grep -o "[0-9]*\.[0-9]*\.[0-9]"
+    exit-status: 0
+    stdout:
+      - {{ .Env.APP_VERSION }}

--- a/.vib/chartmuseum/goss/chartmuseum.yaml
+++ b/.vib/chartmuseum/goss/chartmuseum.yaml
@@ -14,8 +14,3 @@ command:
   check-directories-exist-with-user:
     exec: ls -dl /etc/ssl/certs /etc/pki/tls/certs/ 2>/dev/null | grep "drwxrwxr-x"
     exit-status: 0
-  check-app-version:
-    exec: chartmuseum --version | grep -o "[0-9]*\.[0-9]*\.[0-9]"
-    exit-status: 0
-    stdout:
-      - {{ .Env.APP_VERSION }}

--- a/.vib/chartmuseum/goss/goss.yaml
+++ b/.vib/chartmuseum/goss/goss.yaml
@@ -6,6 +6,7 @@ gossfile:
   ../../common/goss/templates/check-binaries.yaml: {}
   ../../common/goss/templates/check-broken-symlinks.yaml: {}
   ../../common/goss/templates/check-ca-certs.yaml: {}
+  ../../common/goss/templates/check-directories.yaml: {}
   ../../common/goss/templates/check-linked-libraries.yaml: {}
   ../../common/goss/templates/check-sed-in-place.yaml: {}
   ../../common/goss/templates/check-spdx.yaml: {}

--- a/.vib/chartmuseum/goss/goss.yaml
+++ b/.vib/chartmuseum/goss/goss.yaml
@@ -2,6 +2,7 @@ gossfile:
   # Goss tests exclusive to the current container
   ../../chartmuseum/goss/chartmuseum.yaml: {}
   # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-app-version.yaml: {}
   ../../common/goss/templates/check-binaries.yaml: {}
   ../../common/goss/templates/check-broken-symlinks.yaml: {}
   ../../common/goss/templates/check-ca-certs.yaml: {}

--- a/.vib/chartmuseum/goss/goss.yaml
+++ b/.vib/chartmuseum/goss/goss.yaml
@@ -1,0 +1,10 @@
+gossfile:
+  # Goss tests exclusive to the current container
+  ../../chartmuseum/goss/chartmuseum.yaml: {}
+  # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-binaries.yaml: {}
+  ../../common/goss/templates/check-broken-symlinks.yaml: {}
+  ../../common/goss/templates/check-ca-certs.yaml: {}
+  ../../common/goss/templates/check-linked-libraries.yaml: {}
+  ../../common/goss/templates/check-sed-in-place.yaml: {}
+  ../../common/goss/templates/check-spdx.yaml: {}

--- a/.vib/chartmuseum/goss/vars.yaml
+++ b/.vib/chartmuseum/goss/vars.yaml
@@ -1,5 +1,9 @@
 binaries:
   - chartmuseum
+directories:
+  - mode: "0775"
+    paths:
+      - /bitnami/data
 version:
   bin_name: chartmuseum
   flag: --version

--- a/.vib/chartmuseum/goss/vars.yaml
+++ b/.vib/chartmuseum/goss/vars.yaml
@@ -1,3 +1,6 @@
 binaries:
   - chartmuseum
+version:
+  bin_name: chartmuseum
+  flag: --version
 root_dir: /opt/bitnami

--- a/.vib/chartmuseum/goss/vars.yaml
+++ b/.vib/chartmuseum/goss/vars.yaml
@@ -1,0 +1,3 @@
+binaries:
+  - chartmuseum
+root_dir: /opt/bitnami

--- a/.vib/chartmuseum/vib-publish.json
+++ b/.vib/chartmuseum/vib-publish.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{VIB_ENV_CONTAINER_URL}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyJ0YWlsIiwgIi1mIiwgIi9kZXYvbnVsbCJd"
   },
   "phases": {
     "package": {
@@ -33,6 +34,21 @@
     },
     "verify": {
       "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "chartmuseum/goss/goss.yaml",
+            "vars_file": "chartmuseum/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-chartmuseum"
+              }
+            }
+          }
+        },
         {
           "action_id": "trivy",
           "params": {

--- a/.vib/chartmuseum/vib-verify.json
+++ b/.vib/chartmuseum/vib-verify.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyJ0YWlsIiwgIi1mIiwgIi9kZXYvbnVsbCJd"
   },
   "phases": {
     "package": {
@@ -29,6 +30,21 @@
     },
     "verify": {
       "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "chartmuseum/goss/goss.yaml",
+            "vars_file": "chartmuseum/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-chartmuseum"
+              }
+            }
+          }
+        },
         {
           "action_id": "trivy",
           "params": {

--- a/bitnami/chartmuseum/0/debian-11/docker-compose.yml
+++ b/bitnami/chartmuseum/0/debian-11/docker-compose.yml
@@ -1,7 +1,6 @@
 version: '2'
 services:
   chartmuseum:
-    # New change
     image: docker.io/bitnami/chartmuseum:0
     ports:
       - '8080:8080'

--- a/bitnami/chartmuseum/0/debian-11/docker-compose.yml
+++ b/bitnami/chartmuseum/0/debian-11/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '2'
 services:
   chartmuseum:
+    # New change
     image: docker.io/bitnami/chartmuseum:0
     ports:
       - '8080:8080'


### PR DESCRIPTION
### Description of the change

The main objective of this PR is to publish our Bitnami Chartmuseum container using VMware Image Builder. In order to do that, several changes are included:

- Increasing the existing test coverage of the asset by adding Goss tests.
- Update verify and publish VIB pipeline's definitions.

### Benefits

- Ensuring higher quality of the container catalog.
- Increased pool of assets completely handled by VMware Image Builder.

### Possible drawbacks

Automated tests could introduce additional flakiness to the CI/CD.

### Applicable issues

NA

### Additional information

The files dedicated to permissions for Internal TLS for CentOS are not checked since they are used for a specific distro and therefore, it is not a common behavior for all distros:
```
# Fix for CentOS Internal TLS
if [[ -f /etc/pki/tls/certs/ca-bundle.crt ]]; then
    chmod g+w /etc/pki/tls/certs/ca-bundle.crt
fi

if [[ -f /etc/pki/tls/certs/ca-bundle.trust.crt ]]; then
    chmod g+w /etc/pki/tls/certs/ca-bundle.trust.crt
fi
```
Code from postunpack.sh file.