### PR TITLE
openldap: set capabilities on /opt/bitnami/openldap/sbin/slapd binary

### DIFF
--- a/bitnami/openldap/2.5/debian-11/Dockerfile
+++ b/bitnami/openldap/2.5/debian-11/Dockerfile
@@ -19,7 +19,7 @@ ENV HOME="/" \
 COPY prebuildfs /
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Install required system packages and dependencies
-RUN install_packages ca-certificates curl libargon2-1 libcom-err2 libcrypt1 libgssapi-krb5-2 libk5crypto3 libkeyutils1 libkrb5-3 libkrb5support0 libltdl7 libnsl2 libnss3-tools libsasl2-2 libssl1.1 libtirpc3 libwrap0 mdbtools procps psmisc
+RUN install_packages ca-certificates curl libargon2-1 libcap2-bin libcom-err2 libcrypt1 libgssapi-krb5-2 libk5crypto3 libkeyutils1 libkrb5-3 libkrb5support0 libltdl7 libnsl2 libnss3-tools libsasl2-2 libssl1.1 libtirpc3 libwrap0 mdbtools procps psmisc
 RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ && \
     COMPONENTS=( \
       "openldap-2.5.14-3-linux-${OS_ARCH}-debian-11" \
@@ -36,7 +36,7 @@ RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ && \
 RUN apt-get autoremove --purge -y curl && \
     apt-get update && apt-get upgrade -y && \
     apt-get clean && rm -rf /var/lib/apt/lists /var/cache/apt/archives
-RUN chmod g+rwX /opt/bitnami
+RUN chmod g+rwX /opt/bitnami && setcap 'cap_net_bind_service=+ep' /opt/bitnami/openldap/sbin/slapd
 
 COPY rootfs /
 RUN /opt/bitnami/scripts/openldap/postunpack.sh

--- a/bitnami/openldap/2.6/debian-11/Dockerfile
+++ b/bitnami/openldap/2.6/debian-11/Dockerfile
@@ -19,7 +19,7 @@ ENV HOME="/" \
 COPY prebuildfs /
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Install required system packages and dependencies
-RUN install_packages ca-certificates curl libargon2-1 libcom-err2 libcrypt1 libgssapi-krb5-2 libk5crypto3 libkeyutils1 libkrb5-3 libkrb5support0 libltdl7 libnsl2 libnss3-tools libodbc1 libperl5.32 libsasl2-2 libssl1.1 libtirpc3 libwrap0 mdbtools procps psmisc
+RUN install_packages ca-certificates curl libargon2-1 libcap2-bin libcom-err2 libcrypt1 libgssapi-krb5-2 libk5crypto3 libkeyutils1 libkrb5-3 libkrb5support0 libltdl7 libnsl2 libnss3-tools libodbc1 libperl5.32 libsasl2-2 libssl1.1 libtirpc3 libwrap0 mdbtools procps psmisc
 RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ && \
     COMPONENTS=( \
       "openldap-2.6.4-3-linux-${OS_ARCH}-debian-11" \
@@ -36,7 +36,7 @@ RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ && \
 RUN apt-get autoremove --purge -y curl && \
     apt-get update && apt-get upgrade -y && \
     apt-get clean && rm -rf /var/lib/apt/lists /var/cache/apt/archives
-RUN chmod g+rwX /opt/bitnami
+RUN chmod g+rwX /opt/bitnami && setcap 'cap_net_bind_service=+ep' /opt/bitnami/openldap/sbin/slapd
 
 COPY rootfs /
 RUN /opt/bitnami/scripts/openldap/postunpack.sh

--- a/bitnami/openldap/README.md
+++ b/bitnami/openldap/README.md
@@ -173,7 +173,7 @@ docker-compose up -d
 
 The Bitnami Docker OpenLDAP can be easily setup with the following environment variables:
 
-* `LDAP_PORT_NUMBER`: The port OpenLDAP is listening for requests. Default: **1389** (non privileged port)
+* `LDAP_PORT_NUMBER`: The port OpenLDAP is listening for requests. Default: **1389** (non privileged port) or use the standard port **389**
 * `LDAP_ROOT`: LDAP baseDN (or suffix) of the LDAP tree. Default: **dc=example,dc=org**
 * `LDAP_ADMIN_USERNAME`: LDAP database admin user. Default: **admin**
 * `LDAP_ADMIN_PASSWORD`: LDAP database admin password. Default: **adminpassword**
@@ -205,7 +205,7 @@ Check the official [OpenLDAP Configuration Reference](https://www.openldap.org/d
 OpenLDAP clients and servers are capable of using the Transport Layer Security (TLS) framework to provide integrity and confidentiality protections and to support LDAP authentication using the SASL EXTERNAL mechanism. Should you desire to enable this optional feature, you may use the following environment variables to configure the application:
 
 * `LDAP_ENABLE_TLS`: Whether to enable TLS for traffic or not. Defaults to `no`.
-* `LDAP_LDAPS_PORT_NUMBER`: Port used for TLS secure traffic. Defaults to `1636`.
+* `LDAP_LDAPS_PORT_NUMBER`: Port used for TLS secure traffic. Defaults: **1636**  (non privileged port) or use the standard port **636**
 * `LDAP_TLS_CERT_FILE`: File containing the certificate file for the TLS traffic. No defaults.
 * `LDAP_TLS_KEY_FILE`: File containing the key for certificate. No defaults.
 * `LDAP_TLS_CA_FILE`: File containing the CA of the certificate. No defaults.


### PR DESCRIPTION
### Description of the change

set capabilities on the `/opt/bitnami/openldap/sbin/slapd` binary to allow it to listen on privileged ports like `389` (ldap://) or `636` (ldaps://) when using docker network type `host`

### Benefits

When deploying an LDAP server in production, you don't have to deal with unknown custom ports

### Possible drawbacks

none known

### Applicable issues

none

### Additional information

none
