### PR TITLE
[bitnami/pgbouncer] Escape username and password for pgbouncer auth file generation.

### DIFF
--- a/bitnami/pgbouncer/1/debian-11/rootfs/opt/bitnami/scripts/libpgbouncer.sh
+++ b/bitnami/pgbouncer/1/debian-11/rootfs/opt/bitnami/scripts/libpgbouncer.sh
@@ -163,6 +163,19 @@ pgbouncer_is_file_external() {
 }
 
 ########################
+# Output helper for escaped auth fields
+# Arguments:
+#   $1 - raw username or password
+# Returns:
+#   None
+#########################
+pgbouncer_escape_auth() {
+    # replace each " with ""
+    echo "$1" | sed 's/"/""/g'
+}
+
+
+########################
 # Ensure PgBouncer is initialized
 # Globals:
 #   PGBOUNCER_*
@@ -190,7 +203,8 @@ pgbouncer_initialize() {
     info "Configuring credentials"
     # Create credentials file
     if ! pgbouncer_is_file_external "userlist.txt"; then
-        echo "\"$POSTGRESQL_USERNAME\" \"$POSTGRESQL_PASSWORD\"" > "$PGBOUNCER_AUTH_FILE"
+        echo "\""$(pgbouncer_escape_auth "$POSTGRESQL_USERNAME")"\" \""$(pgbouncer_escape_auth "$POSTGRESQL_PASSWORD")"\"" \
+           > "$PGBOUNCER_AUTH_FILE"
         echo "$PGBOUNCER_USERLIST" >> "$PGBOUNCER_AUTH_FILE"
     else
         debug "User list file mounted externally, skipping configuration"


### PR DESCRIPTION
### Description of the change
Escape raw username and password following http://www.pgbouncer.org/config.html#authentication-file-format

### Benefits
Bug fix.

### Possible drawbacks
A workaround for #46094 is escaping quotes in the configuration.
This workaround has to be removed using the bugfix.

### Applicable issues
#46094

### Additional information

