### PR TITLE
[bitnami/jasperreports] Only enable remote management on default webapps if default webapps are installed (#31969).

### DIFF
--- a/bitnami/jasperreports/8/debian-11/rootfs/opt/bitnami/scripts/libtomcat.sh
+++ b/bitnami/jasperreports/8/debian-11/rootfs/opt/bitnami/scripts/libtomcat.sh
@@ -201,18 +201,18 @@ EOF
         if is_boolean_yes "$TOMCAT_INSTALL_DEFAULT_WEBAPPS"; then
             info "Deploying Tomcat from scratch"
             cp -rp "$TOMCAT_BASE_DIR"/webapps_default/* "$TOMCAT_WEBAPPS_DIR"
+
+            # These applications have been enabled for historical reasons, and do not pose any security threat
+            tomcat_enable_application examples
+            tomcat_enable_application docs
+            if is_boolean_yes "$TOMCAT_ALLOW_REMOTE_MANAGEMENT"; then
+                # These applications should not be enabled by default, for security reasons
+                info "Enabling remote connections for manager and host-manager applications"
+                tomcat_enable_application manager
+                tomcat_enable_application host-manager
+            fi
         else
             info "Skipping deployment of default webapps"
-        fi
-
-        # These applications have been enabled for historical reasons, and do not pose any security threat
-        tomcat_enable_application examples
-        tomcat_enable_application docs
-        if is_boolean_yes "$TOMCAT_ALLOW_REMOTE_MANAGEMENT"; then
-            # These applications should not be enabled by default, for security reasons
-            info "Enabling remote connections for manager and host-manager applications"
-            tomcat_enable_application manager
-            tomcat_enable_application host-manager
         fi
     fi
 }


### PR DESCRIPTION
### Description of the change

This change ensures that remote management will not be enabled on the default webapps (examples, docs, manager and host-manager) if `TOMCAT_INSTALL_DEFAULT_WEBAPPS` is disabled. It [currently fails to start up the container](https://github.com/bitnami/containers/issues/31969) if that's the case. 

### Benefits

It fixes the bug.

### Possible drawbacks

Theoretically, enabling remote management was possible on the default webapps, even if TOMCAT_INSTALL_DEFAULT_WEBAPPS was false. I don't think it's sensible to attempt this, but I might be wrong. That is why I moved the code inside the `TOMCAT_INSTALL_DEFAULT_WEBAPPS==true` if condition.
There are more possibilities to fix this, obviously, but I thought this was the cleanest.

### Applicable issues

- fixes #31969

### Additional information

I verified the tomcat:9 image by building and running it locally. (Related PR for Tomcat: https://github.com/bitnami/containers/pull/31970)