### PR TITLE
Change spaces in nginx.conf file

### DIFF
--- a/bitnami/nginx/1.24/debian-11/rootfs/opt/bitnami/nginx/conf/nginx.conf
+++ b/bitnami/nginx/1.24/debian-11/rootfs/opt/bitnami/nginx/conf/nginx.conf
@@ -13,7 +13,7 @@ http {
     include       mime.types;
     default_type  application/octet-stream;
     log_format    main '$remote_addr - $remote_user [$time_local] '
-                       '"$request" $status  $body_bytes_sent "$http_referer" '
+                       '"$request" $status $body_bytes_sent "$http_referer" '
                        '"$http_user_agent" "$http_x_forwarded_for"';
     access_log    "/opt/bitnami/nginx/logs/access.log" main;
     add_header    X-Frame-Options SAMEORIGIN;

--- a/bitnami/nginx/1.25/debian-11/rootfs/opt/bitnami/nginx/conf/nginx.conf
+++ b/bitnami/nginx/1.25/debian-11/rootfs/opt/bitnami/nginx/conf/nginx.conf
@@ -13,7 +13,7 @@ http {
     include       mime.types;
     default_type  application/octet-stream;
     log_format    main '$remote_addr - $remote_user [$time_local] '
-                       '"$request" $status  $body_bytes_sent "$http_referer" '
+                       '"$request" $status $body_bytes_sent "$http_referer" '
                        '"$http_user_agent" "$http_x_forwarded_for"';
     access_log    "/opt/bitnami/nginx/logs/access.log" main;
     add_header    X-Frame-Options SAMEORIGIN;


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change
Change spaces in nginx.conf file

### Benefits

This is necessary for logging systems e.g. fluentd. Logging systems cannot parsed logs because config uses odd space. For example, nginx-ingress-controller is not using odd space and its parsing is ok.
