### PR TITLE
[bitnami/nats] Add support for CLI arguments

### DIFF
--- a/bitnami/nats/2/debian-11/Dockerfile
+++ b/bitnami/nats/2/debian-11/Dockerfile
@@ -50,4 +50,5 @@ EXPOSE 4222 6222 8222
 
 WORKDIR /opt/bitnami/nats
 USER 1001
-ENTRYPOINT [ "/opt/bitnami/scripts/nats/entrypoint.sh", "/opt/bitnami/scripts/nats/run.sh" ]
+ENTRYPOINT [ "/opt/bitnami/scripts/nats/entrypoint.sh" ]
+CMD [ "/opt/bitnami/scripts/nats/run.sh" ]

--- a/bitnami/nats/2/debian-11/Dockerfile
+++ b/bitnami/nats/2/debian-11/Dockerfile
@@ -50,5 +50,4 @@ EXPOSE 4222 6222 8222
 
 WORKDIR /opt/bitnami/nats
 USER 1001
-ENTRYPOINT [ "/opt/bitnami/scripts/nats/entrypoint.sh" ]
-CMD [ "/opt/bitnami/scripts/nats/run.sh" ]
+ENTRYPOINT [ "/opt/bitnami/scripts/nats/entrypoint.sh", "/opt/bitnami/scripts/nats/run.sh" ]

--- a/bitnami/nats/2/debian-11/rootfs/opt/bitnami/scripts/nats-env.sh
+++ b/bitnami/nats/2/debian-11/rootfs/opt/bitnami/scripts/nats-env.sh
@@ -44,7 +44,7 @@ nats_env_vars=(
     NATS_CLUSTER_TOKEN
     NATS_CLUSTER_ROUTES
     NATS_CLUSTER_SEED_NODE
-    NATS_EXTRA_FLAGS
+    NATS_EXTRA_ARGS
 )
 for env_var in "${nats_env_vars[@]}"; do
     file_env_var="${env_var}_FILE"
@@ -109,4 +109,4 @@ export NATS_CLUSTER_ROUTES="${NATS_CLUSTER_ROUTES:-}"
 export NATS_CLUSTER_SEED_NODE="${NATS_CLUSTER_SEED_NODE:-}"
 
 # Custom environment variables may be defined below
-export NATS_EXTRA_FLAGS="${NATS_EXTRA_FLAGS:-}"
+export NATS_EXTRA_ARGS="${NATS_EXTRA_ARGS:-}"

--- a/bitnami/nats/2/debian-11/rootfs/opt/bitnami/scripts/nats-env.sh
+++ b/bitnami/nats/2/debian-11/rootfs/opt/bitnami/scripts/nats-env.sh
@@ -44,6 +44,7 @@ nats_env_vars=(
     NATS_CLUSTER_TOKEN
     NATS_CLUSTER_ROUTES
     NATS_CLUSTER_SEED_NODE
+    NATS_EXTRA_FLAGS
 )
 for env_var in "${nats_env_vars[@]}"; do
     file_env_var="${env_var}_FILE"
@@ -108,3 +109,4 @@ export NATS_CLUSTER_ROUTES="${NATS_CLUSTER_ROUTES:-}"
 export NATS_CLUSTER_SEED_NODE="${NATS_CLUSTER_SEED_NODE:-}"
 
 # Custom environment variables may be defined below
+export NATS_EXTRA_FLAGS="${NATS_EXTRA_FLAGS:-}"

--- a/bitnami/nats/2/debian-11/rootfs/opt/bitnami/scripts/nats/run.sh
+++ b/bitnami/nats/2/debian-11/rootfs/opt/bitnami/scripts/nats/run.sh
@@ -16,9 +16,14 @@ set -o pipefail
 
 declare nats_cmd="nats-server"
 which "$nats_cmd" >/dev/null 2>&1 || nats_cmd="gnatsd"
-declare -a args=($NATS_EXTRA_FLAGS)
+declare -a args=("-c" "$NATS_CONF_FILE")
 
-args+=("-c" "$NATS_CONF_FILE" "$@")
+if [[ -n "${NATS_EXTRA_ARGS:-}" ]]; then
+    read -r -a extra_args <<<"$NATS_EXTRA_ARGS"
+    args+=("${extra_args[@]}")
+fi
+
+args+=("$@")
 
 info "** Starting NATS **"
 if am_i_root; then

--- a/bitnami/nats/2/debian-11/rootfs/opt/bitnami/scripts/nats/run.sh
+++ b/bitnami/nats/2/debian-11/rootfs/opt/bitnami/scripts/nats/run.sh
@@ -16,8 +16,9 @@ set -o pipefail
 
 declare nats_cmd="nats-server"
 which "$nats_cmd" >/dev/null 2>&1 || nats_cmd="gnatsd"
-declare -a args=("-c" "$NATS_CONF_FILE")
-args+=("$@")
+declare -a args=($NATS_EXTRA_FLAGS)
+
+args+=("-c" "$NATS_CONF_FILE" "$@")
 
 info "** Starting NATS **"
 if am_i_root; then

--- a/bitnami/nats/README.md
+++ b/bitnami/nats/README.md
@@ -199,7 +199,8 @@ Available environment variables:
 * `NATS_CLUSTER_PORT_NUMBER`: NATS Cluster port number. Default: **6222**
 * `NATS_HTTP_PORT_NUMBER`: NATS HTTP port number. Default: **8222**
 * `NATS_HTTPS_PORT_NUMBER`: NATS HTTPS port number. Default: **8443**
-* `NATS_FILENAME`: Pefix to use for NATS files (e.g. the PID file would be formed using `${NATS_FILENAME}.pid`). Default: **nats-server**
+* `NATS_FILENAME`: Pefix to use for NATS files (e.g., the PID file would be formed using `${NATS_FILENAME}.pid`). Default: **nats-server**
+* `NATS_EXTRA_FLAGS`: Additional command line arguments passed while starting NATS (e.g., `-js` for enabling JetStream). No defaults.
 
 #### NATS security configuration
 

--- a/bitnami/nats/README.md
+++ b/bitnami/nats/README.md
@@ -200,7 +200,7 @@ Available environment variables:
 * `NATS_HTTP_PORT_NUMBER`: NATS HTTP port number. Default: **8222**
 * `NATS_HTTPS_PORT_NUMBER`: NATS HTTPS port number. Default: **8443**
 * `NATS_FILENAME`: Pefix to use for NATS files (e.g., the PID file would be formed using `${NATS_FILENAME}.pid`). Default: **nats-server**
-* `NATS_EXTRA_FLAGS`: Additional command line arguments passed while starting NATS (e.g., `-js` for enabling JetStream). No defaults.
+* `NATS_EXTRA_ARGS`: Additional command line arguments passed while starting NATS (e.g., `-js` for enabling JetStream). No defaults.
 
 #### NATS security configuration
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

Originally opened as https://github.com/bitnami/containers/pull/31496 this pull request adds support for extra arguments being passed to NATS for the NATS container.

This PR is essentially the same but addresses the original comments.

### Benefits

<!-- What benefits will be realized by the code change? -->

Adds the ability to pass command line arguments such as `-js` to enable jet stream.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
