### PR TITLE
[bitnami/drupal] (feat) Allows custom install directory for Drupal. Needed for some customizations

### DIFF
--- a/bitnami/drupal/10/debian-11/Dockerfile
+++ b/bitnami/drupal/10/debian-11/Dockerfile
@@ -44,6 +44,19 @@ RUN apt-get autoremove --purge -y curl && \
     apt-get clean && rm -rf /var/lib/apt/lists /var/cache/apt/archives
 RUN chmod g+rwX /opt/bitnami
 
+# Optionally override DRUPAL_BASE_DIR to install Drupal in a custom directory
+ARG DRUPAL_BASE_DIR=/opt/bitnami/drupal
+ENV DRUPAL_BASE_DIR=$DRUPAL_BASE_DIR \
+    # For shared libs that don't know about Drupal vars
+    APP_BASE_DIR=$DRUPAL_BASE_DIR
+RUN \
+  if [ "${DRUPAL_BASE_DIR}" != '/opt/bitnami/drupal'  ]; then \
+    tmp=$(mktemp -d) && \
+    mv /opt/bitnami/drupal "${tmp}" && \
+    mkdir -p "$(dirname ${DRUPAL_BASE_DIR})" && \
+    mv "${tmp}/drupal" "${DRUPAL_BASE_DIR}" ; \
+  fi
+
 COPY rootfs /
 RUN /opt/bitnami/scripts/apache/postunpack.sh
 RUN /opt/bitnami/scripts/php/postunpack.sh
@@ -54,7 +67,7 @@ ENV APACHE_HTTPS_PORT_NUMBER="" \
     APACHE_HTTP_PORT_NUMBER="" \
     APP_VERSION="10.0.7" \
     BITNAMI_APP_NAME="drupal" \
-    PATH="/opt/bitnami/php/bin:/opt/bitnami/php/sbin:/opt/bitnami/apache/bin:/opt/bitnami/mysql/bin:/opt/bitnami/common/bin:/opt/bitnami/drupal/vendor/bin:$PATH"
+    PATH="/opt/bitnami/php/bin:/opt/bitnami/php/sbin:/opt/bitnami/apache/bin:/opt/bitnami/mysql/bin:/opt/bitnami/common/bin:${DRUPAL_BASE_DIR}/vendor/bin:$PATH"
 
 EXPOSE 8080 8443
 

--- a/bitnami/drupal/10/debian-11/prebuildfs/opt/bitnami/scripts/libpersistence.sh
+++ b/bitnami/drupal/10/debian-11/prebuildfs/opt/bitnami/scripts/libpersistence.sh
@@ -28,7 +28,8 @@ persist_app() {
     local -r app="${1:?missing app}"
     local -a files_to_restore
     read -r -a files_to_persist <<< "$(tr ',;:' ' ' <<< "$2")"
-    local -r install_dir="${BITNAMI_ROOT_DIR}/${app}"
+    local default_install_dir="${BITNAMI_ROOT_DIR}/${app}"
+    local -r install_dir="${APP_BASE_DIR:-$default_install_dir}"
     local -r persist_dir="${BITNAMI_VOLUME_DIR}/${app}"
     # Persist the individual files
     if [[ "${#files_to_persist[@]}" -le 0 ]]; then
@@ -84,7 +85,8 @@ restore_persisted_app() {
     local -r app="${1:?missing app}"
     local -a files_to_restore
     read -r -a files_to_restore <<< "$(tr ',;:' ' ' <<< "$2")"
-    local -r install_dir="${BITNAMI_ROOT_DIR}/${app}"
+    local default_install_dir="${BITNAMI_ROOT_DIR}/${app}"
+    local -r install_dir="${APP_BASE_DIR:-$default_install_dir}"
     local -r persist_dir="${BITNAMI_VOLUME_DIR}/${app}"
     # Restore the individual persisted files
     if [[ "${#files_to_restore[@]}" -le 0 ]]; then

--- a/bitnami/drupal/10/debian-11/rootfs/opt/bitnami/scripts/drupal-env.sh
+++ b/bitnami/drupal/10/debian-11/rootfs/opt/bitnami/scripts/drupal-env.sh
@@ -66,7 +66,8 @@ done
 unset drupal_env_vars
 
 # Paths
-export DRUPAL_BASE_DIR="${BITNAMI_ROOT_DIR}/drupal"
+default_drupal_base_dir="${BITNAMI_ROOT_DIR}/drupal"
+export DRUPAL_BASE_DIR="${DRUPAL_BASE_DIR:-$default_drupal_base_dir}"
 export DRUPAL_CONF_FILE="${DRUPAL_BASE_DIR}/sites/default/settings.php"
 export DRUPAL_MODULES_DIR="${DRUPAL_BASE_DIR}/modules"
 

--- a/bitnami/drupal/10/debian-11/rootfs/opt/bitnami/scripts/libapache.sh
+++ b/bitnami/drupal/10/debian-11/rootfs/opt/bitnami/scripts/libapache.sh
@@ -274,7 +274,8 @@ apache_replace_htaccess_files() {
     local -r app="${1:?missing app}"
     local -r result_file="${APACHE_HTACCESS_DIR}/${app}-htaccess.conf"
     # Default options
-    local document_root="${BITNAMI_ROOT_DIR}/${app}"
+    local default_document_root="${BITNAMI_ROOT_DIR}/${app}"
+    local document_root="${APP_BASE_DIR:-$default_document_root}"
     local overwrite="yes"
     local -a htaccess_files
     local htaccess_dir
@@ -381,7 +382,8 @@ ensure_apache_app_configuration_exists() {
     export additional_https_configuration=""
     export before_vhost_configuration=""
     export allow_override="All"
-    export document_root="${BITNAMI_ROOT_DIR}/${app}"
+    local default_document_root="${BITNAMI_ROOT_DIR}/${app}"
+    export document_root="${APP_BASE_DIR:-$default_document_root}"
     export extra_directory_configuration=""
     export default_http_port="${APACHE_HTTP_PORT_NUMBER:-"$APACHE_DEFAULT_HTTP_PORT_NUMBER"}"
     export default_https_port="${APACHE_HTTPS_PORT_NUMBER:-"$APACHE_DEFAULT_HTTPS_PORT_NUMBER"}"
@@ -575,7 +577,8 @@ ensure_apache_prefix_configuration_exists() {
     # Template variables defaults
     export additional_configuration=""
     export allow_override="All"
-    export document_root="${BITNAMI_ROOT_DIR}/${app}"
+    local default_document_root="${BITNAMI_ROOT_DIR}/${app}"
+    export document_root="${APP_BASE_DIR:-$default_document_root}"
     export extra_directory_configuration=""
     # Validate arguments
     local var_name

--- a/bitnami/drupal/9/debian-11/Dockerfile
+++ b/bitnami/drupal/9/debian-11/Dockerfile
@@ -44,6 +44,19 @@ RUN apt-get autoremove --purge -y curl && \
     apt-get clean && rm -rf /var/lib/apt/lists /var/cache/apt/archives
 RUN chmod g+rwX /opt/bitnami
 
+# Optionally override DRUPAL_BASE_DIR to install Drupal in a custom directory
+ARG DRUPAL_BASE_DIR=/opt/bitnami/drupal
+ENV DRUPAL_BASE_DIR=$DRUPAL_BASE_DIR \
+    # For shared libs that don't know about Drupal vars
+    APP_BASE_DIR=$DRUPAL_BASE_DIR
+RUN \
+  if [ "${DRUPAL_BASE_DIR}" != '/opt/bitnami/drupal'  ]; then \
+    tmp=$(mktemp -d) && \
+    mv /opt/bitnami/drupal "${tmp}" && \
+    mkdir -p "$(dirname ${DRUPAL_BASE_DIR})" && \
+    mv "${tmp}/drupal" "${DRUPAL_BASE_DIR}" ; \
+  fi
+
 COPY rootfs /
 RUN /opt/bitnami/scripts/apache/postunpack.sh
 RUN /opt/bitnami/scripts/php/postunpack.sh
@@ -54,7 +67,7 @@ ENV APACHE_HTTPS_PORT_NUMBER="" \
     APACHE_HTTP_PORT_NUMBER="" \
     APP_VERSION="9.5.7" \
     BITNAMI_APP_NAME="drupal" \
-    PATH="/opt/bitnami/php/bin:/opt/bitnami/php/sbin:/opt/bitnami/apache/bin:/opt/bitnami/mysql/bin:/opt/bitnami/common/bin:/opt/bitnami/drupal/vendor/bin:$PATH"
+    PATH="/opt/bitnami/php/bin:/opt/bitnami/php/sbin:/opt/bitnami/apache/bin:/opt/bitnami/mysql/bin:/opt/bitnami/common/bin:${DRUPAL_BASE_DIR}/vendor/bin:$PATH"
 
 EXPOSE 8080 8443
 

--- a/bitnami/drupal/9/debian-11/prebuildfs/opt/bitnami/scripts/libpersistence.sh
+++ b/bitnami/drupal/9/debian-11/prebuildfs/opt/bitnami/scripts/libpersistence.sh
@@ -28,7 +28,8 @@ persist_app() {
     local -r app="${1:?missing app}"
     local -a files_to_restore
     read -r -a files_to_persist <<< "$(tr ',;:' ' ' <<< "$2")"
-    local -r install_dir="${BITNAMI_ROOT_DIR}/${app}"
+    local default_install_dir="${BITNAMI_ROOT_DIR}/${app}"
+    local -r install_dir="${APP_BASE_DIR:-$default_install_dir}"
     local -r persist_dir="${BITNAMI_VOLUME_DIR}/${app}"
     # Persist the individual files
     if [[ "${#files_to_persist[@]}" -le 0 ]]; then
@@ -84,7 +85,8 @@ restore_persisted_app() {
     local -r app="${1:?missing app}"
     local -a files_to_restore
     read -r -a files_to_restore <<< "$(tr ',;:' ' ' <<< "$2")"
-    local -r install_dir="${BITNAMI_ROOT_DIR}/${app}"
+    local default_install_dir="${BITNAMI_ROOT_DIR}/${app}"
+    local -r install_dir="${APP_BASE_DIR:-$default_install_dir}"
     local -r persist_dir="${BITNAMI_VOLUME_DIR}/${app}"
     # Restore the individual persisted files
     if [[ "${#files_to_restore[@]}" -le 0 ]]; then

--- a/bitnami/drupal/9/debian-11/rootfs/opt/bitnami/scripts/drupal-env.sh
+++ b/bitnami/drupal/9/debian-11/rootfs/opt/bitnami/scripts/drupal-env.sh
@@ -66,7 +66,8 @@ done
 unset drupal_env_vars
 
 # Paths
-export DRUPAL_BASE_DIR="${BITNAMI_ROOT_DIR}/drupal"
+default_drupal_base_dir="${BITNAMI_ROOT_DIR}/drupal"
+export DRUPAL_BASE_DIR="${DRUPAL_BASE_DIR:-$default_drupal_base_dir}"
 export DRUPAL_CONF_FILE="${DRUPAL_BASE_DIR}/sites/default/settings.php"
 export DRUPAL_MODULES_DIR="${DRUPAL_BASE_DIR}/modules"
 

--- a/bitnami/drupal/9/debian-11/rootfs/opt/bitnami/scripts/libapache.sh
+++ b/bitnami/drupal/9/debian-11/rootfs/opt/bitnami/scripts/libapache.sh
@@ -274,7 +274,8 @@ apache_replace_htaccess_files() {
     local -r app="${1:?missing app}"
     local -r result_file="${APACHE_HTACCESS_DIR}/${app}-htaccess.conf"
     # Default options
-    local document_root="${BITNAMI_ROOT_DIR}/${app}"
+    local default_document_root="${BITNAMI_ROOT_DIR}/${app}"
+    local document_root="${APP_BASE_DIR:-$default_document_root}"
     local overwrite="yes"
     local -a htaccess_files
     local htaccess_dir
@@ -381,7 +382,8 @@ ensure_apache_app_configuration_exists() {
     export additional_https_configuration=""
     export before_vhost_configuration=""
     export allow_override="All"
-    export document_root="${BITNAMI_ROOT_DIR}/${app}"
+    local default_document_root="${BITNAMI_ROOT_DIR}/${app}"
+    export document_root="${APP_BASE_DIR:-$default_document_root}"
     export extra_directory_configuration=""
     export default_http_port="${APACHE_HTTP_PORT_NUMBER:-"$APACHE_DEFAULT_HTTP_PORT_NUMBER"}"
     export default_https_port="${APACHE_HTTPS_PORT_NUMBER:-"$APACHE_DEFAULT_HTTPS_PORT_NUMBER"}"
@@ -575,7 +577,8 @@ ensure_apache_prefix_configuration_exists() {
     # Template variables defaults
     export additional_configuration=""
     export allow_override="All"
-    export document_root="${BITNAMI_ROOT_DIR}/${app}"
+    local default_document_root="${BITNAMI_ROOT_DIR}/${app}"
+    export document_root="${APP_BASE_DIR:-$default_document_root}"
     export extra_directory_configuration=""
     # Validate arguments
     local var_name

--- a/bitnami/drupal/README.md
+++ b/bitnami/drupal/README.md
@@ -65,6 +65,10 @@ cd bitnami/APP/VERSION/OPERATING-SYSTEM
 docker build -t bitnami/APP:latest .
 ```
 
+There are also [build-time variables](https://docs.docker.com/engine/reference/commandline/build/#build-arg) you may pass when building the image yourself, which allow additional customization:
+
+* `DRUPAL_BASE_DIR`: Allows custom install directory for Drupal. Default: **/opt/bitnami/drupal**
+
 ## How to use this image
 
 Drupal requires access to a MySQL or MariaDB database to store information. We'll use the [Bitnami Docker Image for MariaDB](https://github.com/bitnami/containers/tree/main/bitnami/mariadb) for the database requirements.


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

Allows users to customize the Drupal install directory by passing `DRUPAL_BASE_DIR` as a build arg.

Passing `DRUPAL_BASE_DIR` as a build arg also has two other effects:
- Sets `DRUPAL_BASE_DIR` env var. Note this was already an existing, undocumented env var set by `drupal-env.sh`, and used for the same purpose.
- Sets `APP_BASE_DIR` env var with the same value. This is for shared libs – libapache and libpersistence – that should not need to know about Drupal-specific vars, only that there is an `app` `install_dir`, and `document_root`.

Examples:

Building a custom image:
```console
docker build . --build-arg DRUPAL_BASE_DIR=/opt/bitnami/drupal/docroot
```

Using docker compose:
```diff
--- a/bitnami/drupal/9/debian-11/docker-compose.yml
+++ b/bitnami/drupal/9/debian-11/docker-compose.yml
@@ -10,7 +10,11 @@ services:
     volumes:
       - 'mariadb_data:/bitnami/mariadb'
   drupal:
-    image: docker.io/bitnami/drupal:9
+    # image: docker.io/bitnami/drupal:9
+    build:
+      context: .
+      args:
+        DRUPAL_BASE_DIR: /opt/bitnami/drupal/docroot
     ports:
       - '80:8080'
       - '443:8443'
```

### Benefits

<!-- What benefits will be realized by the code change? -->

Currently, users must install Drupal in `/opt/bitnami/drupal`. However, a common pattern for Drupal installations assumes certain files and directories live one directory up from the Drupal installation dir (composer.json, files, config). This change allows users to specify their Drupal install location.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

Will not work with certain paths (for example `/`, as there is no parent directory). However, it will work with any dir below `/opt/bitnami` or custom paths such as `/foo/bar/baz`.

A user could also, in theory, specify an existing dir with conflicting file names once Drupal is unpacked there, which would be possible with an otherwise customized installation.

Users will need to know what they are doing to specify a custom Drupal base directory.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

N/A. I could open an issue though if that would help.

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
