### PR TITLE
[bitnami/kafka] Allow setting ssl.client.auth separately for inter-broker, controller, and client listeners

### DIFF
--- a/bitnami/kafka/3.5/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/bitnami/kafka/3.5/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -978,7 +978,13 @@ kafka_initialize() {
             listener_lower="$(echo "$listener" | tr '[:upper:]' '[:lower:]')"
 
             if [[ "$protocol" = "SSL" || "$protocol" = "SASL_SSL" ]]; then
-                kafka_server_conf_set "listener.name.${listener_lower}.ssl.client.auth" "$KAFKA_TLS_INTER_BROKER_AUTH"
+                if [[ "$listener" = "${KAFKA_CFG_INTER_BROKER_LISTENER_NAME:-INTERNAL}" ]]; then
+                    kafka_server_conf_set "listener.name.${listener_lower}.ssl.client.auth" "$KAFKA_TLS_INTER_BROKER_AUTH"
+                elif [[ "${KAFKA_CFG_CONTROLLER_LISTENER_NAMES:-CONTROLLER}" =~ $listener ]]; then
+                    kafka_server_conf_set "listener.name.${listener_lower}.ssl.client.auth" "$KAFKA_TLS_CONTROLLER_AUTH"
+                else
+                    kafka_server_conf_set "listener.name.${listener_lower}.ssl.client.auth" "$KAFKA_TLS_CLIENT_AUTH"
+                fi
             fi
             if [[ "$protocol" = "SASL_PLAINTEXT" || "$protocol" = "SASL_SSL" ]]; then
                 local role=""


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

The kafka container already has different settings for client auth for client, inter-broker, and controller listeners but it currently uses the same setting for all listeners.

This change allows users to set it separately for inter-broker, controller, and client listeners.

### Benefits

This allows ssl client auth for different categories of listeners

### Possible drawbacks

An even better change might be to make it configurable per listener (for example, you might have a CLIENT listener which doesn't need it, and an EXTERNAL listener which does need it). This change keeps it simple by retaining the existing settings.

### Applicable issues

N/A

### Additional information

N/A