### PR TITLE
[bitnami/cosign] fix: add writable /.docker folder

### DIFF
--- a/bitnami/cosign/2/debian-11/Dockerfile
+++ b/bitnami/cosign/2/debian-11/Dockerfile
@@ -38,6 +38,7 @@ RUN apt-get autoremove --purge -y curl && \
     apt-get clean && rm -rf /var/lib/apt/lists /var/cache/apt/archives
 RUN chmod g+rwX /opt/bitnami
 RUN mkdir -p "/cosign-keys" && chmod -R 777 "/cosign-keys"
+RUN mkdir -p "/.docker" && chmod g+rwX "/.docker"
 RUN mkdir /.sigstore && chmod g+rwX /.sigstore
 
 ENV APP_VERSION="2.0.2" \


### PR DESCRIPTION
Signed-off-by: Manu Schiller <manuel.schiller@gmail.com>



### Description of the change

cosign does operations that need authorization against OCI registries. A user can authenticate by running `cosign login` or by creating a `/.docker/config.json` file that contains an auth-config.

For both of the operations, we need write-permissions to a `/.docker` folder in the image.

Digging through issues on `cosign` it seemed that one can override the default location for the config via `DOCKER_CONFIG`. This did not work before creating this PR, though (see: https://github.com/sigstore/cosign/issues/3015#issuecomment-1568440731)

This PR basically just implements @javsalgar's comment from here: https://github.com/bitnami/containers/issues/28690#issuecomment-1493876353 

### Benefits

cosigns config for communicating with registries is now configurable

### Possible drawbacks

I am not an expert on permissions: `chmod g+rwX "/.docker"` might need some tweaking.

### Applicable issues

- fixes https://github.com/bitnami/containers/issues/28690

### Additional information

n/a
