### PR TITLE
[bitnami/matomo] added optional env variables to set noreply name and address

### DIFF
--- a/bitnami/matomo/4/debian-11/rootfs/opt/bitnami/scripts/libmatomo.sh
+++ b/bitnami/matomo/4/debian-11/rootfs/opt/bitnami/scripts/libmatomo.sh
@@ -204,6 +204,15 @@ EOF
             ini-file set -s "mail" -k "encryption" -v "$MATOMO_SMTP_PROTOCOL" "$MATOMO_CONF_FILE"
         fi
 
+        # Optional noreply name and address
+        if ! is_empty_value "$MATOMO_NOREPLY_NAME"; then
+            ini-file set -s "General" -k "noreply_email_name" -v "$MATOMO_NOREPLY_NAME" "$MATOMO_CONF_FILE"
+        fi
+
+        if ! is_empty_value "$MATOMO_NOREPLY_ADDRESS"; then
+            ini-file set -s "General" -k "noreply_email_address" -v "$MATOMO_NOREPLY_ADDRESS" "$MATOMO_CONF_FILE"
+        fi
+
         info "Persisting Matomo installation"
         persist_app "$app_name" "$MATOMO_DATA_TO_PERSIST"
     else

--- a/bitnami/matomo/4/debian-11/rootfs/opt/bitnami/scripts/libmatomo.sh
+++ b/bitnami/matomo/4/debian-11/rootfs/opt/bitnami/scripts/libmatomo.sh
@@ -202,12 +202,10 @@ EOF
             ini-file set -s "mail" -k "password" -v "$MATOMO_SMTP_PASSWORD" "$MATOMO_CONF_FILE"
             ini-file set -s "mail" -k "type" -v "$MATOMO_SMTP_AUTH" "$MATOMO_CONF_FILE"
             ini-file set -s "mail" -k "encryption" -v "$MATOMO_SMTP_PROTOCOL" "$MATOMO_CONF_FILE"
-
             # Optional noreply name and address
             if ! is_empty_value "$MATOMO_NOREPLY_NAME"; then
                 ini-file set -s "General" -k "noreply_email_name" -v "$MATOMO_NOREPLY_NAME" "$MATOMO_CONF_FILE"
             fi
-
             if ! is_empty_value "$MATOMO_NOREPLY_ADDRESS"; then
                 ini-file set -s "General" -k "noreply_email_address" -v "$MATOMO_NOREPLY_ADDRESS" "$MATOMO_CONF_FILE"
             fi

--- a/bitnami/matomo/4/debian-11/rootfs/opt/bitnami/scripts/libmatomo.sh
+++ b/bitnami/matomo/4/debian-11/rootfs/opt/bitnami/scripts/libmatomo.sh
@@ -202,15 +202,15 @@ EOF
             ini-file set -s "mail" -k "password" -v "$MATOMO_SMTP_PASSWORD" "$MATOMO_CONF_FILE"
             ini-file set -s "mail" -k "type" -v "$MATOMO_SMTP_AUTH" "$MATOMO_CONF_FILE"
             ini-file set -s "mail" -k "encryption" -v "$MATOMO_SMTP_PROTOCOL" "$MATOMO_CONF_FILE"
-        fi
 
-        # Optional noreply name and address
-        if ! is_empty_value "$MATOMO_NOREPLY_NAME"; then
-            ini-file set -s "General" -k "noreply_email_name" -v "$MATOMO_NOREPLY_NAME" "$MATOMO_CONF_FILE"
-        fi
+            # Optional noreply name and address
+            if ! is_empty_value "$MATOMO_NOREPLY_NAME"; then
+                ini-file set -s "General" -k "noreply_email_name" -v "$MATOMO_NOREPLY_NAME" "$MATOMO_CONF_FILE"
+            fi
 
-        if ! is_empty_value "$MATOMO_NOREPLY_ADDRESS"; then
-            ini-file set -s "General" -k "noreply_email_address" -v "$MATOMO_NOREPLY_ADDRESS" "$MATOMO_CONF_FILE"
+            if ! is_empty_value "$MATOMO_NOREPLY_ADDRESS"; then
+                ini-file set -s "General" -k "noreply_email_address" -v "$MATOMO_NOREPLY_ADDRESS" "$MATOMO_CONF_FILE"
+            fi
         fi
 
         info "Persisting Matomo installation"

--- a/bitnami/matomo/4/debian-11/rootfs/opt/bitnami/scripts/matomo-env.sh
+++ b/bitnami/matomo/4/debian-11/rootfs/opt/bitnami/scripts/matomo-env.sh
@@ -47,6 +47,8 @@ matomo_env_vars=(
     MATOMO_SMTP_PASSWORD
     MATOMO_SMTP_AUTH
     MATOMO_SMTP_PROTOCOL
+    MATOMO_NOREPLY_NAME
+    MATOMO_NOREPLY_ADDRESS
     MATOMO_DATABASE_HOST
     MATOMO_DATABASE_PORT_NUMBER
     MATOMO_DATABASE_NAME
@@ -121,6 +123,8 @@ MATOMO_SMTP_AUTH="${MATOMO_SMTP_AUTH:-"${SMTP_AUTH:-}"}"
 export MATOMO_SMTP_AUTH="${MATOMO_SMTP_AUTH:-}" # only used during the first initialization
 MATOMO_SMTP_PROTOCOL="${MATOMO_SMTP_PROTOCOL:-"${SMTP_PROTOCOL:-}"}"
 export MATOMO_SMTP_PROTOCOL="${MATOMO_SMTP_PROTOCOL:-}" # only used during the first initialization
+export MATOMO_NOREPLY_NAME="${MATOMO_NOREPLY_NAME:-}" # only used during the first initialization
+export MATOMO_NOREPLY_ADDRESS="${MATOMO_NOREPLY_ADDRESS:-}" # only used during the first initialization
 
 # Database configuration
 export MATOMO_DEFAULT_DATABASE_HOST="mariadb" # only used at build time

--- a/bitnami/matomo/README.md
+++ b/bitnami/matomo/README.md
@@ -371,8 +371,8 @@ To configure Matomo to send email using SMTP you can set the following environme
 * `MATOMO_SMTP_AUTH`: Matomo SMTP authentication mechanism to use. Available mechanisms are: "Plain", "Login", "Crammd5". Default: **Plain**.
 
 > **Optional**  
-> * `MATOMO_NOREPLY_NAME`: Matomo noreply name.
-> * `MATOMO_NOREPLY_ADDRESS`: Matomo noreply address.
+> `MATOMO_NOREPLY_NAME`: Matomo noreply name.  
+> `MATOMO_NOREPLY_ADDRESS`: Matomo noreply address.
 
 ##### SMTP example
 

--- a/bitnami/matomo/README.md
+++ b/bitnami/matomo/README.md
@@ -369,10 +369,8 @@ To configure Matomo to send email using SMTP you can set the following environme
 * `MATOMO_SMTP_PASSWORD`: Matomo SMTP account password.
 * `MATOMO_SMTP_PROTOCOL`: Matomo SMTP protocol to use. Available protocols are: "ssl", "tls", "none". No default.
 * `MATOMO_SMTP_AUTH`: Matomo SMTP authentication mechanism to use. Available mechanisms are: "Plain", "Login", "Crammd5". Default: **Plain**.
-
-> **Optional**  
-> `MATOMO_NOREPLY_NAME`: Matomo noreply name.  
-> `MATOMO_NOREPLY_ADDRESS`: Matomo noreply address.
+* `MATOMO_NOREPLY_NAME`: Matomo noreply name. No defaults.
+* `MATOMO_NOREPLY_ADDRESS`: Matomo noreply address. No defaults.
 
 ##### SMTP example
 

--- a/bitnami/matomo/README.md
+++ b/bitnami/matomo/README.md
@@ -370,6 +370,10 @@ To configure Matomo to send email using SMTP you can set the following environme
 * `MATOMO_SMTP_PROTOCOL`: Matomo SMTP protocol to use. Available protocols are: "ssl", "tls", "none". No default.
 * `MATOMO_SMTP_AUTH`: Matomo SMTP authentication mechanism to use. Available mechanisms are: "Plain", "Login", "Crammd5". Default: **Plain**.
 
+> **Optional**  
+> * `MATOMO_NOREPLY_NAME`: Matomo noreply name.
+> * `MATOMO_NOREPLY_ADDRESS`: Matomo noreply address.
+
 ##### SMTP example
 
 This would be an example of SMTP configuration using a Gmail account:


### PR DESCRIPTION
### Description of the change

added the possibility to set the config values for noreply_email_address and noreply_email_name in the General section of the matomo config via new environment variables

new variables:
- MATOMO_NOREPLY_NAME
- MATOMO_NOREPLY_ADDRESS

### Benefits

easy way to set the mentiones values right at the start of the container inestead of having to deal with it afterwards.
makes automation of this process way faster and easier.

### Possible drawbacks

none
