### PR TITLE
[bitnami/codeigniter] Fix CodeIgniter database name configuration

### DIFF
--- a/bitnami/codeigniter/4/debian-11/rootfs/opt/bitnami/scripts/libcodeigniter.sh
+++ b/bitnami/codeigniter/4/debian-11/rootfs/opt/bitnami/scripts/libcodeigniter.sh
@@ -103,7 +103,7 @@ codeigniter_initialize() {
             info "Configuring database credentials"
             codeigniter_conf_set "database.default.hostname" "$CODEIGNITER_DATABASE_HOST"
             codeigniter_conf_set "database.default.port" "$CODEIGNITER_DATABASE_PORT_NUMBER"
-            codeigniter_conf_set "database.default.database" "$CODEIGNITER_DATABASE_USER"
+            codeigniter_conf_set "database.default.database" "$CODEIGNITER_DATABASE_NAME"
             codeigniter_conf_set "database.default.username" "$CODEIGNITER_DATABASE_USER"
             codeigniter_conf_set "database.default.password" "$CODEIGNITER_DATABASE_PASSWORD"
         fi


### PR DESCRIPTION
### Description of the change

CodeIgniter database name was set to the database username variable.
This changes it to be set to the database name variable.

### Benefits

This makes it possible to configure the database name in the docker-compose file.

### Possible drawbacks

None

### Applicable issues

- fixes #43310

### Additional information

N/A
