### PR TITLE
[bitnami/kafka] Add SCRAM support for KRaft

### DIFF
--- a/bitnami/kafka/3.5/debian-11/rootfs/opt/bitnami/scripts/kafka/setup.sh
+++ b/bitnami/kafka/3.5/debian-11/rootfs/opt/bitnami/scripts/kafka/setup.sh
@@ -49,9 +49,5 @@ done
 
 # Ensure Kafka is initialized
 kafka_initialize
-# If KRaft is enabled initialize
-if is_boolean_yes "$KAFKA_ENABLE_KRAFT"; then
-    kraft_initialize
-fi
 # Ensure custom initialization scripts are executed
 kafka_custom_init_scripts

--- a/bitnami/kafka/3.5/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/bitnami/kafka/3.5/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -850,7 +850,7 @@ kafka_initialize() {
         fi
     done
 
-    local generate_kraft_scram
+    local generate_kraft_scram=0
 
     # DEPRECATED. Check for server.properties file in old conf directory to maintain compatibility with Helm chart.
     if [[ ! -f "$KAFKA_BASE_DIR"/conf/server.properties ]] && [[ ! -f "$KAFKA_MOUNTED_CONF_DIR"/server.properties ]]; then


### PR DESCRIPTION
### Description of the change

The Kafka container is currently hardcoded to use Zookeeper for SCRAM credential storage. This PR adds support for using KRaft.

It uses kafka-storage.sh to create the configured users during initialisation. This functionality is described here: https://cwiki.apache.org/confluence/display/KAFKA/KIP-900%3A+KRaft+kafka-storage.sh+API+additions+to+support+SCRAM+for+Kafka+Brokers

### Benefits

Support for SCRAM using KRaft

### Possible drawbacks

Unknown 

### Applicable issues

#41415

### Additional information

This is my first ever PR, please let me know if I've done something wrong 😄 