### PR TITLE
[bitnami/containers] Avoid assignment of cards in Build Maintenance column

### DIFF
--- a/.github/workflows/moving-cards.yml
+++ b/.github/workflows/moving-cards.yml
@@ -128,12 +128,15 @@ jobs:
         with:
           path: .github/workflows/
       - name: Assign to a person to work on it
-        # Assign when there is nobody assigned or the card is new
-        if: ${{ github.event.project_card.column_id != env.SOLVED_COLUMN_ID && (needs.get-issue.outputs.assignees == '[]' || github.event.action == 'created') }}
+        # Assign when there is nobody assigned or the card is new.
+        # Cards in Build Maintenance column will remain unassigned.
+        if: |
+          github.event.project_card.column_id != env.SOLVED_COLUMN_ID && github.event.project_card.column_id != env.BUILD_MAINTENANCE_COLUMN_ID &&
+          (needs.get-issue.outputs.assignees == '[]' || github.event.action == 'created')
         uses: pozil/auto-assign-issue@v1.11.0
         with:
           numOfAssignee: 1
-          teams: ${{ github.event.project_card.column_id == env.BITNAMI_COLUMN_ID && env.SUPPORT_TEAM_NAME || (github.event.project_card.column_id == env.BUILD_MAINTENANCE_COLUMN_ID && env.BUILD_MAINTAINERS_TEAM_NAME || env.TRIAGE_TEAM_NAME) }}
+          teams: ${{ github.event.project_card.column_id == env.BITNAMI_COLUMN_ID && env.SUPPORT_TEAM_NAME || env.TRIAGE_TEAM_NAME }}
           repo-token: ${{ secrets.BITNAMI_BOT_TOKEN }}
           allowSelfAssign: false
       - name: Reassign when moved into 'In progress' from 'Triage'


### PR DESCRIPTION
### Description of the change

Keep cards on [Build Maintenance column](https://github.com/bitnami/containers/projects/4#column-19174507) unassigned.

### Benefits

Avoid noise.

### Possible drawbacks

None

### Additional information

* Charts PR https://github.com/bitnami/charts/pull/17150

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
