### PR TITLE
[bitnami/moodle] Update README.md to include information about debug logging

### DIFF
--- a/bitnami/moodle/README.md
+++ b/bitnami/moodle/README.md
@@ -445,6 +445,8 @@ docker-compose logs moodle
 
 You can configure the containers [logging driver](https://docs.docker.com/engine/admin/logging/overview/) using the `--log-driver` option if you wish to consume the container logs differently. In the default configuration docker uses the `json-file` driver.
 
+By default, the logging of debug information is disabled. You can enable it by setting the environment variable `BITNAMI_DEBUG` to `true`.
+
 ## Maintenance
 
 ### Backing up your container


### PR DESCRIPTION
### Description of the change

add information about debug logging to the README.md file

### Benefits

Users and Developers can greatly benefit of additional logging. In my case the installation failed in a test environment where the admin password was set to "admin". Enabling the additional debug logging revealed the error, but the switch to enable that is not documented.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

