### PR TITLE
[bitnami/kong-ingress-controller] Add VIB tests

### DIFF
--- a/.vib/kong-ingress-controller/goss/goss.yaml
+++ b/.vib/kong-ingress-controller/goss/goss.yaml
@@ -1,0 +1,10 @@
+gossfile:
+  # Goss tests exclusive to the current container
+  ../../kong-ingress-controller/goss/kong-ingress-controller.yaml: {}
+  # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-binaries.yaml: {}
+  ../../common/goss/templates/check-broken-symlinks.yaml: {}
+  ../../common/goss/templates/check-ca-certs.yaml: {}
+  ../../common/goss/templates/check-linked-libraries.yaml: {}
+  ../../common/goss/templates/check-sed-in-place.yaml: {}
+  ../../common/goss/templates/check-spdx.yaml: {}

--- a/.vib/kong-ingress-controller/goss/kong-ingress-controller.yaml
+++ b/.vib/kong-ingress-controller/goss/kong-ingress-controller.yaml
@@ -1,0 +1,4 @@
+command:
+  check-app-binary:
+    exec: kong-ingress-controller --help
+    exit-status: 0

--- a/.vib/kong-ingress-controller/goss/vars.yaml
+++ b/.vib/kong-ingress-controller/goss/vars.yaml
@@ -1,0 +1,4 @@
+binaries:
+  - kong-ingress-controller
+  - wait-for-port
+root_dir: /opt/bitnami

--- a/.vib/kong-ingress-controller/vib-publish.json
+++ b/.vib/kong-ingress-controller/vib-publish.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{VIB_ENV_CONTAINER_URL}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyJ0YWlsIiwgIi1mIiwgIi9kZXYvbnVsbCJd"
   },
   "phases": {
     "package": {
@@ -33,6 +34,21 @@
     },
     "verify": {
       "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "kong-ingress-controller/goss/goss.yaml",
+            "vars_file": "kong-ingress-controller/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-kong-ingress-controller"
+              }
+            }
+          }
+        },
         {
           "action_id": "trivy",
           "params": {

--- a/.vib/kong-ingress-controller/vib-verify.json
+++ b/.vib/kong-ingress-controller/vib-verify.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyJ0YWlsIiwgIi1mIiwgIi9kZXYvbnVsbCJd"
   },
   "phases": {
     "package": {
@@ -29,6 +30,21 @@
     },
     "verify": {
       "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "kong-ingress-controller/goss/goss.yaml",
+            "vars_file": "kong-ingress-controller/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-kong-ingress-controller"
+              }
+            }
+          }
+        },
         {
           "action_id": "trivy",
           "params": {

--- a/bitnami/kong-ingress-controller/2/debian-11/docker-compose.yml
+++ b/bitnami/kong-ingress-controller/2/debian-11/docker-compose.yml
@@ -1,5 +1,4 @@
 version: '2'
 services:
   kong-ingress-controller:
-    # New change
     image: docker.io/bitnami/kong-ingress-controller:2

--- a/bitnami/kong-ingress-controller/2/debian-11/docker-compose.yml
+++ b/bitnami/kong-ingress-controller/2/debian-11/docker-compose.yml
@@ -1,4 +1,5 @@
 version: '2'
 services:
   kong-ingress-controller:
+    # New change
     image: docker.io/bitnami/kong-ingress-controller:2


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

The main objective of this PR is to publish our Bitnami Kong-ingress-controller container using VMware Image Builder. In order to do that, several changes are included:

- Increasing the existing test coverage of the asset by adding Goss tests.
- Update verify and publish VIB pipeline's definitions.

### Benefits

- Ensuring higher quality of the container catalog.
- Increased pool of assets completely handled by VMware Image Builder.

### Possible drawbacks

Automated tests could introduce additional flakiness to the CI/CD.

### Applicable issues

NA