### PR TITLE
[bitnami/wordpress] Remove memcached check to fix Photon tests

### DIFF
--- a/.vib/wordpress/goss/vars.yaml
+++ b/.vib/wordpress/goss/vars.yaml
@@ -38,6 +38,4 @@ phpmodules:
   - pcre
   - xml
   - zip
-# Specific from postunpack logic
-  - memcached
 root_dir: /opt/bitnami


### PR DESCRIPTION
### Description of the change

Remove `memcached` from GOSS test since it does not work on Photon.

### Benefits

Fix Photon tests

### Possible drawbacks

N/A

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

N/A