### PR TITLE
[bitnami/kafka] change zookeeper keystore pem location

### DIFF
--- a/bitnami/kafka/3.2/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/bitnami/kafka/3.2/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -773,7 +773,7 @@ kafka_zookeeper_configure_tls() {
         # Concatenating private key into public certificate file
         # This is needed to load keystore from location using PEM
         keystore_location="${KAFKA_CERTS_DIR}/zookeeper.keypair.pem"
-        cat "${KAFKA_CERTS_DIR}/zookeeper.keystore.pem" "${KAFKA_CERTS_DIR}/zookeeper.keystore.key" > "$keystore_location"
+        cat "${KAFKA_CERTS_DIR}/zookeeper.keystore.{pem,key}" > "$keystore_location"
     fi
 
     kafka_server_conf_set "zookeeper.clientCnxnSocket" "org.apache.zookeeper.ClientCnxnSocketNetty"

--- a/bitnami/kafka/3.2/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/bitnami/kafka/3.2/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -772,8 +772,8 @@ kafka_zookeeper_configure_tls() {
     elif [[ "$KAFKA_ZOOKEEPER_TLS_TYPE" = "PEM" ]] && [[ -f "$KAFKA_CERTS_DIR"/zookeeper.keystore.pem ]] && [[ -f "$KAFKA_CERTS_DIR"/zookeeper.keystore.key ]]; then
         # Concatenating private key into public certificate file
         # This is needed to load keystore from location using PEM
-        cat "$KAFKA_CERTS_DIR"/zookeeper.keystore.pem "$KAFKA_CERTS_DIR"/zookeeper.keystore.key > "$KAFKA_CERTS_DIR"/zookeeper-keypair.pem
-        keystore_location="$KAFKA_CERTS_DIR"/zookeeper-keypair.pem
+        keystore_location="${KAFKA_CERTS_DIR}/zookeeper.keypair.pem"
+        cat "${KAFKA_CERTS_DIR}/zookeeper.keystore.pem" "${KAFKA_CERTS_DIR}/zookeeper.keystore.key" > "$keystore_location"
     fi
 
     kafka_server_conf_set "zookeeper.clientCnxnSocket" "org.apache.zookeeper.ClientCnxnSocketNetty"

--- a/bitnami/kafka/3.2/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/bitnami/kafka/3.2/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -772,8 +772,8 @@ kafka_zookeeper_configure_tls() {
     elif [[ "$KAFKA_ZOOKEEPER_TLS_TYPE" = "PEM" ]] && [[ -f "$KAFKA_CERTS_DIR"/zookeeper.keystore.pem ]] && [[ -f "$KAFKA_CERTS_DIR"/zookeeper.keystore.key ]]; then
         # Concatenating private key into public certificate file
         # This is needed to load keystore from location using PEM
-        cat "$KAFKA_CERTS_DIR"/zookeeper.keystore.key >>"$KAFKA_CERTS_DIR"/zookeeper.keystore.pem
-        keystore_location="${KAFKA_CERTS_DIR}/zookeeper.keystore.pem"
+        cat "$KAFKA_CERTS_DIR"/zookeeper.keystore.pem "$KAFKA_CERTS_DIR"/zookeeper.keystore.key > "$KAFKA_CERTS_DIR"/zookeeper-keypair.pem
+        keystore_location="$KAFKA_CERTS_DIR"/zookeeper-keypair.pem
     fi
 
     kafka_server_conf_set "zookeeper.clientCnxnSocket" "org.apache.zookeeper.ClientCnxnSocketNetty"

--- a/bitnami/kafka/3.2/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/bitnami/kafka/3.2/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -773,7 +773,7 @@ kafka_zookeeper_configure_tls() {
         # Concatenating private key into public certificate file
         # This is needed to load keystore from location using PEM
         keystore_location="${KAFKA_CERTS_DIR}/zookeeper.keypair.pem"
-        cat "${KAFKA_CERTS_DIR}/zookeeper.keystore.{pem,key}" > "$keystore_location"
+        cat "${KAFKA_CERTS_DIR}/zookeeper.keystore.pem" "${KAFKA_CERTS_DIR}/zookeeper.keystore.key" > "$keystore_location"
     fi
 
     kafka_server_conf_set "zookeeper.clientCnxnSocket" "org.apache.zookeeper.ClientCnxnSocketNetty"

--- a/bitnami/kafka/3.3/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/bitnami/kafka/3.3/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -772,8 +772,8 @@ kafka_zookeeper_configure_tls() {
     elif [[ "$KAFKA_ZOOKEEPER_TLS_TYPE" = "PEM" ]] && [[ -f "$KAFKA_CERTS_DIR"/zookeeper.keystore.pem ]] && [[ -f "$KAFKA_CERTS_DIR"/zookeeper.keystore.key ]]; then
         # Concatenating private key into public certificate file
         # This is needed to load keystore from location using PEM
-        cat "$KAFKA_CERTS_DIR"/zookeeper.keystore.key >>"$KAFKA_CERTS_DIR"/zookeeper.keystore.pem
-        keystore_location="${KAFKA_CERTS_DIR}/zookeeper.keystore.pem"
+        cat "$KAFKA_CERTS_DIR"/zookeeper.keystore.pem "$KAFKA_CERTS_DIR"/zookeeper.keystore.key > "$KAFKA_CERTS_DIR"/zookeeper-keypair.pem
+        keystore_location="$KAFKA_CERTS_DIR"/zookeeper-keypair.pem
     fi
 
     kafka_server_conf_set "zookeeper.clientCnxnSocket" "org.apache.zookeeper.ClientCnxnSocketNetty"

--- a/bitnami/kafka/3.3/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/bitnami/kafka/3.3/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -773,7 +773,7 @@ kafka_zookeeper_configure_tls() {
         # Concatenating private key into public certificate file
         # This is needed to load keystore from location using PEM
         keystore_location="${KAFKA_CERTS_DIR}/zookeeper.keypair.pem"
-        cat "${KAFKA_CERTS_DIR}/zookeeper.keystore.{pem,key}" > "$keystore_location"
+        cat "${KAFKA_CERTS_DIR}/zookeeper.keystore.pem" "${KAFKA_CERTS_DIR}/zookeeper.keystore.key" > "$keystore_location"
     fi
 
     kafka_server_conf_set "zookeeper.clientCnxnSocket" "org.apache.zookeeper.ClientCnxnSocketNetty"

--- a/bitnami/kafka/3.3/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/bitnami/kafka/3.3/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -772,8 +772,8 @@ kafka_zookeeper_configure_tls() {
     elif [[ "$KAFKA_ZOOKEEPER_TLS_TYPE" = "PEM" ]] && [[ -f "$KAFKA_CERTS_DIR"/zookeeper.keystore.pem ]] && [[ -f "$KAFKA_CERTS_DIR"/zookeeper.keystore.key ]]; then
         # Concatenating private key into public certificate file
         # This is needed to load keystore from location using PEM
-        cat "$KAFKA_CERTS_DIR"/zookeeper.keystore.pem "$KAFKA_CERTS_DIR"/zookeeper.keystore.key > "$KAFKA_CERTS_DIR"/zookeeper-keypair.pem
-        keystore_location="$KAFKA_CERTS_DIR"/zookeeper-keypair.pem
+        keystore_location="${KAFKA_CERTS_DIR}/zookeeper.keypair.pem"
+        cat "${KAFKA_CERTS_DIR}/zookeeper.keystore.{pem,key}" > "$keystore_location"
     fi
 
     kafka_server_conf_set "zookeeper.clientCnxnSocket" "org.apache.zookeeper.ClientCnxnSocketNetty"

--- a/bitnami/kafka/3.4/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/bitnami/kafka/3.4/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -772,8 +772,8 @@ kafka_zookeeper_configure_tls() {
     elif [[ "$KAFKA_ZOOKEEPER_TLS_TYPE" = "PEM" ]] && [[ -f "$KAFKA_CERTS_DIR"/zookeeper.keystore.pem ]] && [[ -f "$KAFKA_CERTS_DIR"/zookeeper.keystore.key ]]; then
         # Concatenating private key into public certificate file
         # This is needed to load keystore from location using PEM
-        cat "$KAFKA_CERTS_DIR"/zookeeper.keystore.key >>"$KAFKA_CERTS_DIR"/zookeeper.keystore.pem
-        keystore_location="${KAFKA_CERTS_DIR}/zookeeper.keystore.pem"
+        cat "$KAFKA_CERTS_DIR"/zookeeper.keystore.pem "$KAFKA_CERTS_DIR"/zookeeper.keystore.key > "$KAFKA_CERTS_DIR"/zookeeper-keypair.pem
+        keystore_location="$KAFKA_CERTS_DIR"/zookeeper-keypair.pem
     fi
 
     kafka_server_conf_set "zookeeper.clientCnxnSocket" "org.apache.zookeeper.ClientCnxnSocketNetty"

--- a/bitnami/kafka/3.4/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/bitnami/kafka/3.4/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -773,7 +773,7 @@ kafka_zookeeper_configure_tls() {
         # Concatenating private key into public certificate file
         # This is needed to load keystore from location using PEM
         keystore_location="${KAFKA_CERTS_DIR}/zookeeper.keypair.pem"
-        cat "${KAFKA_CERTS_DIR}/zookeeper.keystore.{pem,key}" > "$keystore_location"
+        cat "${KAFKA_CERTS_DIR}/zookeeper.keystore.pem" "${KAFKA_CERTS_DIR}/zookeeper.keystore.key" > "$keystore_location"
     fi
 
     kafka_server_conf_set "zookeeper.clientCnxnSocket" "org.apache.zookeeper.ClientCnxnSocketNetty"

--- a/bitnami/kafka/3.4/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/bitnami/kafka/3.4/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -772,8 +772,8 @@ kafka_zookeeper_configure_tls() {
     elif [[ "$KAFKA_ZOOKEEPER_TLS_TYPE" = "PEM" ]] && [[ -f "$KAFKA_CERTS_DIR"/zookeeper.keystore.pem ]] && [[ -f "$KAFKA_CERTS_DIR"/zookeeper.keystore.key ]]; then
         # Concatenating private key into public certificate file
         # This is needed to load keystore from location using PEM
-        cat "$KAFKA_CERTS_DIR"/zookeeper.keystore.pem "$KAFKA_CERTS_DIR"/zookeeper.keystore.key > "$KAFKA_CERTS_DIR"/zookeeper-keypair.pem
-        keystore_location="$KAFKA_CERTS_DIR"/zookeeper-keypair.pem
+        keystore_location="${KAFKA_CERTS_DIR}/zookeeper.keypair.pem"
+        cat "${KAFKA_CERTS_DIR}/zookeeper.keystore.{pem,key}" > "$keystore_location"
     fi
 
     kafka_server_conf_set "zookeeper.clientCnxnSocket" "org.apache.zookeeper.ClientCnxnSocketNetty"

--- a/bitnami/kafka/3.5/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/bitnami/kafka/3.5/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -772,8 +772,8 @@ kafka_zookeeper_configure_tls() {
     elif [[ "$KAFKA_ZOOKEEPER_TLS_TYPE" = "PEM" ]] && [[ -f "$KAFKA_CERTS_DIR"/zookeeper.keystore.pem ]] && [[ -f "$KAFKA_CERTS_DIR"/zookeeper.keystore.key ]]; then
         # Concatenating private key into public certificate file
         # This is needed to load keystore from location using PEM
-        cat "$KAFKA_CERTS_DIR"/zookeeper.keystore.key >>"$KAFKA_CERTS_DIR"/zookeeper.keystore.pem
-        keystore_location="${KAFKA_CERTS_DIR}/zookeeper.keystore.pem"
+        cat "$KAFKA_CERTS_DIR"/zookeeper.keystore.pem "$KAFKA_CERTS_DIR"/zookeeper.keystore.key > "$KAFKA_CERTS_DIR"/zookeeper-keypair.pem
+        keystore_location="$KAFKA_CERTS_DIR"/zookeeper-keypair.pem
     fi
 
     kafka_server_conf_set "zookeeper.clientCnxnSocket" "org.apache.zookeeper.ClientCnxnSocketNetty"

--- a/bitnami/kafka/3.5/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/bitnami/kafka/3.5/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -773,7 +773,7 @@ kafka_zookeeper_configure_tls() {
         # Concatenating private key into public certificate file
         # This is needed to load keystore from location using PEM
         keystore_location="${KAFKA_CERTS_DIR}/zookeeper.keypair.pem"
-        cat "${KAFKA_CERTS_DIR}/zookeeper.keystore.{pem,key}" > "$keystore_location"
+        cat "${KAFKA_CERTS_DIR}/zookeeper.keystore.pem" "${KAFKA_CERTS_DIR}/zookeeper.keystore.key" > "$keystore_location"
     fi
 
     kafka_server_conf_set "zookeeper.clientCnxnSocket" "org.apache.zookeeper.ClientCnxnSocketNetty"

--- a/bitnami/kafka/3.5/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/bitnami/kafka/3.5/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -772,8 +772,8 @@ kafka_zookeeper_configure_tls() {
     elif [[ "$KAFKA_ZOOKEEPER_TLS_TYPE" = "PEM" ]] && [[ -f "$KAFKA_CERTS_DIR"/zookeeper.keystore.pem ]] && [[ -f "$KAFKA_CERTS_DIR"/zookeeper.keystore.key ]]; then
         # Concatenating private key into public certificate file
         # This is needed to load keystore from location using PEM
-        cat "$KAFKA_CERTS_DIR"/zookeeper.keystore.pem "$KAFKA_CERTS_DIR"/zookeeper.keystore.key > "$KAFKA_CERTS_DIR"/zookeeper-keypair.pem
-        keystore_location="$KAFKA_CERTS_DIR"/zookeeper-keypair.pem
+        keystore_location="${KAFKA_CERTS_DIR}/zookeeper.keypair.pem"
+        cat "${KAFKA_CERTS_DIR}/zookeeper.keystore.{pem,key}" > "$keystore_location"
     fi
 
     kafka_server_conf_set "zookeeper.clientCnxnSocket" "org.apache.zookeeper.ClientCnxnSocketNetty"

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -207,7 +207,7 @@ The configuration can easily be setup with the Bitnami Apache Kafka Docker image
 * `KAFKA_CFG_PROCESS_ROLES`: Node roles when running in KRaft mode. No defaults.
 * `KAFKA_CFG_NODE_ID`: Unique node id, required when running in KRaft mode. No defaults.
 * `KAFKA_CFG_CONTROLLER_QUORUM_VOTERS`: Map of id/endpoint information for the set of controller quorum voters in a comma-separated list of {id}@{host}:{port} entries. No defaults.
-* `KAFKA_RAFT_CLUSTER_ID`: Kafka cluster ID when using Kafka Raft (KRaft). No defaults.
+* `KAFKA_KRAFT_CLUSTER_ID`: Kafka cluster ID when using Kafka Raft (KRaft). No defaults.
 
 Additionally, any environment variable beginning with `KAFKA_CFG_` will be mapped to its corresponding Apache Kafka key. For example, use `KAFKA_CFG_BACKGROUND_THREADS` in order to set `background.threads` or `KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE` in order to configure `auto.create.topics.enable`.
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

I think this necessary because from experience, I find that I keep having to update my local keystore which somehow became more of a burden

### Benefits

Eliminate the need to update and change zookeeper.keystore.pem every single time.

### Possible drawbacks

None that I can think of.

### Applicable issues

Frustrating need to keep updating local zookeeper.keystore.pem evicted.