### PR TITLE
[bitnami/drupal] (feat) Allows users to optionally install Drupal dependencies with Composer

### DIFF
--- a/bitnami/drupal/10/debian-11/rootfs/opt/bitnami/scripts/drupal-env.sh
+++ b/bitnami/drupal/10/debian-11/rootfs/opt/bitnami/scripts/drupal-env.sh
@@ -69,6 +69,11 @@ unset drupal_env_vars
 export DRUPAL_BASE_DIR="${BITNAMI_ROOT_DIR}/drupal"
 export DRUPAL_CONF_FILE="${DRUPAL_BASE_DIR}/sites/default/settings.php"
 export DRUPAL_MODULES_DIR="${DRUPAL_BASE_DIR}/modules"
+export DRUPAL_COMPOSER_INSTALL="${DRUPAL_COMPOSER_INSTALL:-no}"
+default_drupal_composer_file="${DRUPAL_BASE_DIR}/composer.json"
+export DRUPAL_COMPOSER_FILE="${DRUPAL_COMPOSER_FILE:-$default_drupal_composer_file}"
+export DRUPAL_MOUNTED_COMPOSER_FILE="${DRUPAL_MOUNTED_COMPOSER_FILE:-}"
+export DRUPAL_MOUNTED_COMPOSER_LOCK_FILE="${DRUPAL_MOUNTED_COMPOSER_LOCK_FILE:-}"
 
 # Drupal persistence configuration
 export DRUPAL_VOLUME_DIR="${BITNAMI_VOLUME_DIR}/drupal"

--- a/bitnami/drupal/9/debian-11/rootfs/opt/bitnami/scripts/drupal-env.sh
+++ b/bitnami/drupal/9/debian-11/rootfs/opt/bitnami/scripts/drupal-env.sh
@@ -69,6 +69,11 @@ unset drupal_env_vars
 export DRUPAL_BASE_DIR="${BITNAMI_ROOT_DIR}/drupal"
 export DRUPAL_CONF_FILE="${DRUPAL_BASE_DIR}/sites/default/settings.php"
 export DRUPAL_MODULES_DIR="${DRUPAL_BASE_DIR}/modules"
+export DRUPAL_COMPOSER_INSTALL="${DRUPAL_COMPOSER_INSTALL:-no}"
+default_drupal_composer_file="${DRUPAL_BASE_DIR}/composer.json"
+export DRUPAL_COMPOSER_FILE="${DRUPAL_COMPOSER_FILE:-$default_drupal_composer_file}"
+export DRUPAL_MOUNTED_COMPOSER_FILE="${DRUPAL_MOUNTED_COMPOSER_FILE:-}"
+export DRUPAL_MOUNTED_COMPOSER_LOCK_FILE="${DRUPAL_MOUNTED_COMPOSER_LOCK_FILE:-}"
 
 # Drupal persistence configuration
 export DRUPAL_VOLUME_DIR="${BITNAMI_VOLUME_DIR}/drupal"

--- a/bitnami/drupal/README.md
+++ b/bitnami/drupal/README.md
@@ -281,6 +281,25 @@ To configure Drupal to send email using SMTP you can set the following environme
 * `PHP_POST_MAX_SIZE`: Maximum size for PHP POST requests. No default.
 * `PHP_UPLOAD_MAX_FILESIZE`: Maximum file size for PHP uploads. No default.
 
+#### Installation options
+
+* `DRUPAL_COMPOSER_INSTALL`: Optionally [installs Drupal dependencies with Composer](https://www.drupal.org/docs/develop/using-composer/manage-dependencies). Default: **no**
+* `DRUPAL_COMPOSER_FILE`: Desired Drupal Composer file location for `DRUPAL_COMPOSER_INSTALL`. Default: **`DRUPAL_BASE_DIR`/composer.json**
+* `DRUPAL_MOUNTED_COMPOSER_FILE`: Location of a mounted custom Composer file for `DRUPAL_COMPOSER_INSTALL`. No defaults
+* `DRUPAL_MOUNTED_COMPOSER_LOCK_FILE`: Location of a mounted custom Composer lock file for `DRUPAL_COMPOSER_INSTALL`. Note a lock file is recommended in testing and production environments for dependency version reproducibility. No defaults
+
+Note, when using Composer to install Drupal dependencies in read-only container volumes, it's recommended to set the Composer [cache-read-only](https://getcomposer.org/doc/06-config.md#cache-read-only) config:
+
+```diff
+     "minimum-stability": "stable",
+     "prefer-stable": true,
+     "config": {
++        "cache-read-only": true,
+         "allow-plugins": {
+             "composer/installers": true,
+             "drupal/core-composer-scaffold": true,
+```
+
 #### Example
 
 This would be an example of SMTP configuration using a Gmail account:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

Setting `DRUPAL_COMPOSER_INSTALL` env var to `yes` will install Drupal dependencies with Composer.

If `DRUPAL_COMPOSER_INSTALL` is `yes`, the following additional env vars apply:
* `DRUPAL_COMPOSER_FILE` allows users to specify an alternative desired Drupal Composer file location. This is useful for some setups, where you want composer.json to be a directory above the Drupal installation dir.
* `DRUPAL_MOUNTED_COMPOSER_FILE` Location of a mounted custom Composer file
* `DRUPAL_MOUNTED_COMPOSER_LOCK_FILE`: Location of a mounted custom Composer lock file. A lock file is recommended in testing and production environments for dependency version reproducibility. This warning is presented to the user if a Composer lock file is not also mounted.

Example custom composer.json file change to add Token contrib module :

```diff
@@ -21,7 +21,8 @@
         "drupal/core-recommended": "^9.5",
         "drupal/core-vendor-hardening": "^9.5",
         "drush/drush": "11.5.1",
-        "phpmailer/phpmailer": "6.8.0"
+        "phpmailer/phpmailer": "6.8.0",
+        "drupal/token": "^1.11"
     },
     "conflict": {
         "drupal/drupal": "*"
```

Example using Docker compose:

```diff
--- a/bitnami/drupal/10/debian-11/docker-compose.yml
+++ b/bitnami/drupal/10/debian-11/docker-compose.yml
@@ -21,8 +23,13 @@ services:
       - DRUPAL_DATABASE_NAME=bitnami_drupal
       # ALLOW_EMPTY_PASSWORD is recommended only for development.
       - ALLOW_EMPTY_PASSWORD=yes
+      - DRUPAL_COMPOSER_INSTALL=true
+      - DRUPAL_MOUNTED_COMPOSER_FILE=/custom/mounted-composer.json
+      - DRUPAL_MOUNTED_COMPOSER_LOCK_FILE=/custom/mounted-composer.lock
     volumes:
       - 'drupal_data:/bitnami/drupal'
+      - './test-data/test-mounted-composer.json:/custom/mounted-composer.json'
+      - './test-data/test-mounted-composer.lock:/custom/mounted-composer.lock'
     depends_on:
       - mariadb
 volumes:
```

### Benefits

<!-- What benefits will be realized by the code change? -->

This is not an edge case. Composer is the preferred way to install Drupal dependencies, such as contrib or custom modules, themes, and install profiles, patches to any of those or to Drupal core. However, there is currently no good way to do this with the bitnami/drupal container for initial installation (see https://www.drupal.org/docs/develop/using-composer/manage-dependencies).

### Possible drawbacks

<!-- Describe any known limitations with your change -->

None.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

N/A

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->