### PR TITLE
[bitnami/spring-cloud-skipper] Increase test timeouts

### DIFF
--- a/.vib/spring-cloud-skipper/goss/spring-cloud-skipper.yaml
+++ b/.vib/spring-cloud-skipper/goss/spring-cloud-skipper.yaml
@@ -1,7 +1,7 @@
 command:
   check-spring-cloud-skipper:
-    timeout: 20000
-    exec: timeout --preserve-status 15 java -jar /opt/bitnami/spring-cloud-skipper/spring-cloud-skipper.jar
+    timeout: 30000
+    exec: timeout --preserve-status 25 java -jar /opt/bitnami/spring-cloud-skipper/spring-cloud-skipper.jar
     exit-status: 143
     stdout:
       - Started SkipperServerApplication


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

In my laptop the test tooks around 13 seconds to be completed, very close to the tiemout previously configured (15). The timeout was increased to avoid issues in slower machines.

### Benefits

Avoid unnecesary retries

### Possible drawbacks

None

### Applicable issues

* https://github.com/bitnami/containers/actions/runs/5386655342
### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
