### PR TITLE
[bitnami/kong] Add VIB tests

### DIFF
--- a/.vib/kong/goss/goss.yaml
+++ b/.vib/kong/goss/goss.yaml
@@ -2,7 +2,7 @@ gossfile:
   # Goss tests exclusive to the current container
   ../../kong/goss/kong.yaml: {}
   # Load scripts from .vib/common/goss/templates
-  ../../common/goss/templates/check-app-version.yaml: {}
+  # ../../common/goss/templates/check-app-version.yaml: {}
   ../../common/goss/templates/check-binaries.yaml: {}
   ../../common/goss/templates/check-broken-symlinks.yaml: {}
   ../../common/goss/templates/check-ca-certs.yaml: {}

--- a/.vib/kong/goss/goss.yaml
+++ b/.vib/kong/goss/goss.yaml
@@ -2,7 +2,6 @@ gossfile:
   # Goss tests exclusive to the current container
   ../../kong/goss/kong.yaml: {}
   # Load scripts from .vib/common/goss/templates
-  # ../../common/goss/templates/check-app-version.yaml: {}
   ../../common/goss/templates/check-binaries.yaml: {}
   ../../common/goss/templates/check-broken-symlinks.yaml: {}
   ../../common/goss/templates/check-ca-certs.yaml: {}

--- a/.vib/kong/goss/goss.yaml
+++ b/.vib/kong/goss/goss.yaml
@@ -2,6 +2,7 @@ gossfile:
   # Goss tests exclusive to the current container
   ../../kong/goss/kong.yaml: {}
   # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-app-version.yaml: {}
   ../../common/goss/templates/check-binaries.yaml: {}
   ../../common/goss/templates/check-broken-symlinks.yaml: {}
   ../../common/goss/templates/check-ca-certs.yaml: {}

--- a/.vib/kong/goss/goss.yaml
+++ b/.vib/kong/goss/goss.yaml
@@ -1,0 +1,12 @@
+gossfile:
+  # Goss tests exclusive to the current container
+  ../../kong/goss/kong.yaml: {}
+  # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-binaries.yaml: {}
+  ../../common/goss/templates/check-broken-symlinks.yaml: {}
+  ../../common/goss/templates/check-ca-certs.yaml: {}
+  ../../common/goss/templates/check-directories.yaml: {}
+  ../../common/goss/templates/check-files.yaml: {}
+  ../../common/goss/templates/check-linked-libraries.yaml: {}
+  ../../common/goss/templates/check-sed-in-place.yaml: {}
+  ../../common/goss/templates/check-spdx.yaml: {}

--- a/.vib/kong/goss/goss.yaml
+++ b/.vib/kong/goss/goss.yaml
@@ -2,7 +2,6 @@ gossfile:
   # Goss tests exclusive to the current container
   ../../kong/goss/kong.yaml: {}
   # Load scripts from .vib/common/goss/templates
-  ../../common/goss/templates/check-app-version.yaml: {}
   ../../common/goss/templates/check-binaries.yaml: {}
   ../../common/goss/templates/check-broken-symlinks.yaml: {}
   ../../common/goss/templates/check-ca-certs.yaml: {}

--- a/.vib/kong/goss/kong.yaml
+++ b/.vib/kong/goss/kong.yaml
@@ -34,8 +34,3 @@ command:
   check-nginx-run:
     exec: nginx -V
     exit-status: 0
-  check-kong-version:
-    exec: /opt/bitnami/scripts/kong/entrypoint.sh /opt/bitnami/kong/bin/kong version
-    exit-status: 0
-    stdout:
-      - {{ .Env.APP_VERSION }}

--- a/.vib/kong/goss/kong.yaml
+++ b/.vib/kong/goss/kong.yaml
@@ -34,3 +34,8 @@ command:
   check-nginx-run:
     exec: nginx -V
     exit-status: 0
+  check-kong-version:
+    exec: /opt/bitnami/scripts/kong/entrypoint.sh /opt/bitnami/kong/bin/ version
+    exit-status: 0
+    stdout:
+      - {{ .Env.APP_VERSION }}

--- a/.vib/kong/goss/kong.yaml
+++ b/.vib/kong/goss/kong.yaml
@@ -31,3 +31,6 @@ command:
   check-status-all-non-empty-keys:
     exec: grep -E '^#+([a-z_ ]+)=\s*[^# ]' /opt/bitnami/kong/conf/kong.conf | grep -v 'pg_ro'
     exit-status: 1
+  check-nginx-run:
+    exec: nginx -V
+    exit-status: 0

--- a/.vib/kong/goss/kong.yaml
+++ b/.vib/kong/goss/kong.yaml
@@ -35,7 +35,7 @@ command:
     exec: nginx -V
     exit-status: 0
   check-kong-version:
-    exec: /opt/bitnami/scripts/kong/entrypoint.sh /opt/bitnami/kong/bin/ version
+    exec: /opt/bitnami/scripts/kong/entrypoint.sh /opt/bitnami/kong/bin/kong version
     exit-status: 0
     stdout:
       - {{ .Env.APP_VERSION }}

--- a/.vib/kong/goss/kong.yaml
+++ b/.vib/kong/goss/kong.yaml
@@ -31,3 +31,6 @@ command:
   check-status-all-non-empty-keys:
     exec: grep -E '^#+([a-z_ ]+)=\s*[^# ]' /opt/bitnami/kong/conf/kong.conf | grep -v 'pg_ro'
     exit-status: 1
+  check-app-version:
+    exec: kong version
+    exit-status: 0

--- a/.vib/kong/goss/kong.yaml
+++ b/.vib/kong/goss/kong.yaml
@@ -23,11 +23,6 @@ file:
     exists: true
     filetype: symlink
 command:
-  check-app-version:
-    exec: /opt/bitnami/kong/bin/kong version
-    exit-status: 1
-    stdout:
-      - {{ .Env.APP_VERSION }}
   # Ensure that there is no uncommented read-only postgres connection parameter in the main Kong configuration file
   check-read-only-conf-values:
     exec: grep -E '^pg_ro.+=.+' /opt/bitnami/kong/conf/kong.conf

--- a/.vib/kong/goss/kong.yaml
+++ b/.vib/kong/goss/kong.yaml
@@ -32,5 +32,5 @@ command:
     exec: grep -E '^#+([a-z_ ]+)=\s*[^# ]' /opt/bitnami/kong/conf/kong.conf | grep -v 'pg_ro'
     exit-status: 1
   check-app-version:
-    exec: kong version
+    exec: opt/bitnami/kong/bin/kong version
     exit-status: 0

--- a/.vib/kong/goss/kong.yaml
+++ b/.vib/kong/goss/kong.yaml
@@ -25,7 +25,9 @@ file:
 command:
   check-app-version:
     exec: /opt/bitnami/kong/bin/kong version
-    exit-status: 0
+    exit-status: 1
+    stdout:
+      - {{ .Env.APP_VERSION }}
   # Ensure that there is no uncommented read-only postgres connection parameter in the main Kong configuration file
   check-read-only-conf-values:
     exec: grep -E '^pg_ro.+=.+' /opt/bitnami/kong/conf/kong.conf

--- a/.vib/kong/goss/kong.yaml
+++ b/.vib/kong/goss/kong.yaml
@@ -21,7 +21,7 @@ file:
       - "\'luarocks path\' configuration"
   /usr/local/kong/include/opentelemetry:
     exists: true
-    type: symlink
+    filetype: symlink
 command:
   # Ensure that there is no uncommented read-only postgres connection parameter in the main Kong configuration file
   check-read-only-conf-values:

--- a/.vib/kong/goss/kong.yaml
+++ b/.vib/kong/goss/kong.yaml
@@ -1,0 +1,30 @@
+group:   
+  kong:     
+    exists: true 
+user:   
+  kong:     
+    exists: true
+file:
+  /opt/bitnami/kong/conf/kong.conf:
+    exists: true
+    contains:
+      - "prefix = /opt/bitnami/kong/server"
+      - "nginx_daemon = off"
+      - "nginx_user = kong"
+  /opt/bitnami/scripts/kong-env.sh:
+    exists: true
+    contains:
+      - "\'luarocks path\' configuration"
+  /etc/bash.bashrc:
+    exists: true
+    contains:
+      - "\'luarocks path\' configuration"
+command:
+  # Ensure that there is no uncommented read-only postgres connection parameter in the main Kong configuration file
+  check-read-only-conf-values:
+    exec: grep -E '^pg_ro.+=.+' kong.conf
+    exit-status: 1
+  # Ensure that all non-empty keys in the main Kong configuration file are uncommented
+  check-status-all-non-empty-keys:
+    exec: grep -E '^#+([a-z_ ]+)=\s*[^# ]' kong.conf | grep -v 'pg_ro'
+    exit-status: 1

--- a/.vib/kong/goss/kong.yaml
+++ b/.vib/kong/goss/kong.yaml
@@ -23,6 +23,9 @@ file:
     exists: true
     filetype: symlink
 command:
+  check-app-version:
+    exec: /opt/bitnami/kong/bin/kong version
+    exit-status: 0
   # Ensure that there is no uncommented read-only postgres connection parameter in the main Kong configuration file
   check-read-only-conf-values:
     exec: grep -E '^pg_ro.+=.+' /opt/bitnami/kong/conf/kong.conf
@@ -31,6 +34,3 @@ command:
   check-status-all-non-empty-keys:
     exec: grep -E '^#+([a-z_ ]+)=\s*[^# ]' /opt/bitnami/kong/conf/kong.conf | grep -v 'pg_ro'
     exit-status: 1
-  check-app-version:
-    exec: opt/bitnami/kong/bin/kong version
-    exit-status: 0

--- a/.vib/kong/goss/kong.yaml
+++ b/.vib/kong/goss/kong.yaml
@@ -31,8 +31,3 @@ command:
   check-status-all-non-empty-keys:
     exec: grep -E '^#+([a-z_ ]+)=\s*[^# ]' /opt/bitnami/kong/conf/kong.conf | grep -v 'pg_ro'
     exit-status: 1
-  check-app-version:
-    exec: kong version
-    exit-status: 0
-    stdout:
-      - {{ .Env.APP_VERSION }}

--- a/.vib/kong/goss/kong.yaml
+++ b/.vib/kong/goss/kong.yaml
@@ -31,3 +31,8 @@ command:
   check-status-all-non-empty-keys:
     exec: grep -E '^#+([a-z_ ]+)=\s*[^# ]' /opt/bitnami/kong/conf/kong.conf | grep -v 'pg_ro'
     exit-status: 1
+  check-app-version:
+    exec: kong version
+    exit-status: 0
+    stdout:
+      - {{ .Env.APP_VERSION }}

--- a/.vib/kong/goss/kong.yaml
+++ b/.vib/kong/goss/kong.yaml
@@ -14,11 +14,11 @@ file:
   /opt/bitnami/scripts/kong-env.sh:
     exists: true
     contains:
-      - "\'luarocks path\' configuration"
+      - "'luarocks path' configuration"
   /etc/bash.bashrc:
     exists: true
     contains:
-      - "\'luarocks path\' configuration"
+      - "'luarocks path' configuration"
   /usr/local/kong/include/opentelemetry:
     exists: true
     filetype: symlink

--- a/.vib/kong/goss/kong.yaml
+++ b/.vib/kong/goss/kong.yaml
@@ -19,12 +19,15 @@ file:
     exists: true
     contains:
       - "\'luarocks path\' configuration"
+  /usr/local/kong/include/opentelemetry:
+    exists: true
+    type: symlink
 command:
   # Ensure that there is no uncommented read-only postgres connection parameter in the main Kong configuration file
   check-read-only-conf-values:
-    exec: grep -E '^pg_ro.+=.+' kong.conf
+    exec: grep -E '^pg_ro.+=.+' /opt/bitnami/kong/conf/kong.conf
     exit-status: 1
   # Ensure that all non-empty keys in the main Kong configuration file are uncommented
   check-status-all-non-empty-keys:
-    exec: grep -E '^#+([a-z_ ]+)=\s*[^# ]' kong.conf | grep -v 'pg_ro'
+    exec: grep -E '^#+([a-z_ ]+)=\s*[^# ]' /opt/bitnami/kong/conf/kong.conf | grep -v 'pg_ro'
     exit-status: 1

--- a/.vib/kong/goss/vars.yaml
+++ b/.vib/kong/goss/vars.yaml
@@ -14,7 +14,7 @@ directories:
 files:
   - paths:
       - /opt/bitnami/kong/server/lib/pluginsocket.proto
-version:
-  bin_name: kong
-  flag: version
+#version:
+#  bin_name: kong
+#  flag: version
 root_dir: /opt/bitnami

--- a/.vib/kong/goss/vars.yaml
+++ b/.vib/kong/goss/vars.yaml
@@ -14,7 +14,4 @@ directories:
 files:
   - paths:
       - /opt/bitnami/kong/server/lib/pluginsocket.proto
-#version:
-#  bin_name: kong
-#  flag: version
 root_dir: /opt/bitnami

--- a/.vib/kong/goss/vars.yaml
+++ b/.vib/kong/goss/vars.yaml
@@ -13,6 +13,8 @@ directories:
       - /opt/bitnami/kong/server/lib
 files:
   - paths:
-      - /opt/bitnami/kong/conf/kong.conf.default
       - /opt/bitnami/kong/server/lib/pluginsocket.proto
+version:
+  bin_name: kong
+  flag: version
 root_dir: /opt/bitnami

--- a/.vib/kong/goss/vars.yaml
+++ b/.vib/kong/goss/vars.yaml
@@ -16,4 +16,7 @@ files:
   - paths:
       - /opt/bitnami/kong/conf/kong.conf.default
       - /opt/bitnami/kong/server/lib/pluginsocket.proto
+version:
+  bin_name: kong
+  flag: version
 root_dir: /opt/bitnami

--- a/.vib/kong/goss/vars.yaml
+++ b/.vib/kong/goss/vars.yaml
@@ -8,7 +8,6 @@ directories:
       - /opt/bitnami/kong/conf
   - paths:
       - /docker-entrypoint-initdb.d
-      - /usr/local/kong/include/opentelemetry
       - /opt/bitnami/kong/openresty/luajit/share/lua/5.1/kong/include/opentelemetry
       - /opt/bitnami/kong/bin
       - /opt/bitnami/kong/server/lib

--- a/.vib/kong/goss/vars.yaml
+++ b/.vib/kong/goss/vars.yaml
@@ -1,0 +1,19 @@
+binaries:
+  - kong
+  - render-template
+directories:
+  - mode: "0775"
+    paths:
+      - /opt/bitnami/kong/server
+      - /opt/bitnami/kong/conf
+  - paths:
+      - /docker-entrypoint-initdb.d
+      - /usr/local/kong/include/opentelemetry
+      - /opt/bitnami/kong/openresty/luajit/share/lua/5.1/kong/include/opentelemetry
+      - /opt/bitnami/kong/bin
+      - /opt/bitnami/kong/server/lib
+files:
+  - paths:
+      - /opt/bitnami/kong/conf/kong.conf.default
+      - /opt/bitnami/kong/server/lib/pluginsocket.proto
+root_dir: /opt/bitnami

--- a/.vib/kong/goss/vars.yaml
+++ b/.vib/kong/goss/vars.yaml
@@ -15,7 +15,4 @@ files:
   - paths:
       - /opt/bitnami/kong/conf/kong.conf.default
       - /opt/bitnami/kong/server/lib/pluginsocket.proto
-version:
-  bin_name: kong
-  flag: version
 root_dir: /opt/bitnami

--- a/.vib/kong/vib-publish.json
+++ b/.vib/kong/vib-publish.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{VIB_ENV_CONTAINER_URL}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyJ0YWlsIiwgIi1mIiwgIi9kZXYvbnVsbCJd"
   },
   "phases": {
     "package": {
@@ -32,6 +33,21 @@
     },
     "verify": {
       "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "kong/goss/goss.yaml",
+            "vars_file": "kong/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-kong"
+              }
+            }
+          }
+        },
         {
           "action_id": "trivy",
           "params": {

--- a/.vib/kong/vib-verify.json
+++ b/.vib/kong/vib-verify.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyJ0YWlsIiwgIi1mIiwgIi9kZXYvbnVsbCJd"
   },
   "phases": {
     "package": {
@@ -29,6 +30,21 @@
     },
     "verify": {
       "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "kong/goss/goss.yaml",
+            "vars_file": "kong/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-kong"
+              }
+            }
+          }
+        },
         {
           "action_id": "trivy",
           "params": {

--- a/bitnami/kong/3/debian-11/docker-compose.yml
+++ b/bitnami/kong/3/debian-11/docker-compose.yml
@@ -1,7 +1,6 @@
 version: '2'
 services:
   postgresql:
-    # New change
     image: docker.io/bitnami/postgresql:14
     volumes:
       - postgresql_data:/bitnami/postgresql

--- a/bitnami/kong/3/debian-11/docker-compose.yml
+++ b/bitnami/kong/3/debian-11/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '2'
 services:
   postgresql:
+    # New change
     image: docker.io/bitnami/postgresql:14
     volumes:
       - postgresql_data:/bitnami/postgresql


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

The main objective of this PR is to publish our Bitnami Kong container using VMware Image Builder. In order to do that, several changes are included:

- Increasing the existing test coverage of the asset by adding Goss tests.
- Update verify and publish VIB pipeline's definitions.

### Benefits

- Ensuring higher quality of the container catalog.
- Increased pool of assets completely handled by VMware Image Builder.

### Possible drawbacks

Automated tests could introduce additional flakiness to the CI/CD.

### Applicable issues

NA

### Additional information

We are unable to check the kong binary by running, for example, `kong version`, as the following error appears:
```
ERROR: /opt/bitnami/kong/bin/kong:9: module 'kong.cmd.init' not found:
	no field package.preload['kong.cmd.init']
	no file './kong/cmd/init.lua'
	no file './kong/cmd/init/init.lua'
	no file '/opt/bitnami/kong/openresty/site/lualib/kong/cmd/init.ljbc'
	no file '/opt/bitnami/kong/openresty/site/lualib/kong/cmd/init/init.ljbc'
	no file '/opt/bitnami/kong/openresty/lualib/kong/cmd/init.ljbc'
	no file '/opt/bitnami/kong/openresty/lualib/kong/cmd/init/init.ljbc'
	no file '/opt/bitnami/kong/openresty/site/lualib/kong/cmd/init.lua'
	no file '/opt/bitnami/kong/openresty/site/lualib/kong/cmd/init/init.lua'
	no file '/opt/bitnami/kong/openresty/lualib/kong/cmd/init.lua'
	no file '/opt/bitnami/kong/openresty/lualib/kong/cmd/init/init.lua'
	no file './kong/cmd/init.lua'
	no file '/opt/bitnami/kong/openresty/luajit/share/luajit-2.1.0-beta3/kong/cmd/init.lua'
	no file '/usr/local/share/lua/5.1/kong/cmd/init.lua'
	no file '/usr/local/share/lua/5.1/kong/cmd/init/init.lua'
	no file '/opt/bitnami/kong/openresty/luajit/share/lua/5.1/kong/cmd/init.lua'
	no file '/opt/bitnami/kong/openresty/luajit/share/lua/5.1/kong/cmd/init/init.lua'
	no file '/opt/bitnami/kong/openresty/site/lualib/kong/cmd/init.so'
	no file '/opt/bitnami/kong/openresty/lualib/kong/cmd/init.so'
	no file './kong/cmd/init.so'
	no file '/usr/local/lib/lua/5.1/kong/cmd/init.so'
	no file '/opt/bitnami/kong/openresty/luajit/lib/lua/5.1/kong/cmd/init.so'
	no file '/usr/local/lib/lua/5.1/loadall.so'
	no file '/opt/bitnami/kong/openresty/site/lualib/kong.so'
	no file '/opt/bitnami/kong/openresty/lualib/kong.so'
	no file './kong.so'
	no file '/usr/local/lib/lua/5.1/kong.so'
	no file '/opt/bitnami/kong/openresty/luajit/lib/lua/5.1/kong.so'
	no file '/usr/local/lib/lua/5.1/loadall.so'
stack traceback:
	/opt/bitnami/kong/bin/kong:9: in function 'file_gen'
	init_worker_by_lua:46: in function <init_worker_by_lua:44>
	[C]: in function 'xpcall'
	init_worker_by_lua:53: in function <init_worker_by_lua:51>
```
The kong binary is missing some configuration to make it work properly. We can check this since, if we also execute the entrypoint script, then the test does work:
`exec: /opt/bitnami/scripts/kong/entrypoint.sh /opt/bitnami/kong/bin/kong version`
Therefore, since another configuration is needed, the test cannot be performed.