### PR TITLE
[bitnami/containers] Fix bug in assign-asset-label workflow

### DIFF
--- a/.github/workflows/assign-asset-label.yml
+++ b/.github/workflows/assign-asset-label.yml
@@ -1,15 +1,17 @@
 name: '[Support] Assign asset label'
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
 permissions:
-  pull-requests: write
-  issues: write
+  # Remove all permissions by default
+  contents: none
 jobs:
   assign-label:
     name: Assign label
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - id: get-asset
         name: Get modified assets


### PR DESCRIPTION
### Description of the change

Change `assign-asset-label.yaml` workflow to listen for `pull_request_target` events to avoid issues with pull requests created from forks.

### Benefits

Assign labels in PRs created from forked repositories.

### Possible drawbacks

None identified

### Applicable issues

- Related to: https://github.com/bitnami/charts/actions/runs/5116736686/jobs/9203138024
- Related to: https://github.com/bitnami/charts/pull/16956

### Additional information

https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

### Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
