### PR TITLE
[bitnami/openldap:2.6] Additional env vars

### DIFF
--- a/bitnami/openldap/2.6/debian-11/rootfs/opt/bitnami/scripts/libopenldap.sh
+++ b/bitnami/openldap/2.6/debian-11/rootfs/opt/bitnami/scripts/libopenldap.sh
@@ -622,10 +622,10 @@ ldap_initialize() {
         fi
         # enable tls
         if is_boolean_yes "$LDAP_ENABLE_TLS"; then
-          ldap_configure_tls
-          if is_boolean_yes "$LDAP_REQUIRE_TLS"; then
-            ldap_configure_tls_required
-          fi
+            ldap_configure_tls
+            if is_boolean_yes "$LDAP_REQUIRE_TLS"; then
+                ldap_configure_tls_required
+            fi
         fi
         ldap_stop
     fi
@@ -775,7 +775,7 @@ olcPPolicyHashCleartext: TRUE
 EOF
     debug_execute ldapmodify -Q -Y EXTERNAL -H "ldapi:///" -f "${LDAP_SHARE_DIR}/ppolicy_configuration_hash_cleartext.ldif"
     fi
-  # enable ppolicy_use_lockout
+    # enable ppolicy_use_lockout
     if is_boolean_yes "$LDAP_PPOLICY_USE_LOCKOUT"; then
         info "Enabling ppolicy_use_lockout"
         cat > "${LDAP_SHARE_DIR}/ppolicy_configuration_use_lockout.ldif" << EOF

--- a/bitnami/openldap/2.6/debian-11/rootfs/opt/bitnami/scripts/libopenldap.sh
+++ b/bitnami/openldap/2.6/debian-11/rootfs/opt/bitnami/scripts/libopenldap.sh
@@ -403,6 +403,9 @@ dn: cn=config
 changetype: modify
 add: olcDisallows
 olcDisallows: bind_anon
+-
+add: olcRequires
+olcRequires: authc
 EOF
     debug_execute ldapmodify -Y EXTERNAL -H "ldapi:///" -f "${LDAP_SHARE_DIR}/disable_anon_bind.ldif"
 }

--- a/bitnami/openldap/README.md
+++ b/bitnami/openldap/README.md
@@ -195,8 +195,10 @@ The Bitnami Docker OpenLDAP can be easily setup with the following environment v
 * `LDAP_ULIMIT_NOFILES`: Maximum number of open file descriptors. Default: **1024**.
 * `LDAP_ALLOW_ANON_BINDING`: Allow anonymous bindings to the LDAP server. Default: **yes**.
 * `LDAP_LOGLEVEL`: Set the loglevel for the OpenLDAP server (see <https://www.openldap.org/doc/admin26/slapdconfig.html> for possible values). Default: **256**.
-* `LDAP_HASH_CLEARTEXT`: Whether plaintext passwords should be hashed automatically. Default: **no**
 * `LDAP_PASSWORD_HASH`: Hash to be used in generation of user passwords. Must be one of {SSHA}, {SHA}, {SMD5}, {MD5}, {CRYPT}, and {CLEARTEXT}. Default: **{SSHA}**.
+* `LDAP_CONFIGURE_PPOLICY`: Enables the ppolicy module and creates an empty configuration. Default: **no**
+* `LDAP_PPOLICY_USE_LOCKOUT`: Whether plaintext passwords should be hashed automatically. Will only be applied with `LDAP_CONFIGURE_PPOLICY` active. Default: **no**
+* `LDAP_PPOLICY_HASH_CLEARTEXT`: Whether plaintext passwords should be hashed automatically. Will only be applied with `LDAP_CONFIGURE_PPOLICY` active. Default: **no**
 
 You can bootstrap the contents of your database by putting LDIF files in the directory `/ldifs` (or the one you define in `LDAP_CUSTOM_LDIF_DIR`). Those may only contain content underneath your base DN (set by `LDAP_ROOT`). You can **not** set configuration for e.g. `cn=config` in those files.
 
@@ -207,7 +209,7 @@ Check the official [OpenLDAP Configuration Reference](https://www.openldap.org/d
 OpenLDAP clients and servers are capable of using the Transport Layer Security (TLS) framework to provide integrity and confidentiality protections and to support LDAP authentication using the SASL EXTERNAL mechanism. Should you desire to enable this optional feature, you may use the following environment variables to configure the application:
 
 * `LDAP_ENABLE_TLS`: Whether to enable TLS for traffic or not. Defaults to `no`.
-* `LDAP_REQUIRE_TLS`: Whether connections must use TLS. Defaults to `no`.
+* `LDAP_REQUIRE_TLS`: Whether connections must use TLS. Will only be applied with `LDAP_ENABLE_TLS` active. Defaults to `no`.
 * `LDAP_LDAPS_PORT_NUMBER`: Port used for TLS secure traffic. Priviledged port is supported (e.g. `636`). Default: **1636** (non privileged port).
 * `LDAP_TLS_CERT_FILE`: File containing the certificate file for the TLS traffic. No defaults.
 * `LDAP_TLS_KEY_FILE`: File containing the key for certificate. No defaults.

--- a/bitnami/openldap/README.md
+++ b/bitnami/openldap/README.md
@@ -194,17 +194,18 @@ The Bitnami Docker OpenLDAP can be easily setup with the following environment v
 * `LDAP_CUSTOM_SCHEMA_DIR`: Location of a directory containing custom internal schema files that could not be added as custom ldif files (i.e. containing some `structuralObjectClass`). This can be used in addition to or instead of `LDAP_CUSTOM_SCHEMA_FILE` (above) to add multiple schema files. Default: **/schemas**
 * `LDAP_ULIMIT_NOFILES`: Maximum number of open file descriptors. Default: **1024**.
 * `LDAP_ALLOW_ANON_BINDING`: Allow anonymous bindings to the LDAP server. Default: **yes**.
-* `LDAP_LOGLEVEL`: Set the loglevel for the OpenLDAP server (see <https://www.openldap.org/doc/admin25/slapdconfig.html> for possible values). Default: **256**.
+* `LDAP_LOGLEVEL`: Set the loglevel for the OpenLDAP server (see <https://www.openldap.org/doc/admin26/slapdconfig.html> for possible values). Default: **256**.
 
 You can bootstrap the contents of your database by putting LDIF files in the directory `/ldifs` (or the one you define in `LDAP_CUSTOM_LDIF_DIR`). Those may only contain content underneath your base DN (set by `LDAP_ROOT`). You can **not** set configuration for e.g. `cn=config` in those files.
 
-Check the official [OpenLDAP Configuration Reference](https://www.openldap.org/doc/admin25/guide.html) for more information about how to configure OpenLDAP.
+Check the official [OpenLDAP Configuration Reference](https://www.openldap.org/doc/admin26/guide.html) for more information about how to configure OpenLDAP.
 
 ### Securing OpenLDAP traffic
 
 OpenLDAP clients and servers are capable of using the Transport Layer Security (TLS) framework to provide integrity and confidentiality protections and to support LDAP authentication using the SASL EXTERNAL mechanism. Should you desire to enable this optional feature, you may use the following environment variables to configure the application:
 
 * `LDAP_ENABLE_TLS`: Whether to enable TLS for traffic or not. Defaults to `no`.
+* `LDAP_REQUIRE_TLS`: Whether connections must use TLS. Defaults to `no`.
 * `LDAP_LDAPS_PORT_NUMBER`: Port used for TLS secure traffic. Priviledged port is supported (e.g. `636`). Default: **1636** (non privileged port).
 * `LDAP_TLS_CERT_FILE`: File containing the certificate file for the TLS traffic. No defaults.
 * `LDAP_TLS_KEY_FILE`: File containing the key for certificate. No defaults.

--- a/bitnami/openldap/README.md
+++ b/bitnami/openldap/README.md
@@ -195,6 +195,8 @@ The Bitnami Docker OpenLDAP can be easily setup with the following environment v
 * `LDAP_ULIMIT_NOFILES`: Maximum number of open file descriptors. Default: **1024**.
 * `LDAP_ALLOW_ANON_BINDING`: Allow anonymous bindings to the LDAP server. Default: **yes**.
 * `LDAP_LOGLEVEL`: Set the loglevel for the OpenLDAP server (see <https://www.openldap.org/doc/admin26/slapdconfig.html> for possible values). Default: **256**.
+* `LDAP_HASH_CLEARTEXT`: Whether plaintext passwords should be hashed automatically. Default: **no**
+* `LDAP_PASSWORD_HASH`: Hash to be used in generation of user passwords. Must be one of {SSHA}, {SHA}, {SMD5}, {MD5}, {CRYPT}, and {CLEARTEXT}. Default: **{SSHA}**.
 
 You can bootstrap the contents of your database by putting LDIF files in the directory `/ldifs` (or the one you define in `LDAP_CUSTOM_LDIF_DIR`). Those may only contain content underneath your base DN (set by `LDAP_ROOT`). You can **not** set configuration for e.g. `cn=config` in those files.
 

--- a/bitnami/openldap/README.md
+++ b/bitnami/openldap/README.md
@@ -197,7 +197,7 @@ The Bitnami Docker OpenLDAP can be easily setup with the following environment v
 * `LDAP_LOGLEVEL`: Set the loglevel for the OpenLDAP server (see <https://www.openldap.org/doc/admin26/slapdconfig.html> for possible values). Default: **256**.
 * `LDAP_PASSWORD_HASH`: Hash to be used in generation of user passwords. Must be one of {SSHA}, {SHA}, {SMD5}, {MD5}, {CRYPT}, and {CLEARTEXT}. Default: **{SSHA}**.
 * `LDAP_CONFIGURE_PPOLICY`: Enables the ppolicy module and creates an empty configuration. Default: **no**
-* `LDAP_PPOLICY_USE_LOCKOUT`: Whether plaintext passwords should be hashed automatically. Will only be applied with `LDAP_CONFIGURE_PPOLICY` active. Default: **no**
+* `LDAP_PPOLICY_USE_LOCKOUT`: Whether bind attempts to locked accounts will always return an error. Will only be applied with `LDAP_CONFIGURE_PPOLICY` active. Default: **no**
 * `LDAP_PPOLICY_HASH_CLEARTEXT`: Whether plaintext passwords should be hashed automatically. Will only be applied with `LDAP_CONFIGURE_PPOLICY` active. Default: **no**
 
 You can bootstrap the contents of your database by putting LDIF files in the directory `/ldifs` (or the one you define in `LDAP_CUSTOM_LDIF_DIR`). Those may only contain content underneath your base DN (set by `LDAP_ROOT`). You can **not** set configuration for e.g. `cn=config` in those files.


### PR DESCRIPTION
### Description of the change

#### Added environment variables
`LDAP_REQUIRE_TLS`
Configures whether connections must use TLS to connect. Can only be applied with LDAP_ENABLE_TLS active. Defaults to `no`.

`LDAP_PASSWORD_HASH`
Configures the hash to be used when generating user passwords. Must be one of {SSHA}, {SHA}, {SMD5}, {MD5}, {CRYPT}, and {CLEARTEXT}. Defaults to **{SSHA}**.

`LDAP_CONFIGURE_PPOLICY`
Enables the ppolicy module and creates an empty configuration. Defaults to **no**

`LDAP_PPOLICY_USE_LOCKOUT`
Whether bind attempts to locked accounts will always return an error. Will only be applied with `LDAP_CONFIGURE_PPOLICY` active. Default: **no**

`LDAP_HASH_CLEARTEXT`
Whether plaintext passwords should be hashed automatically. Will only be applied with `LDAP_CONFIGURE_PPOLICY` active. Default: **no**

#### Modified behaviour
`LDAP_ALLOW_ANON_BINDING`
Regarding the note on bind_anon provided by the openldap configuration reference, disabling this env var will now also enable the requirement for authentication.
 > Disabling the anonymous bind mechanism does not prevent anonymous access to the directory. ... one should instead specify "require authc".

Modified the initial configuration sequence so that tls settings will be applied after everything else to avoid the configuration to fail after `LDAP_REQUIRE_TLS` has been enabled.

### Benefits

Adds more accessible configuration options.

### Possible drawbacks

The default configurations for the newly added env vars have been selected to ensure that OpenLDAP maintains continuity with its previous behavior.
Modifications done to `LDAP_ALLOW_ANON_BINDING` as well as the initial configuration sequence did appear to have an discernible impact.


### Applicable issues

Should resolve #1039 and similar.

### Additional information

It might be useful to additionally reconsider the default values of `LDAP_ALLOW_ANON_BINDING` and `LDAP_REQUIRE_TLS` to provide a more secure out of the box configuration.

