### PR TITLE
[bitnami/redis] Improve tests resiliency

### DIFF
--- a/.vib/redis/goss/redis.yaml
+++ b/.vib/redis/goss/redis.yaml
@@ -16,7 +16,7 @@ command:
     exit-status: 0
     timeout: 20000
     stdout:
-      - redis-server 127.0.0.1:6379
+      - /redis-server.*(127.0.0.1|localhost).*6379/
   check-redis-server-ssl:
     exec: ldd /opt/bitnami/redis/bin/redis-server
     exit-status: 0


### PR DESCRIPTION
### Description of the change

Some executions of the test are still failing intermittently. Use a more permissive regEx instead of a hardcoded string to allow a greater combination of outputs.

### Benefits

Tests are more reliable.

### Possible drawbacks

None

### Applicable issues

- NA.

### Additional information

None.
