### PR TITLE
Fix access log not following specified format

### DIFF
--- a/bitnami/openresty/1.21/debian-11/rootfs/opt/bitnami/openresty/nginx/conf/nginx.conf
+++ b/bitnami/openresty/1.21/debian-11/rootfs/opt/bitnami/openresty/nginx/conf/nginx.conf
@@ -15,7 +15,7 @@ http {
     log_format    main '$remote_addr - $remote_user [$time_local] '
                        '"$request" $status  $body_bytes_sent "$http_referer" '
                        '"$http_user_agent" "$http_x_forwarded_for"';
-    access_log    "/opt/bitnami/openresty/nginx/logs/access.log";
+    access_log    "/opt/bitnami/openresty/nginx/logs/access.log" main;
     add_header    X-Frame-Options SAMEORIGIN;
 
     client_body_temp_path  "/opt/bitnami/openresty/nginx/tmp/client_body" 1 2;


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

From my experiments, it seems that things like http_x_forwarded_for is never printed using the container. It seems to be caused by missing to specify the log format name ("main") in access_log command. I will double check and update here.

The nginx counterpart does have `main`: https://github.com/fzyzcjy/containers/blob/4523a19c498fcbd854d4079207b58761d881874f/bitnami/nginx/1.25/debian-11/rootfs/opt/bitnami/nginx/conf/nginx.conf#L18

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
