### PR TITLE
Fix #44313 `bitnami/suitecrm:7` fails to come up due to group ownership set to `root`

### DIFF
--- a/bitnami/suitecrm/7/debian-11/rootfs/opt/bitnami/scripts/suitecrm/postunpack.sh
+++ b/bitnami/suitecrm/7/debian-11/rootfs/opt/bitnami/scripts/suitecrm/postunpack.sh
@@ -32,7 +32,7 @@ ensure_user_exists "$WEB_SERVER_DAEMON_USER" --group "$WEB_SERVER_DAEMON_GROUP"
 for dir in "$SUITECRM_BASE_DIR" "$SUITECRM_VOLUME_DIR" "${SUITECRM_BASE_DIR}/tmp"; do
     ensure_dir_exists "$dir"
     # Use daemon:daemon ownership for compatibility when running as a non-root user
-    configure_permissions_ownership "$dir" -d "775" -f "664" -u "$WEB_SERVER_DAEMON_USER" -g "$WEB_SERVER_DAEMON_USER"
+    configure_permissions_ownership "$dir" -d "775" -f "664" -u "$WEB_SERVER_DAEMON_USER" -g "$WEB_SERVER_DAEMON_GROUP"
 done
 
 # Configure required PHP options for application to work properly, based on build-time defaults

--- a/bitnami/suitecrm/7/debian-11/rootfs/opt/bitnami/scripts/suitecrm/postunpack.sh
+++ b/bitnami/suitecrm/7/debian-11/rootfs/opt/bitnami/scripts/suitecrm/postunpack.sh
@@ -31,8 +31,8 @@ info "Configuring file permissions for SuiteCRM"
 ensure_user_exists "$WEB_SERVER_DAEMON_USER" --group "$WEB_SERVER_DAEMON_GROUP"
 for dir in "$SUITECRM_BASE_DIR" "$SUITECRM_VOLUME_DIR" "${SUITECRM_BASE_DIR}/tmp"; do
     ensure_dir_exists "$dir"
-    # Use daemon:root ownership for compatibility when running as a non-root user
-    configure_permissions_ownership "$dir" -d "775" -f "664" -u "$WEB_SERVER_DAEMON_USER" -g "root"
+    # Use daemon:daemon ownership for compatibility when running as a non-root user
+    configure_permissions_ownership "$dir" -d "775" -f "664" -u "$WEB_SERVER_DAEMON_USER" -g "$WEB_SERVER_DAEMON_USER"
 done
 
 # Configure required PHP options for application to work properly, based on build-time defaults


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change
Fix the group ownership of all files and folders in the web app `bitnami/suitecrm:7`

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits
Allows the web app to run.  Without my change, the app failed and exited.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks
None.

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #44313

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
