### PR TITLE
[bitnami/containers] Fix permissions in license-headers workflow

### DIFF
--- a/.github/workflows/license-headers.yml
+++ b/.github/workflows/license-headers.yml
@@ -3,14 +3,27 @@
 
 ---
 name: '[License] Check license headers'
-
 on:
-  pull_request:
-
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+    branches:
+      - main
+      - bitnami:main
+# Remove all permissions by default
+permissions: {}
 jobs:
   license-headers-linter:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
+        name: Checkout Repository
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Check license Headers
         uses: apache/skywalking-eyes/header@v0.4.0


### PR DESCRIPTION
### Description of the change

Use `pull_request_target` instead of `pull_request` to allow changes in forked pull requests with licenses issues.

### Benefits

Report license issues in forked pull requests.

### Possible drawbacks

None identified.

### Applicable issues

- https://github.com/bitnami/charts/actions/runs/5450309954/jobs/9915432045

### Additional information

According to the [documentation](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token), the maximum access for pull requests from public forked repositories is 'read' for all the APIs. We have to move to `pull_request_target` if we want to add comments/reviews in the pull request.

[Chart PR](https://github.com/bitnami/charts/pull/17464)

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
