### PR TITLE
[bitnami/opensearch] Fix readiness/liveness probe not working if "restEncryption: false" in values.yaml

### DIFF
--- a/bitnami/opensearch/1/debian-11/rootfs/opt/bitnami/scripts/libopensearch.sh
+++ b/bitnami/opensearch/1/debian-11/rootfs/opt/bitnami/scripts/libopensearch.sh
@@ -940,7 +940,8 @@ elasticsearch_healthcheck() {
 
     host=$(get_elasticsearch_hostname)
 
-    is_boolean_yes "$DB_ENABLE_SECURITY" && is_boolean_yes "$DB_ENABLE_REST_TLS" && protocol="https" && command_args+=("-k" "--user" "${DB_USERNAME}:${DB_PASSWORD}")
+    is_boolean_yes "$DB_ENABLE_SECURITY" && command_args+=("-k" "--user" "${DB_USERNAME}:${DB_PASSWORD}")
+    is_boolean_yes "$DB_ENABLE_REST_TLS" && protocol="https"
 
     # Combination of --silent, --output and --write-out allows us to obtain both the status code and the request body
     output=$(mktemp)

--- a/bitnami/opensearch/2/debian-11/rootfs/opt/bitnami/scripts/libopensearch.sh
+++ b/bitnami/opensearch/2/debian-11/rootfs/opt/bitnami/scripts/libopensearch.sh
@@ -940,8 +940,9 @@ elasticsearch_healthcheck() {
 
     host=$(get_elasticsearch_hostname)
 
-    is_boolean_yes "$DB_ENABLE_SECURITY" && is_boolean_yes "$DB_ENABLE_REST_TLS" && protocol="https" && command_args+=("-k" "--user" "${DB_USERNAME}:${DB_PASSWORD}")
-
+    is_boolean_yes "$DB_ENABLE_SECURITY" && command_args+=("-k" "--user" "${DB_USERNAME}:${DB_PASSWORD}")
+    is_boolean_yes "$DB_ENABLE_REST_TLS" && protocol="https"
+    
     # Combination of --silent, --output and --write-out allows us to obtain both the status code and the request body
     output=$(mktemp)
     command_args+=("-o" "$output" "${protocol}://${host}:${DB_HTTP_PORT_NUMBER}/_cluster/health?local=true")


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
The readiness and liveness probes should work correctly regardless of the "restEncryption" setting. When "restEncryption" is set to "false," Opensearch should still be responsive to these probes, indicating its green health status.

### Benefits

<!-- What benefits will be realized by the code change? -->
This fix the failing health-check (that is preventing opensearch startup if security is on and tlsEncryption is off).
Without the fix, the health-check is failing because misses the basic-auth

### Possible drawbacks

Nothing

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #47078

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->