### PR TITLE
[bitnami/kibana] Increase linked_libraries.timeout to 60s

### DIFF
--- a/.vib/kibana/goss/vars.yaml
+++ b/.vib/kibana/goss/vars.yaml
@@ -15,6 +15,8 @@ directories:
 files:
   - paths:
       - /opt/bitnami/kibana/config/node.options
+linked_libraries:
+  timeout: 60000
 root_dir: /opt/bitnami
 version:
   bin_name: kibana


### PR DESCRIPTION
### Description of the change

Increases Kibana linked_libraries test timeout from 20s to 60s.

In my local tests, the linked_libraries test takes about 35 seconds to complete when using the latest 7.x version of Kibana.