### PR TITLE
[bitnami/minio*] Simplify GOSS tests to support PhotonOS

### DIFF
--- a/.vib/minio-client/goss/minio-client.yaml
+++ b/.vib/minio-client/goss/minio-client.yaml
@@ -3,7 +3,7 @@
 
 command:
   check-app-version:
-    exec: mc --version | grep -P -o "[0-9]{4}\-[0-9]{2}\-[0-9]{2}" | sed "s/\-0*/./g"
+    exec: mc --version | sed "s/\-0*/./g"
     exit-status: 0
     stdout:
       - {{ .Env.APP_VERSION }}

--- a/.vib/minio/goss/minio.yaml
+++ b/.vib/minio/goss/minio.yaml
@@ -8,7 +8,7 @@ file:
     linked-to: /dev/stdout
 command:
   check-app-version:
-    exec: minio --version | grep -P -o "[0-9]{4}\-[0-9]{2}\-[0-9]{2}" | sed "s/\-0*/./g"
+    exec: minio --version | sed "s/\-0*/./g"
     exit-status: 0
     stdout:
       - {{ .Env.APP_VERSION }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

PhotonOS does not include `grep -P` support:

```
grep: support for the -P option is not compiled into this --disable-perl-regexp binary
```

### Benefits

Tests work on PhotonOS

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A
