### PR TITLE
[bitnami/kafka] Fix scram class name for KafkaClient in JAAS

### DIFF
--- a/bitnami/kafka/3.5/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/bitnami/kafka/3.5/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -402,7 +402,7 @@ EOF
             else
                 cat >>"${KAFKA_CONF_DIR}/kafka_jaas.conf" <<EOF
 KafkaClient {
-   org.apache.kafka.common.security.plain.ScramLoginModule required
+   org.apache.kafka.common.security.scram.ScramLoginModule required
 EOF
             fi
             cat >>"${KAFKA_CONF_DIR}/kafka_jaas.conf" <<EOF


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

The kafka_jaas.conf file generated when SASL is enabled contains the following KafkaClient information:
```
KafkaClient {
   org.apache.kafka.common.security.plain.ScramLoginModule required
   username="myuser"
   password="mypassword";
   };
```
Using this to connect to a cluster results in the following error:
_No LoginModule found for org.apache.kafka.common.security.plain.ScramLoginModule_

It appears there is a typo in the class name. Replacing the word 'plain' with 'scram' fixes it.


<!-- Describe the scope of your change - i.e. what the change does. -->

Updates the JAAS KafkaClient element when SASL is enabled from using class
org.apache.kafka.common.security.plain.ScramLoginModule
to using class
org.apache.kafka.common.security.scram.ScramLoginModule

<!-- What benefits will be realized by the code change? -->

This will allow the file to be used to connect to SASL clusters

### Possible drawbacks

<!-- Describe any known limitations with your change -->

Unknown

