### PR TITLE
[bitnami/prometheus-operator] Add VIB tests

### DIFF
--- a/.vib/prometheus-operator/goss/goss.yaml
+++ b/.vib/prometheus-operator/goss/goss.yaml
@@ -1,0 +1,9 @@
+gossfile:
+  # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-app-version.yaml: {}
+  ../../common/goss/templates/check-binaries.yaml: {}
+  ../../common/goss/templates/check-broken-symlinks.yaml: {}
+  ../../common/goss/templates/check-ca-certs.yaml: {}
+  ../../common/goss/templates/check-linked-libraries.yaml: {}
+  ../../common/goss/templates/check-sed-in-place.yaml: {}
+  ../../common/goss/templates/check-spdx.yaml: {}

--- a/.vib/prometheus-operator/goss/vars.yaml
+++ b/.vib/prometheus-operator/goss/vars.yaml
@@ -1,0 +1,7 @@
+binaries:
+  - operator
+  - prometheus-config-reloader
+root_dir: /opt/bitnami
+version:
+  bin_name: operator
+  flag: --version

--- a/.vib/prometheus-operator/vib-publish.json
+++ b/.vib/prometheus-operator/vib-publish.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{VIB_ENV_CONTAINER_URL}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyJ0YWlsIiwgIi1mIiwgIi9kZXYvbnVsbCJd"
   },
   "phases": {
     "package": {
@@ -80,6 +81,21 @@
                   "header": "Authorization",
                   "token": "Bearer {VIB_ENV_GITHUB_TOKEN}"
                 }
+            }
+          }
+        },
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "prometheus-operator/goss/goss.yaml",
+            "vars_file": "prometheus-operator/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-prometheus-operator"
+              }
             }
           }
         }

--- a/.vib/prometheus-operator/vib-verify.json
+++ b/.vib/prometheus-operator/vib-verify.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyJ0YWlsIiwgIi1mIiwgIi9kZXYvbnVsbCJd"
   },
   "phases": {
     "package": {
@@ -45,6 +46,21 @@
             "package_type": [
               "OS"
             ]
+          }
+        },
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "prometheus-operator/goss/goss.yaml",
+            "vars_file": "prometheus-operator/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-prometheus-operator"
+              }
+            }
           }
         }
       ]


### PR DESCRIPTION
### Description of the change

The main objective of this PR is to publish our Bitnami Prometheus Operator container using VMware Image Builder. In order to do that, several changes are included:

- Increasing the existing test coverage of the asset by adding Goss tests.
- Update verify and publish VIB pipeline's definitions.

### Benefits

- Ensuring higher quality of the container catalog.
- Increased pool of assets completely handled by VMware Image Builder.

### Possible drawbacks

Automated tests could introduce additional flakiness to the CI/CD.

### Applicable issues

NA