### PR TITLE
[bitnami/containers] Run license check on modified files #17542

### DIFF
--- a/.github/workflows/license-headers.yml
+++ b/.github/workflows/license-headers.yml
@@ -25,5 +25,31 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - id: get-modified-files
+        name: 'Get modified files'
+        env:
+          DIFF_URL: "${{github.event.pull_request.diff_url}}"
+          TEMP_FILE: "${{runner.temp}}/pr-${{github.event.number}}.diff"
+        run: |
+          # This request doesn't consume API calls.
+          curl -Lkso $TEMP_FILE $DIFF_URL
+          files_changed="$(sed -nr 's/[\-\+]{3} [ab]\/(.*)/\1/p' $TEMP_FILE | sort | uniq)"
+          dockerfiles=()
+          while read -r file_changed; do
+            # Avoid removed files
+            if [[ -f "${file_changed}" ]]; then
+              dockerfiles+=("${file_changed}")
+            fi
+          done <<< "$(echo "$files_changed" | grep -oE "Dockerfile$" | sort | uniq || true)"
+          if [[ ${#dockerfiles[@]} -gt 0 ]]; then
+            # There are modifications on dockerfiles
+            export dockerfiles_json=$(printf "%s\n" "${dockerfiles[@]}" | jq -R . | jq -cs .)
+            # Overwrite configuration file to analyze only changed dockerfiles
+            yq -i '. | .header.paths=env(dockerfiles_json)' .licenserc.yaml
+            echo "result=success" >> $GITHUB_OUTPUT
+          else
+            echo "result=skip" >> $GITHUB_OUTPUT
+          fi
       - name: Check license Headers
         uses: apache/skywalking-eyes/header@v0.4.0
+        if: ${{ steps.get-modified-files.outputs.result == 'success' }}

--- a/.github/workflows/license-headers.yml
+++ b/.github/workflows/license-headers.yml
@@ -40,7 +40,7 @@ jobs:
             if [[ -f "${file_changed}" ]]; then
               dockerfiles+=("${file_changed}")
             fi
-          done <<< "$(echo "$files_changed" | grep -oE "Dockerfile$" | sort | uniq || true)"
+          done <<< "$(echo "$files_changed" | grep -oE ".*/Dockerfile$" | sort | uniq || true)"
           if [[ ${#dockerfiles[@]} -gt 0 ]]; then
             # There are modifications on dockerfiles
             export dockerfiles_json=$(printf "%s\n" "${dockerfiles[@]}" | jq -R . | jq -cs .)


### PR DESCRIPTION
### Description of the change

Run license header check only on modified files. Please note that current configuration only checks Dockerfiles

### Benefits

Users won't be warned about errors in license header coming from main branch.

### Possible drawbacks

None identifed

### Applicable issues

- #17524

### Additional information

Several tests performed in a forked repository:
- https://github.com/fmulero/containers/pull/66
- https://github.com/fmulero/containers/pull/65

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
