### PR TITLE
[bitnami/*] Add paragraph in notable changes section about scratch renaming

### DIFF
--- a/bitnami/argo-workflow-cli/README.md
+++ b/bitnami/argo-workflow-cli/README.md
@@ -121,6 +121,12 @@ docker run --rm --name argo-workflow-cli bitnami/argo-workflow-cli:latest --help
 
 Check the [official Argo Workflows CLI documentation](https://argoproj.github.io/argo-workflows/cli/argo/) for the list of the available parameters.
 
+## Notable Changes
+
+Starting from August 16, 2023, all container images with the "scratch" suffix in their tag name will be changed to use the "debian" suffix. It's important to note that this change also affects the structure of our repository.
+
+This adjustment helps to accurately reflect the operating system used in our pipeline for building our distroless binary-only container. Apart from the change in tag naming, there are no other impacts on the generated images.
+
 ## Contributing
 
 We'd love for you to contribute to this Docker image. You can request new features by creating an [issue](https://github.com/bitnami/containers/issues) or submitting a [pull request](https://github.com/bitnami/containers/pulls) with your contribution.

--- a/bitnami/argo-workflow-controller/README.md
+++ b/bitnami/argo-workflow-controller/README.md
@@ -121,6 +121,12 @@ docker run --rm --name argo-workflow-controller bitnami/argo-workflow-controller
 
 Check the [official Argo Workflows Controller documentation](https://argoproj.github.io/argo-workflows/environment-variables/#controller) for the list of the available parameters.
 
+## Notable Changes
+
+Starting from August 16, 2023, all container images with the "scratch" suffix in their tag name will be changed to use the "debian" suffix. It's important to note that this change also affects the structure of our repository.
+
+This adjustment helps to accurately reflect the operating system used in our pipeline for building our distroless binary-only container. Apart from the change in tag naming, there are no other impacts on the generated images.
+
 ## Contributing
 
 We'd love for you to contribute to this Docker image. You can request new features by creating an [issue](https://github.com/bitnami/containers/issues) or submitting a [pull request](https://github.com/bitnami/containers/pulls) with your contribution.

--- a/bitnami/kaniko/README.md
+++ b/bitnami/kaniko/README.md
@@ -113,6 +113,12 @@ docker run --rm --name kaniko bitnami/kaniko:latest --help
 
 Check the [official Kaniko documentation](https://github.com/GoogleContainerTools/kanikodocs/) for more information about how to use Kaniko.
 
+## Notable Changes
+
+Starting from August 16, 2023, all container images with the "scratch" suffix in their tag name will be changed to use the "debian" suffix. It's important to note that this change also affects the structure of our repository.
+
+This adjustment helps to accurately reflect the operating system used in our pipeline for building our distroless binary-only container. Apart from the change in tag naming, there are no other impacts on the generated images.
+
 ## Contributing
 
 We'd love for you to contribute to this Docker image. You can request new features by creating an [issue](https://github.com/bitnami/containers/issues) or submitting a [pull request](https://github.com/bitnami/containers/pulls) with your contribution.

--- a/bitnami/kube-rbac-proxy/README.md
+++ b/bitnami/kube-rbac-proxy/README.md
@@ -70,6 +70,12 @@ docker run --rm --name kube-rbac-proxy bitnami/kube-rbac-proxy:latest --  --upst
 
 Check the [official Kube RBAC Proxy documentation](https://github.com/brancz/kube-rbac-proxy) for more information.
 
+## Notable Changes
+
+Starting from August 16, 2023, all container images with the "scratch" suffix in their tag name will be changed to use the "debian" suffix. It's important to note that this change also affects the structure of our repository.
+
+This adjustment helps to accurately reflect the operating system used in our pipeline for building our distroless binary-only container. Apart from the change in tag naming, there are no other impacts on the generated images.
+
 ## Contributing
 
 We'd love for you to contribute to this container. You can request new features by creating an [issue](https://github.com/bitnami/containers/issues) or submitting a [pull request](https://github.com/bitnami/containers/pulls) with your contribution.

--- a/bitnami/kubeapps-apprepository-controller/README.md
+++ b/bitnami/kubeapps-apprepository-controller/README.md
@@ -40,6 +40,12 @@ Subscribe to project updates by watching the [bitnami/containers GitHub repo](ht
 
 For further documentation, please check [here](https://github.com/vmware-tanzu/kubeapps/tree/master/cmd/apprepository-controller).
 
+## Notable Changes
+
+Starting from August 16, 2023, all container images with the "scratch" suffix in their tag name will be changed to use the "debian" suffix. It's important to note that this change also affects the structure of our repository.
+
+This adjustment helps to accurately reflect the operating system used in our pipeline for building our distroless binary-only container. Apart from the change in tag naming, there are no other impacts on the generated images.
+
 ## Contributing
 
 We'd love for you to contribute to this container. You can request new features by creating an [issue](https://github.com/bitnami/containers/issues) or submitting a [pull request](https://github.com/bitnami/containers/pulls) with your contribution.

--- a/bitnami/kubeapps-asset-syncer/README.md
+++ b/bitnami/kubeapps-asset-syncer/README.md
@@ -40,6 +40,12 @@ Subscribe to project updates by watching the [bitnami/containers GitHub repo](ht
 
 For further documentation, please check [here](https://github.com/vmware-tanzu/kubeapps/tree/master/cmd/asset-syncer).
 
+## Notable Changes
+
+Starting from August 16, 2023, all container images with the "scratch" suffix in their tag name will be changed to use the "debian" suffix. It's important to note that this change also affects the structure of our repository.
+
+This adjustment helps to accurately reflect the operating system used in our pipeline for building our distroless binary-only container. Apart from the change in tag naming, there are no other impacts on the generated images.
+
 ## Contributing
 
 We'd love for you to contribute to this container. You can request new features by creating an [issue](https://github.com/bitnami/containers/issues) or submitting a [pull request](https://github.com/bitnami/containers/pulls) with your contribution.

--- a/bitnami/oras/README.md
+++ b/bitnami/oras/README.md
@@ -68,7 +68,6 @@ docker run --rm --name oras bitnami/oras:latest --version
 
 Check the [official ORAS documentation](https://oras.land/cli/) for a list of the available commands and parameters.
 
-
 ## Notable Changes
 
 Starting from August 16, 2023, all container images with the "scratch" suffix in their tag name will be changed to use the "debian" suffix. It's important to note that this change also affects the structure of our repository.

--- a/bitnami/oras/README.md
+++ b/bitnami/oras/README.md
@@ -68,6 +68,13 @@ docker run --rm --name oras bitnami/oras:latest --version
 
 Check the [official ORAS documentation](https://oras.land/cli/) for a list of the available commands and parameters.
 
+
+## Notable Changes
+
+Starting from August 16, 2023, all container images with the "scratch" suffix in their tag name will be changed to use the "debian" suffix. It's important to note that this change also affects the structure of our repository.
+
+This adjustment helps to accurately reflect the operating system used in our pipeline for building our distroless binary-only container. Apart from the change in tag naming, there are no other impacts on the generated images.
+
 ## Contributing
 
 We'd love for you to contribute to this container. You can request new features by creating an [issue](https://github.com/bitnami/containers/issues) or submitting a [pull request](https://github.com/bitnami/containers/pulls) with your contribution.

--- a/bitnami/pinniped/README.md
+++ b/bitnami/pinniped/README.md
@@ -70,6 +70,12 @@ docker run --rm --name pinniped bitnami/pinniped:latest --  --help
 
 Check the [official Pinniped documentation](https://pinniped.dev//docs) for more information.
 
+## Notable Changes
+
+Starting from August 16, 2023, all container images with the "scratch" suffix in their tag name will be changed to use the "debian" suffix. It's important to note that this change also affects the structure of our repository.
+
+This adjustment helps to accurately reflect the operating system used in our pipeline for building our distroless binary-only container. Apart from the change in tag naming, there are no other impacts on the generated images.
+
 ## Contributing
 
 We'd love for you to contribute to this container. You can request new features by creating an [issue](https://github.com/bitnami/containers/issues) or submitting a [pull request](https://github.com/bitnami/containers/pulls) with your contribution.

--- a/bitnami/rabbitmq-cluster-operator/README.md
+++ b/bitnami/rabbitmq-cluster-operator/README.md
@@ -70,6 +70,12 @@ docker run --rm --name rabbitmq-cluster-operator bitnami/rabbitmq-cluster-operat
 
 Check the [official RabbitMQ Cluster Operator documentation](https://github.com/rabbitmq/cluster-operator/tree/main/docs) for more information.
 
+## Notable Changes
+
+Starting from August 16, 2023, all container images with the "scratch" suffix in their tag name will be changed to use the "debian" suffix. It's important to note that this change also affects the structure of our repository.
+
+This adjustment helps to accurately reflect the operating system used in our pipeline for building our distroless binary-only container. Apart from the change in tag naming, there are no other impacts on the generated images.
+
 ## Contributing
 
 We'd love for you to contribute to this container. You can request new features by creating an [issue](https://github.com/bitnami/containers/issues) or submitting a [pull request](https://github.com/bitnami/containers/pulls) with your contribution.

--- a/bitnami/rmq-default-credential-updater/README.md
+++ b/bitnami/rmq-default-credential-updater/README.md
@@ -70,6 +70,12 @@ docker run --rm --name rmq-default-credential-updater bitnami/rmq-default-creden
 
 Check the [official RabbitMQ Default User Credential Updater documentation](https://github.com/rabbitmq/default-user-credential-updater) for more information.
 
+## Notable Changes
+
+Starting from August 16, 2023, all container images with the "scratch" suffix in their tag name will be changed to use the "debian" suffix. It's important to note that this change also affects the structure of our repository.
+
+This adjustment helps to accurately reflect the operating system used in our pipeline for building our distroless binary-only container. Apart from the change in tag naming, there are no other impacts on the generated images.
+
 ## Contributing
 
 We'd love for you to contribute to this container. You can request new features by creating an [issue](https://github.com/bitnami/containers/issues) or submitting a [pull request](https://github.com/bitnami/containers/pulls) with your contribution.

--- a/bitnami/rmq-messaging-topology-operator/README.md
+++ b/bitnami/rmq-messaging-topology-operator/README.md
@@ -70,6 +70,12 @@ docker run --rm --name rmq-default-credential-updater bitnami/rmq-default-creden
 
 Check the [official RabbitMQ Messaging Topology Operator documentation](https://github.com/rabbitmq/messaging-topology-operator) for more information.
 
+## Notable Changes
+
+Starting from August 16, 2023, all container images with the "scratch" suffix in their tag name will be changed to use the "debian" suffix. It's important to note that this change also affects the structure of our repository.
+
+This adjustment helps to accurately reflect the operating system used in our pipeline for building our distroless binary-only container. Apart from the change in tag naming, there are no other impacts on the generated images.
+
 ## Contributing
 
 We'd love for you to contribute to this container. You can request new features by creating an [issue](https://github.com/bitnami/containers/issues) or submitting a [pull request](https://github.com/bitnami/containers/pulls) with your contribution.

--- a/bitnami/sealed-secrets/README.md
+++ b/bitnami/sealed-secrets/README.md
@@ -63,6 +63,12 @@ To run commands inside this container you can use `docker run`, for example to e
 docker run --rm --name sealed-secrets bitnami/sealed-secrets:latest -- kubeseal --version
 ```
 
+## Notable Changes
+
+Starting from August 16, 2023, all container images with the "scratch" suffix in their tag name will be changed to use the "debian" suffix. It's important to note that this change also affects the structure of our repository.
+
+This adjustment helps to accurately reflect the operating system used in our pipeline for building our distroless binary-only container. Apart from the change in tag naming, there are no other impacts on the generated images.
+
 ## Contributing
 
 We'd love for you to contribute to this container. You can request new features by creating an [issue](https://github.com/bitnami/containers/issues) or submitting a [pull request](https://github.com/bitnami/containers/pulls) with your contribution.

--- a/bitnami/thanos/README.md
+++ b/bitnami/thanos/README.md
@@ -181,6 +181,12 @@ docker logs thanos
 
 You can configure the containers [logging driver](https://docs.docker.com/engine/admin/logging/overview/) using the `--log-driver` option if you wish to consume the container logs differently. In the default configuration docker uses the `json-file` driver.
 
+## Notable Changes
+
+Starting from August 16, 2023, all container images with the "scratch" suffix in their tag name will be changed to use the "debian" suffix. It's important to note that this change also affects the structure of our repository.
+
+This adjustment helps to accurately reflect the operating system used in our pipeline for building our distroless binary-only container. Apart from the change in tag naming, there are no other impacts on the generated images.
+
 ## Contributing
 
 We'd love for you to contribute to this container. You can request new features by creating an [issue](https://github.com/bitnami/containers/issues) or submitting a [pull request](https://github.com/bitnami/containers/pulls) with your contribution.


### PR DESCRIPTION
### Description of the change

Add the following paragraph to the README file present in all scratch containers:

>## Notable Changes
>
>Starting from August 16, 2023, all container images with the "scratch" suffix in their tag name will be changed to use the "debian" suffix. It's important to note that this change also affects the structure of our repository.
>
>This adjustment helps to accurately reflect the operating system used in our pipeline for building our distroless binary-only container. Apart from the change in tag naming, there are no other impacts on the generated images.