### PR TITLE
[bitnami/containers] Automate license checks

### DIFF
--- a/.github/workflows/license-headers.yml
+++ b/.github/workflows/license-headers.yml
@@ -1,0 +1,16 @@
+# Copyright VMware, Inc.
+# SPDX-License-Identifier: APACHE-2.0
+
+---
+name: license-headers
+
+on:
+  pull_request:
+
+jobs:
+  license-headers-linter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check license Headers
+        uses: apache/skywalking-eyes/header@v0.4.0

--- a/.github/workflows/license-headers.yml
+++ b/.github/workflows/license-headers.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: APACHE-2.0
 
 ---
-name: [License] Check license headers
+name: '[License] Check license headers'
 
 on:
   pull_request:

--- a/.github/workflows/license-headers.yml
+++ b/.github/workflows/license-headers.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: APACHE-2.0
 
 ---
-name: license-headers
+name: [License] Check license headers
 
 on:
   pull_request:

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,0 +1,16 @@
+# Copyright VMware, Inc.
+# SPDX-License-Identifier: APACHE-2.0
+
+---
+header:
+  comment: on-failure
+  license:
+    spdx-id: Apache-2.0
+    copyright-owner: VMware, Inc.
+
+    pattern: |
+      # Copyright VMware, Inc.
+      # SPDX-License-Identifier: APACHE-2.0
+
+  paths:
+    - "**/Dockerfile"

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -8,7 +8,7 @@ header:
     spdx-id: Apache-2.0
     copyright-owner: VMware, Inc.
 
-    pattern: |
+    content: |
       # Copyright VMware, Inc.
       # SPDX-License-Identifier: APACHE-2.0
 

--- a/bitnami/argo-workflow-controller/3/scratch/Dockerfile
+++ b/bitnami/argo-workflow-controller/3/scratch/Dockerfile
@@ -1,3 +1,6 @@
+# Copyright VMware, Inc.
+# SPDX-License-Identifier: APACHE-2.0
+
 FROM bitnami/minideb:bullseye as builder
 
 ARG TARGETARCH

--- a/bitnami/drupal-nginx/10/debian-11/Dockerfile
+++ b/bitnami/drupal-nginx/10/debian-11/Dockerfile
@@ -1,3 +1,6 @@
+# Copyright VMware, Inc.
+# SPDX-License-Identifier: APACHE-2.0
+
 FROM docker.io/bitnami/minideb:bullseye
 
 ARG TARGETARCH

--- a/bitnami/drupal/10/debian-11/Dockerfile
+++ b/bitnami/drupal/10/debian-11/Dockerfile
@@ -1,3 +1,6 @@
+# Copyright VMware, Inc.
+# SPDX-License-Identifier: APACHE-2.0
+
 FROM docker.io/bitnami/minideb:bullseye
 
 ARG TARGETARCH

--- a/bitnami/kube-rbac-proxy/0/scratch/Dockerfile
+++ b/bitnami/kube-rbac-proxy/0/scratch/Dockerfile
@@ -1,3 +1,6 @@
+# Copyright VMware, Inc.
+# SPDX-License-Identifier: APACHE-2.0
+
 FROM bitnami/minideb:bullseye as builder
 
 ARG TARGETARCH

--- a/bitnami/kubeapps-apprepository-controller/2/scratch/Dockerfile
+++ b/bitnami/kubeapps-apprepository-controller/2/scratch/Dockerfile
@@ -1,3 +1,6 @@
+# Copyright VMware, Inc.
+# SPDX-License-Identifier: APACHE-2.0
+
 FROM bitnami/minideb:bullseye as builder
 
 ARG TARGETARCH

--- a/bitnami/kubeapps-asset-syncer/2/scratch/Dockerfile
+++ b/bitnami/kubeapps-asset-syncer/2/scratch/Dockerfile
@@ -1,3 +1,6 @@
+# Copyright VMware, Inc.
+# SPDX-License-Identifier: APACHE-2.0
+
 FROM bitnami/minideb:bullseye as builder
 
 ARG TARGETARCH

--- a/bitnami/oras/1/scratch/Dockerfile
+++ b/bitnami/oras/1/scratch/Dockerfile
@@ -1,3 +1,6 @@
+# Copyright VMware, Inc.
+# SPDX-License-Identifier: APACHE-2.0
+
 FROM bitnami/minideb:bullseye as builder
 
 ARG TARGETARCH

--- a/bitnami/rabbitmq-cluster-operator/2/scratch/Dockerfile
+++ b/bitnami/rabbitmq-cluster-operator/2/scratch/Dockerfile
@@ -1,3 +1,6 @@
+# Copyright VMware, Inc.
+# SPDX-License-Identifier: APACHE-2.0
+
 FROM bitnami/minideb:bullseye as builder
 
 ARG TARGETARCH

--- a/bitnami/rmq-default-credential-updater/1/scratch/Dockerfile
+++ b/bitnami/rmq-default-credential-updater/1/scratch/Dockerfile
@@ -1,3 +1,6 @@
+# Copyright VMware, Inc.
+# SPDX-License-Identifier: APACHE-2.0
+
 FROM bitnami/minideb:bullseye as builder
 
 ARG TARGETARCH

--- a/bitnami/rmq-messaging-topology-operator/1/scratch/Dockerfile
+++ b/bitnami/rmq-messaging-topology-operator/1/scratch/Dockerfile
@@ -1,3 +1,6 @@
+# Copyright VMware, Inc.
+# SPDX-License-Identifier: APACHE-2.0
+
 FROM bitnami/minideb:bullseye as builder
 
 ARG TARGETARCH

--- a/bitnami/sealed-secrets/0/scratch/Dockerfile
+++ b/bitnami/sealed-secrets/0/scratch/Dockerfile
@@ -1,3 +1,6 @@
+# Copyright VMware, Inc.
+# SPDX-License-Identifier: APACHE-2.0
+
 FROM bitnami/minideb:bullseye as builder
 
 ARG TARGETARCH

--- a/bitnami/thanos/0/scratch/Dockerfile
+++ b/bitnami/thanos/0/scratch/Dockerfile
@@ -1,3 +1,6 @@
+# Copyright VMware, Inc.
+# SPDX-License-Identifier: APACHE-2.0
+
 FROM bitnami/minideb:bullseye as builder
 
 ARG TARGETARCH


### PR DESCRIPTION
### Description of the change

Licenses and copyright notices are included as headers in all our public repositories.
We'll automatically check license headers with the [SkyWalking Eyes](https://github.com/apache/skywalking-eyes) GitHub action.

### Benefits

Automatic license compliance.

### Possible drawbacks

No known drawbacks.

### Applicable issues

None.