### PR TITLE
[bitnami/etcd] Support for ARM is dropped for branch 3.4

### DIFF
--- a/.vib/etcd/3.4/vib-publish.json
+++ b/.vib/etcd/3.4/vib-publish.json
@@ -1,0 +1,125 @@
+{
+  "context": {
+    "resources": {
+      "url": "{VIB_ENV_CONTAINER_URL}",
+      "path": "{VIB_ENV_PATH}"
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyJ0YWlsIiwgIi1mIiwgIi9kZXYvbnVsbCJd"
+  },
+  "phases": {
+    "package": {
+      "actions": [
+        {
+          "action_id": "container-image-package",
+          "params": {
+            "application": {
+              "details": {
+                "name": "{VIB_ENV_CONTAINER}",
+                "tag": "{VIB_ENV_TAG}"
+              }
+            },
+            "architectures": [
+              "linux/amd64",
+              "linux/arm64"
+            ]
+          }
+        },
+        {
+          "action_id": "container-image-lint",
+          "params": {
+            "threshold": "error"
+          }
+        }
+      ]
+    },
+    "verify": {
+      "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "etcd/goss/goss.yaml",
+            "vars_file": "etcd/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-etcd"
+              }
+            }
+          }
+        },
+        {
+          "action_id": "trivy",
+          "params": {
+            "threshold": "CRITICAL",
+            "vuln_type": [
+              "OS"
+            ]
+          }
+        },
+        {
+          "action_id": "grype",
+          "params": {
+            "threshold": "CRITICAL",
+            "package_type": [
+              "OS"
+            ]
+          }
+        },
+        {
+          "action_id": "osspi-application",
+          "params": {
+            "additional_packages_file": "osspi-packages-amd64.json",
+            "scan_type": "BASE_OS",
+            "osm": {
+              "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
+              "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
+              "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
+              "architecture_overrides": [
+                {
+                  "architecture": "linux/amd64",
+                  "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
+                  "additional_packages_file": "osspi-packages-amd64.json"
+                },
+                {
+                  "architecture": "linux/arm64",
+                  "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container-arm64",
+                  "additional_packages_file": "osspi-packages-arm64.json"
+                }
+              ]
+            },
+            "resources": {
+              "url": "{VIB_ENV_PACKAGES_JSON_URL}",
+              "path": "/{VIB_ENV_PATH}",
+              "authn": {
+                "header": "Authorization",
+                "token": "Bearer {VIB_ENV_GITHUB_TOKEN}"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "publish": {
+      "actions": [
+        {
+          "action_id": "container-image-publish",
+          "params": {
+            "metadata": {
+              "tags": {VIB_ENV_ROLLING_TAGS}
+            },
+            "repository": {
+              "kind": "OCI",
+              "url": "{VIB_ENV_REGISTRY_URL}",
+              "authn": {
+                "username": "{VIB_ENV_REGISTRY_USERNAME}",
+                "password": "{VIB_ENV_REGISTRY_PASSWORD}"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/.vib/etcd/3.4/vib-publish.json
+++ b/.vib/etcd/3.4/vib-publish.json
@@ -19,8 +19,7 @@
               }
             },
             "architectures": [
-              "linux/amd64",
-              "linux/arm64"
+              "linux/amd64"
             ]
           }
         },
@@ -75,19 +74,7 @@
             "osm": {
               "associated_bossd_release": "{VIB_ENV_BOSSD_RELEASE_ID}",
               "product_name": "main-catalog-{VIB_ENV_CONTAINER}",
-              "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
-              "architecture_overrides": [
-                {
-                  "architecture": "linux/amd64",
-                  "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container",
-                  "additional_packages_file": "osspi-packages-amd64.json"
-                },
-                {
-                  "architecture": "linux/arm64",
-                  "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container-arm64",
-                  "additional_packages_file": "osspi-packages-arm64.json"
-                }
-              ]
+              "product_version": "{VIB_ENV_APP_VERSION}-{VIB_ENV_OS_FLAVOUR}-container"
             },
             "resources": {
               "url": "{VIB_ENV_PACKAGES_JSON_URL}",


### PR DESCRIPTION
### Description of the change

Remove ARM support for `etcd` 3.4. According to [v3.4.26 docs](https://github.com/etcd-io/etcd/blob/v3.4.26/Documentation/op-guide/supported-platform.md), arm64 is experimental and not maintained by official etcd maintainers

### Benefits

Unblock AMD64 releases for branch 3.4 (currently blocked due to some failures in ARM tests)

### Possible drawbacks

None identified

### Applicable issues

CD pipelines failing due to ARM tests in 3.4
- https://github.com/bitnami/containers/actions/runs/5044589128
- https://github.com/bitnami/containers/actions/runs/5038203387
