### PR TITLE
[bitnami/os-shell] Fix os-shell for distros with numbers & strings

### DIFF
--- a/.vib/os-shell/goss/os-shell.yaml
+++ b/.vib/os-shell/goss/os-shell.yaml
@@ -3,5 +3,5 @@
 
 command:
   check-distro-version:
-    exec: grep VERSION_ID /etc/os-release | grep "$(echo $APP_VERSION | sed -E 's|^([0-9]+).*$|\1|g')
+    exec: grep VERSION_ID /etc/os-release | grep "$(echo $APP_VERSION | sed -E 's|^([0-9]+).*$|\1|g')"
     exit-status: 0

--- a/.vib/os-shell/goss/os-shell.yaml
+++ b/.vib/os-shell/goss/os-shell.yaml
@@ -3,7 +3,5 @@
 
 command:
   check-distro-version:
-    exec: grep VERSION_ID /etc/os-release
+    exec: grep VERSION_ID /etc/os-release | grep "$(echo $APP_VERSION | sed -E 's|^([0-9]+).*$|\1|g')
     exit-status: 0
-    stdout:
-      - {{ .Env.APP_VERSION }}

--- a/.vib/os-shell/goss/os-shell.yaml
+++ b/.vib/os-shell/goss/os-shell.yaml
@@ -3,5 +3,5 @@
 
 command:
   check-distro-version:
-    exec: grep VERSION_ID /etc/os-release | grep "$(echo $APP_VERSION | sed -E 's|^([0-9]+).*$|\1|g')"
+    exec: grep VERSION_ID /etc/os-release | grep "$(echo "$APP_VERSION" | sed -E 's|^([0-9]+).*$|\1|g')"
     exit-status: 0


### PR DESCRIPTION
### Description of the change

Improve verification test for distros that container numbers and strings E.g. 11-fips

```console
$ export APP_VERSION=11
$ ./goss v
.

Total Duration: 0.005s
Count: 1, Failed: 0, Skipped: 0

$ export APP_VERSION=11-fips
$ ./goss v
.

Total Duration: 0.004s
Count: 1, Failed: 0, Skipped: 0

$ export APP_VERSION=12
$ ./goss v
F

Failures/Skipped:

Command: check-distro-version: exit-status:
Expected
    <int>: 1
to equal
    <int>: 0

Total Duration: 0.004s
```