### PR TITLE
[bitnami/keycloak] Fix full configuration overwriting instructions in README

### DIFF
--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -215,11 +215,11 @@ See [the official documentation](https://www.keycloak.org/server/health) for mor
 
 #### Full configuration
 
-The image looks for configuration files in the `/bitnami/keycloak/configuration/` directory, this directory can be changed by setting the KEYCLOAK_MOUNTED_CONF_DIR environment variable.
+The image looks for configuration files in the `/bitnami/keycloak/conf/` directory, this directory can be changed by setting the `KEYCLOAK_MOUNTED_CONF_DIR` environment variable.
 
 ```console
 docker run --name keycloak \
-    -v /path/to/standalone-ha.xml:/bitnami/keycloak/configuration/standalone-ha.xml \
+    -v /path/to/keycloak.conf:/bitnami/keycloak/conf/keycloak.conf \
     bitnami/keycloak:latest
 ```
 
@@ -229,7 +229,7 @@ Or with docker-compose
 keycloak:
   image: bitnami/keycloak:latest
   volumes:
-    - /path/to/standalone-ha.xml:/bitnami/keycloak/configuration/standalone-ha.xml:ro
+    - /path/to/keycloak.conf:/bitnami/keycloak/conf/keycloak.conf:ro
 ```
 
 After that, your changes will be taken into account in the server's behaviour.


### PR DESCRIPTION
### Description of the change

As it's mentioned by @ice09 in the linked issue, Keycloak is no longer configured using the Wildfly-based configuration file, therefore we need to update the instructions to overwrite the full configuration.

### Benefits

Accurate documentation.

### Possible drawbacks

None

### Applicable issues

- fixes #40881

### Additional information

N/A