### PR TITLE
[bitnami/jenkins] Add VIB tests

### DIFF
--- a/.vib/jenkins/goss/goss.yaml
+++ b/.vib/jenkins/goss/goss.yaml
@@ -2,10 +2,12 @@ gossfile:
   # Goss tests exclusive to the current container
   ../../jenkins/goss/jenkins.yaml: {}
   # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-app-version.yaml: {}
   ../../common/goss/templates/check-binaries.yaml: {}
   ../../common/goss/templates/check-broken-symlinks.yaml: {}
   ../../common/goss/templates/check-ca-certs.yaml: {}
   ../../common/goss/templates/check-directories.yaml: {}
+  ../../common/goss/templates/check-files.yaml: {}
   ../../common/goss/templates/check-linked-libraries.yaml: {}
   ../../common/goss/templates/check-sed-in-place.yaml: {}
   ../../common/goss/templates/check-spdx.yaml: {}

--- a/.vib/jenkins/goss/goss.yaml
+++ b/.vib/jenkins/goss/goss.yaml
@@ -6,7 +6,6 @@ gossfile:
   ../../common/goss/templates/check-broken-symlinks.yaml: {}
   ../../common/goss/templates/check-ca-certs.yaml: {}
   ../../common/goss/templates/check-directories.yaml: {}
-  ../../common/goss/templates/check-files.yaml: {}
   ../../common/goss/templates/check-linked-libraries.yaml: {}
   ../../common/goss/templates/check-sed-in-place.yaml: {}
   ../../common/goss/templates/check-spdx.yaml: {}

--- a/.vib/jenkins/goss/goss.yaml
+++ b/.vib/jenkins/goss/goss.yaml
@@ -1,6 +1,6 @@
 gossfile:
   # Goss tests exclusive to the current container
-  ../../jenkins/goss/jenkins.yaml: { }
+  ../../jenkins/goss/jenkins.yaml: {}
   # Load scripts from .vib/common/goss/templates
   ../../common/goss/templates/check-binaries.yaml: {}
   ../../common/goss/templates/check-broken-symlinks.yaml: {}

--- a/.vib/jenkins/goss/goss.yaml
+++ b/.vib/jenkins/goss/goss.yaml
@@ -1,0 +1,12 @@
+gossfile:
+  # Goss tests exclusive to the current container
+  ../../jenkins/goss/jenkins.yaml: { }
+  # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-binaries.yaml: {}
+  ../../common/goss/templates/check-broken-symlinks.yaml: {}
+  ../../common/goss/templates/check-ca-certs.yaml: {}
+  ../../common/goss/templates/check-directories.yaml: {}
+  ../../common/goss/templates/check-files.yaml: {}
+  ../../common/goss/templates/check-linked-libraries.yaml: {}
+  ../../common/goss/templates/check-sed-in-place.yaml: {}
+  ../../common/goss/templates/check-spdx.yaml: {}

--- a/.vib/jenkins/goss/jenkins.yaml
+++ b/.vib/jenkins/goss/jenkins.yaml
@@ -2,11 +2,6 @@ command:
   check-app-jar:
     exec: java -jar /opt/bitnami/jenkins/jenkins-plugin-manager.jar
     exit-status: 0
-  check-app-version:
-    exec: java -jar /opt/bitnami/jenkins/jenkins.war --version
-    exit-status: 0
-    stdout:              
-      - {{ .Env.APP_VERSION }}
 file:
   /opt/bitnami/jenkins/plugins.txt:
     exists: true

--- a/.vib/jenkins/goss/jenkins.yaml
+++ b/.vib/jenkins/goss/jenkins.yaml
@@ -2,10 +2,3 @@ command:
   check-app-jar:
     exec: java -jar /opt/bitnami/jenkins/jenkins-plugin-manager.jar
     exit-status: 0
-file:
-  /opt/bitnami/jenkins/plugins.txt:
-    exists: true
-    contains:
-      - "swarm"
-      - "matrix-auth"
-      - "authorize-project"

--- a/.vib/jenkins/goss/jenkins.yaml
+++ b/.vib/jenkins/goss/jenkins.yaml
@@ -1,9 +1,10 @@
 command:
   check-app-jar:
-    exec: java -jar /opt/bitnami/jenkins/jenkins-plugin-manager.jar --war /opt/bitnami/jenkins/jenkins.war --plugin-file /opt/bitnami/jenkins/plugins.txt -d /opt/bitnami/jenkins/plugins
+    exec: java -jar /opt/bitnami/jenkins/jenkins-plugin-manager.jar
     exit-status: 0
   check-app-version:
     exec: java -jar /opt/bitnami/jenkins/jenkins.war --version
+    exit-status: 0
     stdout:              
       - {{ .Env.APP_VERSION }}
 file:

--- a/.vib/jenkins/goss/jenkins.yaml
+++ b/.vib/jenkins/goss/jenkins.yaml
@@ -1,0 +1,15 @@
+command:
+  check-app-jar:
+    exec: java -jar /opt/bitnami/jenkins/jenkins-plugin-manager.jar --war /opt/bitnami/jenkins/jenkins.war --plugin-file /opt/bitnami/jenkins/plugins.txt -d /opt/bitnami/jenkins/plugins
+    exit-status: 0
+  check-app-version:
+    exec: java -jar /opt/bitnami/jenkins/jenkins.war --version
+    stdout:              
+      - {{ .Env.APP_VERSION }}
+file:
+  /opt/bitnami/jenkins/plugins.txt:
+    exists: true
+    contains:
+      - "swarm"
+      - "matrix-auth"
+      - "authorize-project"

--- a/.vib/jenkins/goss/vars.yaml
+++ b/.vib/jenkins/goss/vars.yaml
@@ -10,4 +10,12 @@ directories:
       - /opt/bitnami/jenkins/logs
       - /bitnami/jenkins
       - /bitnami/jenkins/home
+files:
+  - paths:
+      - /opt/bitnami/jenkins/plugins/authorize-project.jpi
+      - /opt/bitnami/jenkins/plugins/matrix-auth.jpi
+      - /opt/bitnami/jenkins/plugins/swarm.jpi
+version:
+  bin_name: java -jar /opt/bitnami/jenkins/jenkins.war
+  flag: --version
 root_dir: /opt/bitnami

--- a/.vib/jenkins/goss/vars.yaml
+++ b/.vib/jenkins/goss/vars.yaml
@@ -1,0 +1,17 @@
+binaries:
+  - java
+  - jenkins
+  - render-template
+directories:
+  - mode: "0775"
+    paths:
+      - /opt/bitnami/jenkins
+      - /op/bitnami/jenkins/plugins
+      - /opt/bitnami/jenkins/tmp
+      - /opt/bitnami/jenkins/logs
+      - /bitnami/jenkins
+      - /bitnami/jenkins/home
+files:
+  - paths:
+      - /opt/bitnami/jenkins/jenkins-plugin-manager.jar
+root_dir: /opt/bitnami

--- a/.vib/jenkins/goss/vars.yaml
+++ b/.vib/jenkins/goss/vars.yaml
@@ -1,17 +1,13 @@
 binaries:
   - java
-  - jenkins
   - render-template
 directories:
   - mode: "0775"
     paths:
       - /opt/bitnami/jenkins
-      - /op/bitnami/jenkins/plugins
+      - /opt/bitnami/jenkins/plugins
       - /opt/bitnami/jenkins/tmp
       - /opt/bitnami/jenkins/logs
       - /bitnami/jenkins
       - /bitnami/jenkins/home
-files:
-  - paths:
-      - /opt/bitnami/jenkins/jenkins-plugin-manager.jar
 root_dir: /opt/bitnami

--- a/.vib/jenkins/vib-publish.json
+++ b/.vib/jenkins/vib-publish.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{VIB_ENV_CONTAINER_URL}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyJ0YWlsIiwgIi1mIiwgIi9kZXYvbnVsbCJd"
   },
   "phases": {
     "package": {
@@ -33,6 +34,21 @@
     },
     "verify": {
       "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "jenkins/goss/goss.yaml",
+            "vars_file": "jenkins/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-jenkins"
+              }
+            }
+          }
+        },
         {
           "action_id": "trivy",
           "params": {

--- a/.vib/jenkins/vib-verify.json
+++ b/.vib/jenkins/vib-verify.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyJ0YWlsIiwgIi1mIiwgIi9kZXYvbnVsbCJd"
   },
   "phases": {
     "package": {
@@ -29,6 +30,21 @@
     },
     "verify": {
       "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "jenkins/goss/goss.yaml",
+            "vars_file": "jenkins/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-jenkins"
+              }
+            }
+          }
+        },
         {
           "action_id": "trivy",
           "params": {

--- a/bitnami/jenkins/2/debian-11/docker-compose.yml
+++ b/bitnami/jenkins/2/debian-11/docker-compose.yml
@@ -2,7 +2,6 @@ version: '2'
 
 services:
   jenkins:
-    # New change
     image: docker.io/bitnami/jenkins:2
     ports:
       - '80:8080'

--- a/bitnami/jenkins/2/debian-11/docker-compose.yml
+++ b/bitnami/jenkins/2/debian-11/docker-compose.yml
@@ -2,6 +2,7 @@ version: '2'
 
 services:
   jenkins:
+    # New change
     image: docker.io/bitnami/jenkins:2
     ports:
       - '80:8080'


### PR DESCRIPTION
### Description of the change

The main objective of this PR is to publish our Bitnami Jenkins container using VMware Image Builder. In order to do that, several changes are included:

- Increasing the existing test coverage of the asset by adding Goss tests.
- Update verify and publish VIB pipeline's definitions.

### Benefits

- Ensuring higher quality of the container catalog.
- Increased pool of assets completely handled by VMware Image Builder.

### Possible drawbacks

Automated tests could introduce additional flakiness to the CI/CD.

### Applicable issues

NA

### Additional information

The `jenkins-plugin-manager.jar` file is not checked with the command provided in the build recipe (`java -jar /opt/bitnami/jenkins/jenkins-plugin-manager.jar --war /opt/bitnami/jenkins/jenkins. war --plugin-file /opt/bitnami/jenkins/plugins.txt -d /opt/bitnami/jenkins/plugins`) as it requires the `java -jar /opt/bitnami/jenkins/jenkins.war` command to be executed first and we should force it to stop so that we can then run the `jenkins-plugin-manager.jar` command. As we only want to test that the file works, with the `java -jar /opt/bitnami/jenkins/jenkins-plugin-manager.jar` command we can already verify that it works.