### PR TITLE
[bitnami/discourse] Precompile passanger

### DIFF
--- a/bitnami/discourse/3/debian-11/Dockerfile
+++ b/bitnami/discourse/3/debian-11/Dockerfile
@@ -20,7 +20,7 @@ ENV HOME="/" \
 COPY prebuildfs /
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Install required system packages and dependencies
-RUN install_packages acl advancecomp ca-certificates curl file gifsicle git hostname imagemagick jhead jpegoptim libbrotli1 libbsd0 libbz2-1.0 libcom-err2 libcrypt1 libedit2 libffi7 libgcc-s1 libgmp10 libgnutls30 libgssapi-krb5-2 libhogweed6 libicu67 libidn2-0 libjpeg-turbo-progs libk5crypto3 libkeyutils1 libkrb5-3 libkrb5support0 libldap-2.4-2 liblzma5 libmd0 libncursesw6 libnettle8 libnsl2 libp11-kit0 libpq5 libreadline-dev libreadline8 libsasl2-2 libsqlite3-0 libssl-dev libssl1.1 libstdc++6 libtasn1-6 libtinfo6 libtirpc3 libunistring2 libuuid1 libxml2 libxslt1.1 optipng pngcrush pngquant procps rsync sqlite3 zlib1g
+RUN install_packages acl advancecomp ca-certificates curl file gcc gifsicle git hostname imagemagick jhead jpegoptim libbrotli1 libbsd0 libbz2-1.0 libcom-err2 libcrypt1 libedit2 libffi7 libgcc-s1 libgmp10 libgnutls30 libgssapi-krb5-2 libhogweed6 libicu67 libidn2-0 libjpeg-turbo-progs libk5crypto3 libkeyutils1 libkrb5-3 libkrb5support0 libldap-2.4-2 liblzma5 libmd0 libncursesw6 libnettle8 libnsl2 libp11-kit0 libpq5 libreadline-dev libreadline8 libsasl2-2 libsqlite3-0 libssl-dev libssl1.1 libstdc++6 libtasn1-6 libtinfo6 libtirpc3 libunistring2 libuuid1 libxml2 libxslt1.1 make optipng pngcrush pngquant procps rsync sqlite3 zlib1g zlib1g-dev
 RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ && \
     COMPONENTS=( \
       "python-3.9.16-11-linux-${OS_ARCH}-debian-11" \
@@ -40,9 +40,7 @@ RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ && \
       tar -zxf "${COMPONENT}.tar.gz" -C /opt/bitnami --strip-components=2 --no-same-owner --wildcards '*/files' && \
       rm -rf "${COMPONENT}".tar.gz{,.sha256} ; \
     done
-RUN apt-get autoremove --purge -y curl && \
-    apt-get update && apt-get upgrade -y && \
-    apt-get clean && rm -rf /var/lib/apt/lists /var/cache/apt/archives
+
 RUN chmod g+rwX /opt/bitnami
 RUN /opt/bitnami/ruby/bin/gem install --force bundler -v '< 2'
 
@@ -52,6 +50,11 @@ ENV APP_VERSION="3.0.3" \
     BITNAMI_APP_NAME="discourse" \
     LD_LIBRARY_PATH="/opt/bitnami/postgresql/lib:$LD_LIBRARY_PATH" \
     PATH="/opt/bitnami/python/bin:/opt/bitnami/common/bin:/opt/bitnami/ruby/bin:/opt/bitnami/postgresql/bin:/opt/bitnami/node/bin:/opt/bitnami/brotli/bin:/opt/bitnami/discourse/app/assets/javascripts/node_modules/ember-cli/bin:$PATH"
+
+RUN cd /opt/bitnami/discourse/vendor/bundle/ruby/3.1.0/gems/passenger-6.0.17/ && ruby src/ruby_native_extension/extconf.rb && make && make install
+RUN apt-get autoremove --purge -y curl gcc make zlib1g-dev && \
+    apt-get update && apt-get upgrade -y && \
+    apt-get clean && rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 EXPOSE 3000
 


### PR DESCRIPTION
### Description of the change

Precompile phusion/passanger. Every http request will trigger compilation of passanger native extension, however the compilation will failed due to unmet dependencies.

### Benefits

This pull request will precompile the passanger native extension and install it.

### Possible drawbacks

Not known

### Applicable issues

- fixes #31503

### Additional information

Below is excerpt from two log files when running discourse. Passanger will try to compile it, and if it fail it will try to download the binary.
```
discourse_1   | [ N 2023-04-24 11:33:38.9577 737/T5 age/Cor/SecurityUpdateChecker.h:519 ]: Security update check: no update found (next check in 24 hours)
discourse_1   | App 793 output:  [passenger_native_support.so] trying to compile for the current user (discourse) and Ruby interpreter...
discourse_1   | App 793 output:      (set PASSENGER_COMPILE_NATIVE_SUPPORT_BINARY=0 to disable)
discourse_1   | App 793 output:      Warning: compilation didn't succeed. To learn why, read this file:
discourse_1   | App 793 output:      /tmp/passenger_native_support-xpz2t9.log
discourse_1   | App 793 output:  [passenger_native_support.so] finding downloads for the current Ruby interpreter...
discourse_1   | App 793 output:      (set PASSENGER_DOWNLOAD_NATIVE_SUPPORT_BINARY=0 to disable)
**discourse_1   | App 793 output:      Could not download https://github.com/phusion/passenger/releases/download/release-6.0.17/rubyext-ruby-3.1.4-x86_64-linux.tar.gz: no download tool found (curl or wget required)**
discourse_1   | App 793 output:      Trying next mirror...
discourse_1   | App 793 output:      Could not download https://oss-binaries.phusionpassenger.com/binaries/passenger/by_release/6.0.17/rubyext-ruby-3.1.4-x86_64-linux.tar.gz: no download tool found (curl or wget required)
discourse_1   | App 793 output:      Trying next mirror...
discourse_1   | App 793 output:      Could not download https://s3.amazonaws.com/phusion-passenger/binaries/passenger/by_release/6.0.17/rubyext-ruby-3.1.4-x86_64-linux.tar.gz: no download tool found (curl or wget required)
discourse_1   | App 793 output:  [passenger_native_support.so] will not be used (can't compile or download)
discourse_1   | App 793 output:   --> Passenger will still operate normally.
```

```
checking for alloca.h... *** src/ruby_native_extension/extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
        --with-opt-dir
        --without-opt-dir
        --with-opt-include
        --without-opt-include=${opt-dir}/include
        --with-opt-lib
        --without-opt-lib=${opt-dir}/lib
        --with-make-prog
        --without-make-prog
        --srcdir=src/ruby_native_extension
        --curdir
        --ruby=/opt/bitnami/ruby/bin/$(RUBY_BASE_NAME)
        --with-alloca-dir
        --without-alloca-dir
        --with-alloca-include
        --without-alloca-include=${alloca-dir}/include
        --with-alloca-lib
        --without-alloca-lib=${alloca-dir}/lib
/opt/bitnami/ruby/lib/ruby/3.1.0/mkmf.rb:490:in `try_do': The compiler failed to generate an executable file. (RuntimeError)
You have to install development tools first.
        from /opt/bitnami/ruby/lib/ruby/3.1.0/mkmf.rb:616:in `block in try_compile'
        from /opt/bitnami/ruby/lib/ruby/3.1.0/mkmf.rb:565:in `with_werror'
        from /opt/bitnami/ruby/lib/ruby/3.1.0/mkmf.rb:616:in `try_compile'
        from /opt/bitnami/ruby/lib/ruby/3.1.0/mkmf.rb:1157:in `block in have_header'
        from /opt/bitnami/ruby/lib/ruby/3.1.0/mkmf.rb:989:in `block in checking_for'
        from /opt/bitnami/ruby/lib/ruby/3.1.0/mkmf.rb:354:in `block (2 levels) in postpone'
        from /opt/bitnami/ruby/lib/ruby/3.1.0/mkmf.rb:324:in `open'
        from /opt/bitnami/ruby/lib/ruby/3.1.0/mkmf.rb:354:in `block in postpone'
        from /opt/bitnami/ruby/lib/ruby/3.1.0/mkmf.rb:324:in `open'
        from /opt/bitnami/ruby/lib/ruby/3.1.0/mkmf.rb:350:in `postpone'
        from /opt/bitnami/ruby/lib/ruby/3.1.0/mkmf.rb:988:in `checking_for'
        from /opt/bitnami/ruby/lib/ruby/3.1.0/mkmf.rb:1156:in `have_header'
        from src/ruby_native_extension/extconf.rb:45:in `<main>'
```