### PR TITLE
[bitnami/rails] Fix check-app-version test

### DIFF
--- a/.vib/rails/goss/rails.yaml
+++ b/.vib/rails/goss/rails.yaml
@@ -11,7 +11,7 @@ command:
   # Major.Minor.Patch-Build, such as 1.2.3-4 while the `rails -v` command returns
   # the version in the format of Major.Minor.Patch.Build, such as 1.2.3.4 so we
   # need to convert the environment variable before comparing the two versions
-    exec: {{ .Vars.version.bin_name }} {{ .Vars.version.flag }} | sed '/^[0-9]\+\.[0-9]\+\.[0-9]\+$/ s/$/-0/' | sed "s/\.\([0-9]\)$/-\1/"
+    exec: {{ .Vars.version.bin_name }} {{ .Vars.version.flag }} | sed '/\s[0-9]\+\.[0-9]\+\.[0-9]\+$/ s/$/\.0/' | sed 's/\.\([0-9]\)$/-\1/'
     exit-status: 0
     stdout:
     - {{ .Env.APP_VERSION }}


### PR DESCRIPTION
### Description of the change

Rails versions can have 3 or 4 coordinates. In the case of using 3 coordinates we have to include the fourth one to match with the env var `APP_VERSION`.

### Benefits

Fix bug, unblock release 7.0.5 #35322

### Possible drawbacks

None identified

### Applicable issues

- relates to #35322

