### PR TITLE
[bitnami/mongodb-sharded] Fix "Authentication Failed" error if the mongodb-sharded Helm chart is deployed with custom root username

### DIFF
--- a/bitnami/mongodb-sharded/5.0/debian-11/rootfs/opt/bitnami/scripts/libmongodb-sharded.sh
+++ b/bitnami/mongodb-sharded/5.0/debian-11/rootfs/opt/bitnami/scripts/libmongodb-sharded.sh
@@ -85,7 +85,7 @@ mongodb_sharded_mongod_initialize() {
 
     mongodb_set_listen_all_conf
     if [[ "$MONGODB_SHARDING_MODE" = "shardsvr" ]] && [[ "$MONGODB_REPLICA_SET_MODE" = "primary" ]]; then
-        mongodb_wait_for_node "$MONGODB_MONGOS_HOST" "$MONGODB_MONGOS_PORT_NUMBER" "root" "$MONGODB_ROOT_PASSWORD"
+        mongodb_wait_for_node "$MONGODB_MONGOS_HOST" "$MONGODB_MONGOS_PORT_NUMBER" "$MONGODB_ROOT_USER" "$MONGODB_ROOT_PASSWORD"
         if ! mongodb_sharded_shard_currently_in_cluster "$MONGODB_REPLICA_SET_NAME"; then
             mongodb_sharded_join_shard_cluster
         else
@@ -306,7 +306,7 @@ mongodb_sharded_is_svr_primary_reconfigured() {
     local result
 
     result=$(
-        mongodb_execute_print_output "root" "$MONGODB_ROOT_PASSWORD" "admin" "$node" "$MONGODB_PORT_NUMBER" <<EOF
+        mongodb_execute_print_output "$MONGODB_ROOT_USER" "$MONGODB_ROOT_PASSWORD" "admin" "$node" "$MONGODB_PORT_NUMBER" <<EOF
 rs.reconfig({"_id":"$MONGODB_REPLICA_SET_NAME","configsvr": $([[ "$MONGODB_SHARDING_MODE" = "configsvr" ]] && echo "true" || echo "false"),"protocolVersion":1,"members":[{"_id":0,"host":"$node:$MONGODB_PORT_NUMBER","priority":5}]})
 EOF
     )
@@ -352,7 +352,7 @@ mongodb_sharded_mongos_initialize() {
     mongodb_set_net_conf "$MONGODB_MONGOS_CONF_FILE"
     mongodb_set_log_conf "$MONGODB_MONGOS_CONF_FILE"
     mongodb_sharded_set_cfg_server_host_conf "$MONGODB_MONGOS_CONF_FILE"
-    mongodb_wait_for_primary_node "$MONGODB_CFG_PRIMARY_HOST" "$MONGODB_CFG_PRIMARY_PORT_NUMBER" "root" "$MONGODB_ROOT_PASSWORD"
+    mongodb_wait_for_primary_node "$MONGODB_CFG_PRIMARY_HOST" "$MONGODB_CFG_PRIMARY_PORT_NUMBER" "$MONGODB_ROOT_USER" "$MONGODB_ROOT_PASSWORD"
     mongodb_set_listen_all_conf "$MONGODB_MONGOS_CONF_FILE"
 }
 

--- a/bitnami/mongodb-sharded/6.0/debian-11/rootfs/opt/bitnami/scripts/libmongodb-sharded.sh
+++ b/bitnami/mongodb-sharded/6.0/debian-11/rootfs/opt/bitnami/scripts/libmongodb-sharded.sh
@@ -85,7 +85,7 @@ mongodb_sharded_mongod_initialize() {
 
     mongodb_set_listen_all_conf
     if [[ "$MONGODB_SHARDING_MODE" = "shardsvr" ]] && [[ "$MONGODB_REPLICA_SET_MODE" = "primary" ]]; then
-        mongodb_wait_for_node "$MONGODB_MONGOS_HOST" "$MONGODB_MONGOS_PORT_NUMBER" "root" "$MONGODB_ROOT_PASSWORD"
+        mongodb_wait_for_node "$MONGODB_MONGOS_HOST" "$MONGODB_MONGOS_PORT_NUMBER" "$MONGODB_ROOT_USER" "$MONGODB_ROOT_PASSWORD"
         if ! mongodb_sharded_shard_currently_in_cluster "$MONGODB_REPLICA_SET_NAME"; then
             mongodb_sharded_join_shard_cluster
         else
@@ -306,7 +306,7 @@ mongodb_sharded_is_svr_primary_reconfigured() {
     local result
 
     result=$(
-        mongodb_execute_print_output "root" "$MONGODB_ROOT_PASSWORD" "admin" "$node" "$MONGODB_PORT_NUMBER" <<EOF
+        mongodb_execute_print_output "$MONGODB_ROOT_USER" "$MONGODB_ROOT_PASSWORD" "admin" "$node" "$MONGODB_PORT_NUMBER" <<EOF
 rs.reconfig({"_id":"$MONGODB_REPLICA_SET_NAME","configsvr": $([[ "$MONGODB_SHARDING_MODE" = "configsvr" ]] && echo "true" || echo "false"),"protocolVersion":1,"members":[{"_id":0,"host":"$node:$MONGODB_PORT_NUMBER","priority":5}]})
 EOF
     )
@@ -352,7 +352,7 @@ mongodb_sharded_mongos_initialize() {
     mongodb_set_net_conf "$MONGODB_MONGOS_CONF_FILE"
     mongodb_set_log_conf "$MONGODB_MONGOS_CONF_FILE"
     mongodb_sharded_set_cfg_server_host_conf "$MONGODB_MONGOS_CONF_FILE"
-    mongodb_wait_for_primary_node "$MONGODB_CFG_PRIMARY_HOST" "$MONGODB_CFG_PRIMARY_PORT_NUMBER" "root" "$MONGODB_ROOT_PASSWORD"
+    mongodb_wait_for_primary_node "$MONGODB_CFG_PRIMARY_HOST" "$MONGODB_CFG_PRIMARY_PORT_NUMBER" "$MONGODB_ROOT_USER" "$MONGODB_ROOT_PASSWORD"
     mongodb_set_listen_all_conf "$MONGODB_MONGOS_CONF_FILE"
 }
 


### PR DESCRIPTION
Fix "Authentication Failed" error if the mongodb-sharded Helm chart is deployed with custom root username

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
This change replaces the hardcoded root username `root` by the dynamically injected environment variable `MONGODB_ROOT_USERNAME`.

### Benefits

<!-- What benefits will be realized by the code change? -->
Due to the hardcode, "Authentication Failed" error occurs during the initialisation of a sharded MongoDB if a custom root username is supplied by the user (since the creation of admin user uses the variable `MONGODB_ROOT_USERNAME` instead of the hardcoded root username `root`). After the change, this error can be fixed.

### Possible drawbacks

<!-- Describe any known limitations with your change -->
I believe this change has no drawback.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
<!-- - fixes # -->
*N/A*

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
- Hope that my PR is appropriate enough.
- If it passes review, I hope that this can be released as soon as possible since I found this when I encountered the stated error during my work to set up a sharded MongoDB cluster.