### PR TITLE
[bitnami/keycloak] Redact db password from debug log

### DIFF
--- a/bitnami/keycloak/21/debian-11/rootfs/opt/bitnami/scripts/libkeycloak.sh
+++ b/bitnami/keycloak/21/debian-11/rootfs/opt/bitnami/scripts/libkeycloak.sh
@@ -106,7 +106,7 @@ keycloak_conf_set() {
     local -r value="${2:-}"
     # Redact sensitive values before outputting to debug log
     local redacted_value="${value}"
-    if [[ "${key}" == "db-password" ]]; then
+    if [[ "${key}" =~ ^(db|https-key-store|https-trust-store|spi-truststore-file)-password$ ]]; then
         redacted_value="_redacted_"
     fi
     debug "Setting ${key} to '${redacted_value}' in Keycloak configuration"

--- a/bitnami/keycloak/21/debian-11/rootfs/opt/bitnami/scripts/libkeycloak.sh
+++ b/bitnami/keycloak/21/debian-11/rootfs/opt/bitnami/scripts/libkeycloak.sh
@@ -104,7 +104,12 @@ keycloak_validate() {
 keycloak_conf_set() {
     local -r key="${1:?key missing}"
     local -r value="${2:-}"
-    debug "Setting ${key} to '${value}' in Keycloak configuration"
+    # Redact sensitive values before outputting to debug log
+    local redacted_value="${value}"
+    if [[ "${key}" == "db-password" ]]; then
+        redacted_value="_redacted_"
+    fi
+    debug "Setting ${key} to '${redacted_value}' in Keycloak configuration"
     # Sanitize key (sed does not support fixed string substitutions)
     local sanitized_pattern
     sanitized_pattern="^\s*(#\s*)?$(sed 's/[]\[^$.*/]/\\&/g' <<<"$key")\s*=\s*(.*)"


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Display `_redacted_` in place of db password in debug log.

### Benefits

<!-- What benefits will be realized by the code change? -->
- Avoid unintentionally leaking db password to logs.

### Possible drawbacks

<!-- Describe any known limitations with your change -->
I don't think there are any.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #31067

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
