### PR TITLE
[bitnami/solr] Introducing SOLR_ZK_CHROOT

### DIFF
--- a/bitnami/solr/8/debian-11/rootfs/opt/bitnami/scripts/solr-env.sh
+++ b/bitnami/solr/8/debian-11/rootfs/opt/bitnami/scripts/solr-env.sh
@@ -43,6 +43,7 @@ solr_env_vars=(
     SOLR_SSL_CHECK_PEER_NAME
     SOLR_ZK_MAX_RETRIES
     SOLR_ZK_SLEEP_TIME
+    SOLR_ZK_CHROOT
     SOLR_COLLECTION
 )
 for env_var in "${solr_env_vars[@]}"; do
@@ -68,6 +69,7 @@ export SOLR_TMP_DIR="${SOLR_BASE_DIR}/tmp"
 export SOLR_PID_DIR="${SOLR_BASE_DIR}/tmp"
 export SOLR_LOGS_DIR="${SOLR_BASE_DIR}/logs"
 export SOLR_SERVER_DIR="${SOLR_BASE_DIR}/server"
+export SOLR_ZK_CHROOT="${SOLR_ZK_CHROOT:-/solr}"
 
 # Persistence
 export SOLR_VOLUME_DIR="${BITNAMI_VOLUME_DIR}/solr"

--- a/bitnami/solr/8/debian-11/rootfs/opt/bitnami/scripts/solr/run.sh
+++ b/bitnami/solr/8/debian-11/rootfs/opt/bitnami/scripts/solr/run.sh
@@ -19,7 +19,7 @@ info "** Starting solr **"
 start_command=("${SOLR_BIN_DIR}/solr" "-p" "${SOLR_PORT_NUMBER}" "-d" "/opt/bitnami/solr/server" "-f")
 
 if is_boolean_yes "$SOLR_ENABLE_CLOUD_MODE"; then
-    start_command+=("-cloud" "-z" "$SOLR_ZK_HOSTS/solr")
+    start_command+=("-cloud" "-z" "${SOLR_ZK_HOSTS}${SOLR_ZK_CHROOT}")
 fi
 
 is_boolean_yes "$SOLR_SSL_ENABLED" && export SOLR_SSL_ENABLED=true

--- a/bitnami/solr/9/debian-11/rootfs/opt/bitnami/scripts/solr-env.sh
+++ b/bitnami/solr/9/debian-11/rootfs/opt/bitnami/scripts/solr-env.sh
@@ -43,6 +43,7 @@ solr_env_vars=(
     SOLR_SSL_CHECK_PEER_NAME
     SOLR_ZK_MAX_RETRIES
     SOLR_ZK_SLEEP_TIME
+    SOLR_ZK_CHROOT
     SOLR_COLLECTION
 )
 for env_var in "${solr_env_vars[@]}"; do
@@ -68,6 +69,7 @@ export SOLR_TMP_DIR="${SOLR_BASE_DIR}/tmp"
 export SOLR_PID_DIR="${SOLR_BASE_DIR}/tmp"
 export SOLR_LOGS_DIR="${SOLR_BASE_DIR}/logs"
 export SOLR_SERVER_DIR="${SOLR_BASE_DIR}/server"
+export SOLR_ZK_CHROOT="${SOLR_ZK_CHROOT:-/solr}"
 
 # Persistence
 export SOLR_VOLUME_DIR="${BITNAMI_VOLUME_DIR}/solr"

--- a/bitnami/solr/9/debian-11/rootfs/opt/bitnami/scripts/solr/run.sh
+++ b/bitnami/solr/9/debian-11/rootfs/opt/bitnami/scripts/solr/run.sh
@@ -19,7 +19,7 @@ info "** Starting solr **"
 start_command=("${SOLR_BIN_DIR}/solr" "-p" "${SOLR_PORT_NUMBER}" "-d" "/opt/bitnami/solr/server" "-f")
 
 if is_boolean_yes "$SOLR_ENABLE_CLOUD_MODE"; then
-    start_command+=("-cloud" "-z" "$SOLR_ZK_HOSTS/solr")
+    start_command+=("-cloud" "-z" "${SOLR_ZK_HOSTS}${SOLR_ZK_CHROOT}")
 fi
 
 is_boolean_yes "$SOLR_SSL_ENABLED" && export SOLR_SSL_ENABLED=true

--- a/bitnami/solr/README.md
+++ b/bitnami/solr/README.md
@@ -168,6 +168,7 @@ Cluster related environment variables:
 * `SOLR_HOST`: Name of the node. If not set the node IP will be used. Default: **null**
 * `SORL_ZK_SLEEP_TIME`: Sleep time when waiting for init configuration operations to finish. Default: **5**
 * `SOLR_ZK_MAX_RETRIES`: Maximum retries when waiting for init configuration operations to finish. Default: **5**
+* `SOLR_ZK_CHROOT`: ZooKeeper ZNode chroot where to store solr data. Default: **/solr**
 
 Authentication related environment variables:
 


### PR DESCRIPTION

### Description of the change

Introducing SOLR_ZK_CHROOT variable

### Benefits

ZooKeeper base ZNode (chroot) now can be set via parameter instead of hardcoded /solr

### Possible drawbacks

Not known

### Applicable issues

- fixes #31862

### Additional information

Signed-off-by: Piotr Rybicki <ryba@mewe.com>