### PR TITLE
test that directory exists before mkdir #37448

### DIFF
--- a/bitnami/rabbitmq/3.10/debian-11/prebuildfs/opt/bitnami/scripts/libfs.sh
+++ b/bitnami/rabbitmq/3.10/debian-11/prebuildfs/opt/bitnami/scripts/libfs.sh
@@ -42,7 +42,7 @@ ensure_dir_exists() {
     local owner_user="${2:-}"
     local owner_group="${3:-}"
 
-    mkdir -p "${dir}"
+    [ -d "${dir}" ] || mkdir -p "${dir}"
     if [[ -n $owner_user ]]; then
         owned_by "$dir" "$owner_user" "$owner_group"
     fi

--- a/bitnami/rabbitmq/3.11/debian-11/prebuildfs/opt/bitnami/scripts/libfs.sh
+++ b/bitnami/rabbitmq/3.11/debian-11/prebuildfs/opt/bitnami/scripts/libfs.sh
@@ -42,7 +42,7 @@ ensure_dir_exists() {
     local owner_user="${2:-}"
     local owner_group="${3:-}"
 
-    mkdir -p "${dir}"
+    [ -d "${dir}" ] || mkdir -p "${dir}"
     if [[ -n $owner_user ]]; then
         owned_by "$dir" "$owner_user" "$owner_group"
     fi

--- a/bitnami/rabbitmq/3.12/debian-11/prebuildfs/opt/bitnami/scripts/libfs.sh
+++ b/bitnami/rabbitmq/3.12/debian-11/prebuildfs/opt/bitnami/scripts/libfs.sh
@@ -42,7 +42,7 @@ ensure_dir_exists() {
     local owner_user="${2:-}"
     local owner_group="${3:-}"
 
-    mkdir -p "${dir}"
+    [ -d "${dir}" ] || mkdir -p "${dir}"
     if [[ -n $owner_user ]]; then
         owned_by "$dir" "$owner_user" "$owner_group"
     fi

--- a/bitnami/rabbitmq/3.9/debian-11/prebuildfs/opt/bitnami/scripts/libfs.sh
+++ b/bitnami/rabbitmq/3.9/debian-11/prebuildfs/opt/bitnami/scripts/libfs.sh
@@ -42,7 +42,7 @@ ensure_dir_exists() {
     local owner_user="${2:-}"
     local owner_group="${3:-}"
 
-    mkdir -p "${dir}"
+    [ -d "${dir}" ] || mkdir -p "${dir}"
     if [[ -n $owner_user ]]; then
         owned_by "$dir" "$owner_user" "$owner_group"
     fi


### PR DESCRIPTION
This simple patch fixes issue #37448 that makes RabbitMQ crashing when the directory is mounted as a volume, so it already exists and cannot be created.

### Applicable issues

- fixes #37448

### Additional information

Tested in a StatefulSet with a temporary configMap mounted as file path -> Passed OK
