### PR TITLE
[bitnami/rabbitmq]: failure to start rabbitmq due to missing `curl` to load community plugins

### DIFF
--- a/bitnami/rabbitmq/3.11/debian-11/Dockerfile
+++ b/bitnami/rabbitmq/3.11/debian-11/Dockerfile
@@ -35,8 +35,7 @@ RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ && \
       tar -zxf "${COMPONENT}.tar.gz" -C /opt/bitnami --strip-components=2 --no-same-owner --wildcards '*/files' && \
       rm -rf "${COMPONENT}".tar.gz{,.sha256} ; \
     done
-RUN apt-get autoremove --purge -y curl && \
-    apt-get update && apt-get upgrade -y && \
+RUN apt-get update && apt-get upgrade -y && \
     apt-get clean && rm -rf /var/lib/apt/lists /var/cache/apt/archives
 RUN chmod g+rwX /opt/bitnami
 RUN localedef -c -f UTF-8 -i en_US en_US.UTF-8


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Fix the Dockerfile to prevent `curl` removal since community plugins depend on `curl` to load https://github.com/bitnami/containers/blob/a618a6d5acb2567bf5296b3f9a81f4dadd56d78a/bitnami/rabbitmq/3.11/debian-11/rootfs/opt/bitnami/scripts/librabbitmq.sh#L514 

### Benefits

Solve the `curl: command not found` error when `RABBITMQ_COMMUNITY_PLUGINS` is enabled

```yaml
        - name: RABBITMQ_COMMUNITY_PLUGINS
          value: >-
            https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/releases/download/3.11.1/rabbitmq_delayed_message_exchange-3.11.1.ez
```

<img width="783" alt="image" src="https://github.com/bitnami/containers/assets/41980722/b9a63400-490a-46f7-8f58-6e1c63e6ec57">

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
