### PR TITLE
[bitnami/airflow] Add missing LDAP environment variables

### DIFF
--- a/bitnami/airflow/docker-compose-ldap.yml
+++ b/bitnami/airflow/docker-compose-ldap.yml
@@ -49,6 +49,8 @@ services:
       - AIRFLOW_LDAP_BIND_PASSWORD=adminpassword
       - AIRFLOW_LDAP_UID_FIELD=uid
       - AIRFLOW_LDAP_USE_TLS=False
+      - AIRFLOW_LDAP_ROLES_MAPPING="{ 'cn=All,ou=Groups,dc=example,dc=org':['User'], 'cn=Admins,ou=Groups,dc=example,dc=org':['Admin'], }"
+      - AIRFLOW_LDAP_USER_REGISTRATION_ROLE=Public
       - AIRFLOW_USER_REGISTRATION_ROLE=Public
       - AIRFLOW_DATABASE_NAME=bitnami_airflow
       - AIRFLOW_DATABASE_USERNAME=bn_airflow


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

Trying to reproduce https://github.com/bitnami/containers/issues/48234 I came across some LDAP environment variables that are being missed. 

```
$ docker-compose -f docker-compose-ldap.yml up -d
$ docker-compose -f docker-compose-ldap.yml logs -f airflow
airflow-airflow-1  | airflow 08:04:48.96 
airflow-airflow-1  | airflow 08:04:48.97 Welcome to the Bitnami airflow container
airflow-airflow-1  | airflow 08:04:48.97 Subscribe to project updates by watching https://github.com/bitnami/containers
airflow-airflow-1  | airflow 08:04:48.97 Submit issues and feature requests at https://github.com/bitnami/containers/issues
airflow-airflow-1  | airflow 08:04:48.97 
airflow-airflow-1  | airflow 08:04:48.98 INFO  ==> Enabling non-root system user with nss_wrapper
airflow-airflow-1  | airflow 08:04:49.00 INFO  ==> ** Starting Airflow setup **
airflow-airflow-1  | airflow 08:04:49.01 INFO  ==> Validating settings in POSTGRESQL_CLIENT_* env vars
airflow-airflow-1  | airflow 08:04:49.05 ERROR ==> Missing AIRFLOW_LDAP_ROLES_MAPPING
airflow-airflow-1  | airflow 08:04:49.05 ERROR ==> Missing AIRFLOW_LDAP_USER_REGISTRATION_ROLE
```
To prevent the occurrence of missing messages, we should include the following variables: `AIRFLOW_LDAP_ROLES_MAPPING` and `AIRFLOW_LDAP_USER_REGISTRATION_ROLE`.

### Benefits

<!-- What benefits will be realized by the code change? -->

Users have a docker-compose-ldap.yml preconfigured with all the necessary environment variables.

### Possible drawbacks

N/A
