### PR TITLE
Include Nashorn js engine in keycloak image

### DIFF
--- a/bitnami/keycloak/21/debian-11/Dockerfile
+++ b/bitnami/keycloak/21/debian-11/Dockerfile
@@ -1,3 +1,14 @@
+# syntax=docker/dockerfile:1
+FROM docker.io/bitnami/minideb:bullseye
+
+WORKDIR /mvn-build
+ARG JAVA_EXTRA_SECURITY_DIR="/bitnami/java/extra-security"
+ARG TARGETARCH
+RUN apt-get update && apt-get upgrade -y
+RUN apt-get install maven -y
+COPY pom.xml ./
+RUN mvn clean package
+
 FROM docker.io/bitnami/minideb:bullseye
 
 ARG JAVA_EXTRA_SECURITY_DIR="/bitnami/java/extra-security"
@@ -48,7 +59,7 @@ ENV APP_VERSION="21.0.2" \
     BITNAMI_APP_NAME="keycloak" \
     JAVA_HOME="/opt/bitnami/java" \
     PATH="/opt/bitnami/common/bin:/opt/bitnami/java/bin:/opt/bitnami/keycloak/bin:$PATH"
-
+COPY --from=0 /mvn-build/target/keycloak-server-copy/ /opt/bitnami/keycloak/
 USER 1001
 ENTRYPOINT [ "/opt/bitnami/scripts/keycloak/entrypoint.sh" ]
 CMD [ "/opt/bitnami/scripts/keycloak/run.sh" ]

--- a/bitnami/keycloak/21/debian-11/pom.xml
+++ b/bitnami/keycloak/21/debian-11/pom.xml
@@ -1,0 +1,35 @@
+<project>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.bitnami</groupId>
+    <artifactId>keycloak-scriptengine</artifactId>
+    <version>1</version>
+    <dependencies>
+        <dependency>
+            <groupId>org.openjdk.nashorn</groupId>
+            <artifactId>nashorn-core</artifactId>
+            <version>15.3</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-dependencies-quarkus</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/keycloak-server-copy/providers</outputDirectory>
+                            <includeArtifactIds>nashorn-core,asm,asm-util,asm-commons</includeArtifactIds>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION


### Description of the change
After upgrading the image to use java 17 (which no longer includes the nashorn JS engine), users using authentication providers that depends on a js engine being present, found that their providers no longer worked.

This commit Includes a separate buildstep in the keycloak dockerfile that basically runs a maven build that depends on nashorn and copies the resulting dependencies to the keycloak image. 
The reason for using a maven build is basically to make it easier to keep track of, and include, any transient dependencies (mostly just asm stuff)

### Benefits

Users can use the image to run keycloak providers without having to bother with copying the nashorn jar and dependencies into the container

### Possible drawbacks



### Applicable issues

https://github.com/bitnami/charts/issues/15659


Signed-off-by: Peter Holtegaard Nielsen <peterholtegaard@gmail.com>
