### PR TITLE
[bitnami/gitlab-runner-helper] Symlink gitlab-runner-helper binary to expected path

### DIFF
--- a/bitnami/gitlab-runner-helper/15/debian-11/Dockerfile
+++ b/bitnami/gitlab-runner-helper/15/debian-11/Dockerfile
@@ -40,7 +40,10 @@ RUN apt-get autoremove --purge -y curl && \
 RUN chmod g+rwX /opt/bitnami
 
 COPY rootfs /
-RUN mkdir /home/gitlab-runner && chmod -R g+rwX /home/gitlab-runner && ln -s /opt/bitnami/common/bin/dumb-init /usr/bin/dumb-init && ln -s /opt/bitnami/scripts/gitlab-runner-helper/entrypoint.sh /entrypoint
+RUN mkdir /home/gitlab-runner && chmod -R g+rwX /home/gitlab-runner && \
+    ln -s /opt/bitnami/common/bin/dumb-init /usr/bin/dumb-init && \
+    ln -s /opt/bitnami/scripts/gitlab-runner-helper/entrypoint.sh /entrypoint && \
+    ln -s /opt/bitnami/gitlab-runner-helper/bin/gitlab-runner-helper /usr/bin/gitlab-runner-helper
 ENV APP_VERSION="15.11.0" \
     BITNAMI_APP_NAME="gitlab-runner-helper" \
     PATH="/opt/bitnami/common/bin:/opt/bitnami/gitlab-runner-helper/bin:$PATH"


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

GitLab Runner artifact upload (and possibly other features) depend on the `gitlab-runner-helper` binary being present in `/usr/bin`. Symlinking the binary in an additional layer has resolved the issue in a test environment.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #32156 
