### PR TITLE
Removal of the curl cleanup line

### DIFF
--- a/bitnami/rabbitmq/3.10/debian-11/Dockerfile
+++ b/bitnami/rabbitmq/3.10/debian-11/Dockerfile
@@ -35,8 +35,7 @@ RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ && \
       tar -zxf "${COMPONENT}.tar.gz" -C /opt/bitnami --strip-components=2 --no-same-owner --wildcards '*/files' && \
       rm -rf "${COMPONENT}".tar.gz{,.sha256} ; \
     done
-RUN apt-get autoremove --purge -y curl && \
-    apt-get update && apt-get upgrade -y && \
+RUN apt-get update && apt-get upgrade -y && \
     apt-get clean && rm -rf /var/lib/apt/lists /var/cache/apt/archives
 RUN chmod g+rwX /opt/bitnami
 RUN localedef -c -f UTF-8 -i en_US en_US.UTF-8

--- a/bitnami/rabbitmq/3.11/debian-11/Dockerfile
+++ b/bitnami/rabbitmq/3.11/debian-11/Dockerfile
@@ -35,8 +35,7 @@ RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ && \
       tar -zxf "${COMPONENT}.tar.gz" -C /opt/bitnami --strip-components=2 --no-same-owner --wildcards '*/files' && \
       rm -rf "${COMPONENT}".tar.gz{,.sha256} ; \
     done
-RUN apt-get autoremove --purge -y curl && \
-    apt-get update && apt-get upgrade -y && \
+RUN apt-get update && apt-get upgrade -y && \
     apt-get clean && rm -rf /var/lib/apt/lists /var/cache/apt/archives
 RUN chmod g+rwX /opt/bitnami
 RUN localedef -c -f UTF-8 -i en_US en_US.UTF-8

--- a/bitnami/rabbitmq/3.9/debian-11/Dockerfile
+++ b/bitnami/rabbitmq/3.9/debian-11/Dockerfile
@@ -35,8 +35,7 @@ RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ && \
       tar -zxf "${COMPONENT}.tar.gz" -C /opt/bitnami --strip-components=2 --no-same-owner --wildcards '*/files' && \
       rm -rf "${COMPONENT}".tar.gz{,.sha256} ; \
     done
-RUN apt-get autoremove --purge -y curl && \
-    apt-get update && apt-get upgrade -y && \
+RUN apt-get update && apt-get upgrade -y && \
     apt-get clean && rm -rf /var/lib/apt/lists /var/cache/apt/archives
 RUN chmod g+rwX /opt/bitnami
 RUN localedef -c -f UTF-8 -i en_US en_US.UTF-8


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Keeping curl installed in the rabbitmq images since it's used in runtime to install "RabbitMQ - community-plugins" (as documented in linked issue).

### Benefits

Fixes https://github.com/bitnami/containers/issues/35694

### Possible drawbacks

I don't how and where the [vmware-bot](https://github.com/bitnami/containers/commit/a618a6d5acb2567bf5296b3f9a81f4dadd56d78a) is updating those Dockerfile from, my fix may only hold until it does an other run at it.

Also, the removal of curl in the containers was maybe due to security issues that I would bring back with this change.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #35694

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
