### PR TITLE
[bitnami/kafka] Issue 32224-  Allow empty values in Kafka config as environment variable 

### DIFF
--- a/bitnami/kafka/3.2/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/bitnami/kafka/3.2/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -757,7 +757,9 @@ kafka_configure_from_environment_variables() {
         done
 
         value="${!var}"
-        kafka_server_conf_set "$key" "$value"
+        if [[ -n "$value" ]]; then
+            kafka_server_conf_set "$key" "$value"
+        fi
     done
 }
 

--- a/bitnami/kafka/3.2/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/bitnami/kafka/3.2/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -757,9 +757,7 @@ kafka_configure_from_environment_variables() {
         done
 
         value="${!var}"
-        if [[ -n "$value" ]]; then
-            kafka_server_conf_set "$key" "$value"
-        fi
+        kafka_server_conf_set "$key" "$value"
     done
 }
 

--- a/bitnami/kafka/3.3/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/bitnami/kafka/3.3/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -757,7 +757,9 @@ kafka_configure_from_environment_variables() {
         done
 
         value="${!var}"
-        kafka_server_conf_set "$key" "$value"
+        if [[ -n "$value" ]]; then
+            kafka_server_conf_set "$key" "$value"
+        fi
     done
 }
 

--- a/bitnami/kafka/3.3/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/bitnami/kafka/3.3/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -757,9 +757,7 @@ kafka_configure_from_environment_variables() {
         done
 
         value="${!var}"
-        if [[ -n "$value" ]]; then
-            kafka_server_conf_set "$key" "$value"
-        fi
+        kafka_server_conf_set "$key" "$value"
     done
 }
 

--- a/bitnami/kafka/3.4/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/bitnami/kafka/3.4/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -757,7 +757,9 @@ kafka_configure_from_environment_variables() {
         done
 
         value="${!var}"
-        kafka_server_conf_set "$key" "$value"
+        if [[ -n "$value" ]]; then
+            kafka_server_conf_set "$key" "$value"
+        fi
     done
 }
 

--- a/bitnami/kafka/3.4/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/bitnami/kafka/3.4/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -757,9 +757,7 @@ kafka_configure_from_environment_variables() {
         done
 
         value="${!var}"
-        if [[ -n "$value" ]]; then
-            kafka_server_conf_set "$key" "$value"
-        fi
+        kafka_server_conf_set "$key" "$value"
     done
 }
 

--- a/bitnami/kafka/3.5/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/bitnami/kafka/3.5/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -757,7 +757,9 @@ kafka_configure_from_environment_variables() {
         done
 
         value="${!var}"
-        kafka_server_conf_set "$key" "$value"
+        if [[ -n "$value" ]]; then
+            kafka_server_conf_set "$key" "$value"
+        fi
     done
 }
 

--- a/bitnami/kafka/3.5/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/bitnami/kafka/3.5/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -757,9 +757,7 @@ kafka_configure_from_environment_variables() {
         done
 
         value="${!var}"
-        if [[ -n "$value" ]]; then
-            kafka_server_conf_set "$key" "$value"
-        fi
+        kafka_server_conf_set "$key" "$value"
     done
 }
 


### PR DESCRIPTION
**Description of the change**

Remove the 'Empty String' check for Kafka configuration values in the kafka_configure_from_environment_variables function in the libkafka.sh script for the 3.2, 3.3 and 3.4 Kafka containers

**Benefits**

This allows the 'ssl.endpoint.identification.algorithm' configuration value to be set to an empty string.
By default, the broker will the 'HTTPS' as the default value. To choose to disable this check, the configuration value must be set to an empty string.
There is a similar setting to configure zookeeper.

**Possible drawbacks**

This change allows any parameter to be set to an empty string.

**Applicable issues**

fixes https://github.com/bitnami/containers/issues/32224