### PR TITLE
[bitnami/supabase-realtime] Disable check-app-version test

### DIFF
--- a/.vib/supabase-realtime/goss/goss.yaml
+++ b/.vib/supabase-realtime/goss/goss.yaml
@@ -3,7 +3,7 @@
 
 gossfile:
   # Load scripts from .vib/common/goss/templates
-  ../../common/goss/templates/check-app-version.yaml: {}
+  # ../../common/goss/templates/check-app-version.yaml: {} - Disable due to mismatch version in the upstream release https://github.com/supabase/realtime/releases/tag/v2.22.3
   ../../common/goss/templates/check-binaries.yaml: {}
   ../../common/goss/templates/check-broken-symlinks.yaml: {}
   ../../common/goss/templates/check-ca-certs.yaml: {}


### PR DESCRIPTION
### Description of the change

Disable `check-app-version` GOSS test due to a mismatch in [this release](https://github.com/supabase/realtime/releases/tag/v2.22.3).
 
### Benefits

Allow us to release the new version.

### Possible drawbacks

N/A

### Applicable issues

- fixes #

### Additional information

N/A