### PR TITLE
[bitnami/nats] add support for cli args

### DIFF
--- a/bitnami/nats/2/debian-11/Dockerfile
+++ b/bitnami/nats/2/debian-11/Dockerfile
@@ -50,5 +50,4 @@ EXPOSE 4222 6222 8222
 
 WORKDIR /opt/bitnami/nats
 USER 1001
-ENTRYPOINT [ "/opt/bitnami/scripts/nats/entrypoint.sh" ]
-CMD [ "/opt/bitnami/scripts/nats/run.sh" ]
+ENTRYPOINT [ "/opt/bitnami/scripts/nats/entrypoint.sh", "/opt/bitnami/scripts/nats/run.sh" ]

--- a/bitnami/nats/2/debian-11/rootfs/opt/bitnami/scripts/nats-env.sh
+++ b/bitnami/nats/2/debian-11/rootfs/opt/bitnami/scripts/nats-env.sh
@@ -44,6 +44,7 @@ nats_env_vars=(
     NATS_CLUSTER_TOKEN
     NATS_CLUSTER_ROUTES
     NATS_CLUSTER_SEED_NODE
+    NATS_EXTRA_FLAGS
 )
 for env_var in "${nats_env_vars[@]}"; do
     file_env_var="${env_var}_FILE"
@@ -108,3 +109,4 @@ export NATS_CLUSTER_ROUTES="${NATS_CLUSTER_ROUTES:-}"
 export NATS_CLUSTER_SEED_NODE="${NATS_CLUSTER_SEED_NODE:-}"
 
 # Custom environment variables may be defined below
+export NATS_EXTRA_FLAGS="${NATS_EXTRA_FLAGS:-}"

--- a/bitnami/nats/2/debian-11/rootfs/opt/bitnami/scripts/nats/run.sh
+++ b/bitnami/nats/2/debian-11/rootfs/opt/bitnami/scripts/nats/run.sh
@@ -16,8 +16,9 @@ set -o pipefail
 
 declare nats_cmd="nats-server"
 which "$nats_cmd" >/dev/null 2>&1 || nats_cmd="gnatsd"
-declare -a args=("-c" "$NATS_CONF_FILE")
-args+=("$@")
+declare -a args=($NATS_EXTRA_FLAGS)
+
+args+=("-c" "$NATS_CONF_FILE" "$@")
 
 info "** Starting NATS **"
 if am_i_root; then


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Fixes CLI Arguments on the nats container

currently this does not work
```
docker run --rm bitnami/nats --jetstream   
```

Adds ability to set cli arguments via ENV variable `NATS_EXTRA_FLAGS` - So that github services can also set arguments.

### Benefits

Allow people to enable jetstream

### Possible drawbacks

None really

### Applicable issues

- fixes #31485

### Additional information

-_-
