### PR TITLE
[bitnami/keycloak] Remove reference to defunct environment variables in documentation

### DIFF
--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -80,8 +80,6 @@ The Bitnami Keycloak container can create a default admin user by setting the fo
 * `KEYCLOAK_CREATE_ADMIN_USER`: Create administrator user on boot. Default: **true**.
 * `KEYCLOAK_ADMIN_USER`: Administrator default user. Default: **user**.
 * `KEYCLOAK_ADMIN_PASSWORD`: Administrator default password. Default: **bitnami**.
-* `KEYCLOAK_MANAGEMENT_USER`: WildFly default management user. Default: **manager**.
-* `KEYCLOAK_MANAGEMENT_PASSWORD`: WildFly default management password. Default: **bitnami1**.
 
 ### Connecting to a database
 


### PR DESCRIPTION


<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

The README for the Keycloak image mentions environment variables which are remnants of the old Wildfly flavored distribution.
This PR removes those references.

### Benefits

Removes old, now irrelevant information.

### Possible drawbacks

None that I can think of.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #40881

### Additional information

None.
<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
