### PR TITLE
[bitnami/keycloak] Add VIB tests

### DIFF
--- a/.vib/keycloak/goss/goss.yaml
+++ b/.vib/keycloak/goss/goss.yaml
@@ -2,10 +2,10 @@ gossfile:
   # Goss tests exclusive to the current container
   ../../keycloak/goss/keycloak.yaml: {}
   # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-app-version.yaml: {}
   ../../common/goss/templates/check-binaries.yaml: {}
   ../../common/goss/templates/check-broken-symlinks.yaml: {}
   ../../common/goss/templates/check-ca-certs.yaml: {}
-  ../../common/goss/templates/check-directories.yaml: {}
   ../../common/goss/templates/check-linked-libraries.yaml: {}
   ../../common/goss/templates/check-sed-in-place.yaml: {}
   ../../common/goss/templates/check-spdx.yaml: {}

--- a/.vib/keycloak/goss/goss.yaml
+++ b/.vib/keycloak/goss/goss.yaml
@@ -1,0 +1,11 @@
+gossfile:
+  # Goss tests exclusive to the current container
+  ../../keycloak/goss/keycloak.yaml: {}
+  # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-binaries.yaml: {}
+  ../../common/goss/templates/check-broken-symlinks.yaml: {}
+  ../../common/goss/templates/check-ca-certs.yaml: {}
+  ../../common/goss/templates/check-directories.yaml: {}
+  ../../common/goss/templates/check-linked-libraries.yaml: {}
+  ../../common/goss/templates/check-sed-in-place.yaml: {}
+  ../../common/goss/templates/check-spdx.yaml: {}

--- a/.vib/keycloak/goss/keycloak.yaml
+++ b/.vib/keycloak/goss/keycloak.yaml
@@ -61,9 +61,3 @@ file:
     exists: true
     contains:
       - "<module xmlns=\"urn:jboss:module:1.0\" name=\"org.postgresql.jdbc\">"
-command:
-  check-app-version:
-    exec: /opt/bitnami/keycloak/bin/kc.sh --version
-    exit-status: 0          
-    stdout:              
-      - {{ .Env.APP_VERSION }}

--- a/.vib/keycloak/goss/keycloak.yaml
+++ b/.vib/keycloak/goss/keycloak.yaml
@@ -60,11 +60,7 @@ file:
   /opt/bitnami/keycloak/modules/system/layers/keycloak/org/postgresql/jdbc/main/module.xml:
     exists: true
     contains:
-      - "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
       - "<module xmlns=\"urn:jboss:module:1.0\" name=\"org.postgresql.jdbc\">"
-      - "<resource-root path=\"postgresql-"
-      - "<module name=\"javax.api\"/>"
-      - "<module name=\"javax.transaction.api\"/>"
 command:
   check-app-version:
     exec: /opt/bitnami/keycloak/bin/kc.sh --version

--- a/.vib/keycloak/goss/keycloak.yaml
+++ b/.vib/keycloak/goss/keycloak.yaml
@@ -67,7 +67,7 @@ file:
       - "<module name=\"javax.transaction.api\"/>"
 command:
   check-app-version:
-    exec: /opt/bitnami/keycloak/bin/kc.sh --version | grep "Keycloak" | grep -m 1 -o "[0-9]*\.[0-9]*\.[0-9]"
+    exec: /opt/bitnami/keycloak/bin/kc.sh --version
     exit-status: 0          
     stdout:              
       - {{ .Env.APP_VERSION }}

--- a/.vib/keycloak/goss/keycloak.yaml
+++ b/.vib/keycloak/goss/keycloak.yaml
@@ -1,0 +1,78 @@
+group:
+  keycloak:
+    exists: true
+user:
+  user:
+    exists: true
+  keycloak:
+    exists: true
+file:
+  /opt/bitnami/keycloak:
+    exists: true
+    mode: "0775"
+    owner: keycloak
+    filetype: directory
+  /opt/bitnami/keycloak/providers:
+    exists: true
+    mode: "0775"
+    owner: keycloak
+    filetype: directory
+  /opt/bitnami/keycloak/providers/log:
+    exists: true
+    mode: "0775"     
+    owner: keycloak     
+    filetype: directory
+  /opt/bitnami/keycloak/providers/tmp:
+    exists: true
+    mode: "0775"
+    owner: keycloak
+    filetype: directory
+  /opt/bitnami/keycloak/conf:
+    exists: true
+    mode: "0775"
+    owner: keycloak
+    filetype: directory
+  /opt/bitnami/keycloak/.installation:
+    exists: true
+    mode: "0775"
+    owner: keycloak
+    filetype: directory
+  /opt/bitnami/keycloak/data:
+    exists: true
+    mode: "0775"
+    owner: keycloak
+    filetype: directory
+  /opt/bitnami/keycloak/lib:
+    exists: true
+    mode: "0775"
+    owner: keycloak
+    filetype: directory
+  /bitnami/keycloak:
+    exists: true
+    mode: "0775"
+    owner: keycloak
+    filetype: directory
+  /docker-entrypoint-initdb.d:
+    exists: true
+    mode: "0775"
+    owner: keycloak
+    filetype: directory
+  /opt/bitnami/keycloak/modules/system/layers/keycloak/org/postgresql/jdbc/main/module.xml:
+    exists: true
+    contains:
+      - "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+          <module xmlns=\"urn:jboss:module:1.0\" name=\"org.postgresql.jdbc\">
+          <resources>
+          <resource-root path=\"postgresql-${psqlDriverVersion}.jar\"/>
+          </resources>
+          <dependencies>
+          <module name=\"javax.api\"/>
+          <module name=\"javax.transaction.api\"/>
+          </dependencies>
+          </module>"
+command:
+  check-app-version:
+    exec: /opt/bitnami/keycloak/bin/kc.sh --version | grep "Keycloak" | grep -m 1 -o "[0-9]*\.[0-9]*\.[0-9]"
+    exit-status: 0          
+    stdout:              
+      - {{ .Env.APP_VERSION }}

--- a/.vib/keycloak/goss/keycloak.yaml
+++ b/.vib/keycloak/goss/keycloak.yaml
@@ -60,16 +60,11 @@ file:
   /opt/bitnami/keycloak/modules/system/layers/keycloak/org/postgresql/jdbc/main/module.xml:
     exists: true
     contains:
-      - "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
-          <module xmlns=\"urn:jboss:module:1.0\" name=\"org.postgresql.jdbc\">
-          <resources>
-          <resource-root path=\"postgresql-${psqlDriverVersion}.jar\"/>
-          </resources>
-          <dependencies>
-          <module name=\"javax.api\"/>
-          <module name=\"javax.transaction.api\"/>
-          </dependencies>
-          </module>"
+      - "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+      - "<module xmlns=\"urn:jboss:module:1.0\" name=\"org.postgresql.jdbc\">"
+      - "<resource-root path=\"postgresql-"
+      - "<module name=\"javax.api\"/>"
+      - "<module name=\"javax.transaction.api\"/>"
 command:
   check-app-version:
     exec: /opt/bitnami/keycloak/bin/kc.sh --version | grep "Keycloak" | grep -m 1 -o "[0-9]*\.[0-9]*\.[0-9]"

--- a/.vib/keycloak/goss/vars.yaml
+++ b/.vib/keycloak/goss/vars.yaml
@@ -1,7 +1,8 @@
 binaries:
   - java
   - wait-for-port
-directories:
-  - paths:
-      - /opt/bitnami/keycloak/modules/system/layers/keycloak/org/postgresql/jdbc/main
+  - kc.sh
+version:
+  bin_name: kc.sh
+  flag: --version
 root_dir: /opt/bitnami

--- a/.vib/keycloak/goss/vars.yaml
+++ b/.vib/keycloak/goss/vars.yaml
@@ -1,0 +1,8 @@
+binaries:
+  - java
+  - keycloak
+  - wait-for-port
+directories:
+  - paths:
+      - /opt/bitnami/keycloak/modules/system/layers/keycloak/org/postgresql/jdbc/main
+root_dir: /opt/bitnami

--- a/.vib/keycloak/goss/vars.yaml
+++ b/.vib/keycloak/goss/vars.yaml
@@ -1,6 +1,5 @@
 binaries:
   - java
-  - keycloak
   - wait-for-port
 directories:
   - paths:

--- a/.vib/keycloak/vib-publish.json
+++ b/.vib/keycloak/vib-publish.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{VIB_ENV_CONTAINER_URL}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyJ0YWlsIiwgIi1mIiwgIi9kZXYvbnVsbCJd"
   },
   "phases": {
     "package": {
@@ -33,6 +34,21 @@
     },
     "verify": {
       "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "keycloak/goss/goss.yaml",
+            "vars_file": "keycloak/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-keycloak"
+              }
+            }
+          }
+        },
         {
           "action_id": "trivy",
           "params": {

--- a/.vib/keycloak/vib-verify.json
+++ b/.vib/keycloak/vib-verify.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyJ0YWlsIiwgIi1mIiwgIi9kZXYvbnVsbCJd"
   },
   "phases": {
     "package": {
@@ -29,6 +30,21 @@
     },
     "verify": {
       "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "keycloak/goss/goss.yaml",
+            "vars_file": "keycloak/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-keycloak"
+              }
+            }
+          }
+        },
         {
           "action_id": "trivy",
           "params": {

--- a/bitnami/keycloak/21/debian-11/docker-compose.yml
+++ b/bitnami/keycloak/21/debian-11/docker-compose.yml
@@ -1,7 +1,6 @@
 version: '2'
 services:
   postgresql:
-    # New change
     image: docker.io/bitnami/postgresql:11
     environment:
       # ALLOW_EMPTY_PASSWORD is recommended only for development.

--- a/bitnami/keycloak/21/debian-11/docker-compose.yml
+++ b/bitnami/keycloak/21/debian-11/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '2'
 services:
   postgresql:
+    # New change
     image: docker.io/bitnami/postgresql:11
     environment:
       # ALLOW_EMPTY_PASSWORD is recommended only for development.


### PR DESCRIPTION
### Description of the change

The main objective of this PR is to publish our Bitnami Keycloak container using VMware Image Builder. In order to do that, several changes are included:

- Increasing the existing test coverage of the asset by adding Goss tests.
- Update verify and publish VIB pipeline's definitions.

### Benefits

- Ensuring higher quality of the container catalog.
- Increased pool of assets completely handled by VMware Image Builder.

### Possible drawbacks

Automated tests could introduce additional flakiness to the CI/CD.

### Applicable issues

NA

### Additional information

The part of code in the build recipe where execution permissions are given to different libraries isn't checked as it depends on the specific architecture being used:
```
    // Some libraries in Keycloak don't have execution permissions and ldd warns about that
    const arch = this.be.target.platform.arch === 'arm64' ? 'aarch64' : 'x86_64';
    const paths = [
      `modules/system/layers/base/org/apache/activemq/artemis/journal/main/lib/linux-${arch}/*`,
      'modules/system/layers/base/org/wildfly/openssl/main/lib/*/*.so',
    ];
    paths.forEach((p) => {
      const libraries = glob.sync(path.join(
        this.prefix,
        p
      ));
      this.logger.debug('Granting execution permisions in the following libraries:', libraries.join(', '));
      libraries.forEach((lib) => fs.chmodSync(lib, 0o754));
    });
  }
```
