### PR TITLE
[bitnami/gitea] add ssh-client to the packages installed so I can use ssh-keygen to my account

### DIFF
--- a/bitnami/gitea/1/debian-11/Dockerfile
+++ b/bitnami/gitea/1/debian-11/Dockerfile
@@ -19,7 +19,7 @@ ENV HOME="/" \
 COPY prebuildfs /
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Install required system packages and dependencies
-RUN install_packages acl ca-certificates curl git procps
+RUN install_packages acl ca-certificates curl git procps ssh-client
 RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ && \
     COMPONENTS=( \
       "wait-for-port-1.0.6-8-linux-${OS_ARCH}-debian-11" \


### PR DESCRIPTION
This pull request fixes this issue: https://github.com/bitnami/containers/issues/38803

The problem is that in gitea there is a functionality that will allow you to add ssh public keys to your account, the problem is when you try this functionality with the original code, it does not have the ssh-client package installed and therefore you will get a problem saying that "ssh-keygen" is not in the $PATH.

So I added it to the packages installed. I tried it locally and also I deployed this image into a kubernetes cluster and then added my key to my account without any issue.