### PR TITLE
[bitnami/tensorflow-serving] Add VIB tests

### DIFF
--- a/.vib/tensorflow-serving/goss/goss.yaml
+++ b/.vib/tensorflow-serving/goss/goss.yaml
@@ -1,0 +1,12 @@
+gossfile:
+  # Goss tests exclusive to the current container
+  ../../tensorflow-serving/goss/tensorflow-serving.yaml: {}
+  # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-app-version.yaml: {}
+  ../../common/goss/templates/check-binaries.yaml: {}
+  ../../common/goss/templates/check-broken-symlinks.yaml: {}
+  ../../common/goss/templates/check-ca-certs.yaml: {}
+  ../../common/goss/templates/check-directories.yaml: {}
+  ../../common/goss/templates/check-linked-libraries.yaml: {}
+  ../../common/goss/templates/check-sed-in-place.yaml: {}
+  ../../common/goss/templates/check-spdx.yaml: {}

--- a/.vib/tensorflow-serving/goss/tensorflow-serving.yaml
+++ b/.vib/tensorflow-serving/goss/tensorflow-serving.yaml
@@ -1,0 +1,6 @@
+group:
+  tensorflow:
+    exists: true
+user:
+  tensorflow:
+    exists: true

--- a/.vib/tensorflow-serving/goss/vars.yaml
+++ b/.vib/tensorflow-serving/goss/vars.yaml
@@ -1,0 +1,15 @@
+binaries:
+  - render-template
+directories:
+  - mode: "0775"
+    paths:
+      - /opt/bitnami/tensorflow-serving
+      - /opt/bitnami/tensorflow-serving/tmp
+      - /opt/bitnami/tensorflow-serving/bin
+      - /opt/bitnami/tensorflow-serving/conf
+      - /opt/bitnami/tensorflow-serving/logs
+      - /bitnami/tensorflow-serving
+root_dir: /opt/bitnami
+version:
+  bin_name: tensorflow_model_server
+  flag: --version

--- a/.vib/tensorflow-serving/goss/vars.yaml
+++ b/.vib/tensorflow-serving/goss/vars.yaml
@@ -1,7 +1,10 @@
 binaries:
   - render-template
+  - tensorflow_model_server
 directories:
   - mode: "0775"
+    owner: tensorflow
+    group: root
     paths:
       - /opt/bitnami/tensorflow-serving
       - /opt/bitnami/tensorflow-serving/tmp

--- a/.vib/tensorflow-serving/vib-publish.json
+++ b/.vib/tensorflow-serving/vib-publish.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{VIB_ENV_CONTAINER_URL}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyJ0YWlsIiwgIi1mIiwgIi9kZXYvbnVsbCJd"
   },
   "phases": {
     "package": {
@@ -33,6 +34,21 @@
     },
     "verify": {
       "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "tensorflow-serving/goss/goss.yaml",
+            "vars_file": "tensorflow-serving/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-tensorflow-serving"
+              }
+            }
+          }
+        },
         {
           "action_id": "trivy",
           "params": {

--- a/.vib/tensorflow-serving/vib-verify.json
+++ b/.vib/tensorflow-serving/vib-verify.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyJ0YWlsIiwgIi1mIiwgIi9kZXYvbnVsbCJd"
   },
   "phases": {
     "package": {
@@ -29,6 +30,21 @@
     },
     "verify": {
       "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "tensorflow-serving/goss/goss.yaml",
+            "vars_file": "tensorflow-serving/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-tensorflow-serving"
+              }
+            }
+          }
+        },
         {
           "action_id": "trivy",
           "params": {

--- a/bitnami/tensorflow-serving/2/debian-11/docker-compose.yml
+++ b/bitnami/tensorflow-serving/2/debian-11/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '2'
 
 services:
+  # New change
   tensorflow-serving:
     image: docker.io/bitnami/tensorflow-serving:2
     ports:

--- a/bitnami/tensorflow-serving/2/debian-11/docker-compose.yml
+++ b/bitnami/tensorflow-serving/2/debian-11/docker-compose.yml
@@ -1,7 +1,6 @@
 version: '2'
 
 services:
-  # New change
   tensorflow-serving:
     image: docker.io/bitnami/tensorflow-serving:2
     ports:


### PR DESCRIPTION
### Description of the change

The main objective of this PR is to publish our Bitnami Tensorflow-serving container using VMware Image Builder. In order to do that, several changes are included:

- Increasing the existing test coverage of the asset by adding Goss tests.
- Update verify and publish VIB pipeline's definitions.

### Benefits

- Ensuring higher quality of the container catalog.
- Increased pool of assets completely handled by VMware Image Builder.

### Possible drawbacks

Automated tests could introduce additional flakiness to the CI/CD.

### Applicable issues

NA
