### PR TITLE
[bitnami/openldap:2.6] Add support for accesslog and syncprov overlays

### DIFF
--- a/bitnami/openldap/2.6/debian-11/rootfs/opt/bitnami/scripts/libopenldap.sh
+++ b/bitnami/openldap/2.6/debian-11/rootfs/opt/bitnami/scripts/libopenldap.sh
@@ -34,6 +34,7 @@ export LDAP_SHARE_DIR="${LDAP_BASE_DIR}/share"
 export LDAP_VAR_DIR="${LDAP_BASE_DIR}/var"
 export LDAP_VOLUME_DIR="/bitnami/openldap"
 export LDAP_DATA_DIR="${LDAP_VOLUME_DIR}/data"
+export LDAP_ACCESSLOG_DATA_DIR="${LDAP_DATA_DIR}/accesslog"
 export LDAP_ONLINE_CONF_DIR="${LDAP_VOLUME_DIR}/slapd.d"
 export LDAP_PID_FILE="${LDAP_VAR_DIR}/run/slapd.pid"
 export LDAP_CUSTOM_LDIF_DIR="${LDAP_CUSTOM_LDIF_DIR:-/ldifs}"
@@ -75,12 +76,26 @@ export LDAP_PASSWORD_HASH="${LDAP_PASSWORD_HASH:-{SSHA}}"
 export LDAP_CONFIGURE_PPOLICY="${LDAP_CONFIGURE_PPOLICY:-no}"
 export LDAP_PPOLICY_USE_LOCKOUT="${LDAP_PPOLICY_USE_LOCKOUT:-no}"
 export LDAP_PPOLICY_HASH_CLEARTEXT="${LDAP_PPOLICY_HASH_CLEARTEXT:-no}"
+export LDAP_ENABLE_ACCESSLOG="${LDAP_ENABLE_ACCESSLOG:-no}"
+export LDAP_ACCESSLOG_DB="${LDAP_ACCESSLOG_DB:-cn=accesslog}"
+export LDAP_ACCESSLOG_LOGOPS="${LDAP_ACCESSLOG_LOGOPS:-writes}"
+export LDAP_ACCESSLOG_LOGSUCCESS="${LDAP_ACCESSLOG_LOGSUCCESS:-TRUE}"
+export LDAP_ACCESSLOG_LOGPURGE="${LDAP_ACCESSLOG_LOGPURGE:-07+00:00 01+00:00}"
+export LDAP_ACCESSLOG_LOGOLD="${LDAP_ACCESSLOG_LOGOLD:-(objectClass=*)}"
+export LDAP_ACCESSLOG_LOGOLDATTR="${LDAP_ACCESSLOG_LOGOLDATTR:-objectClass}"
+export LDAP_ACCESSLOG_ADMIN_USERNAME="${LDAP_ACCESSLOG_ADMIN_USERNAME:-admin}"
+export LDAP_ACCESSLOG_ADMIN_DN="${LDAP_ACCESSLOG_ADMIN_USERNAME/#/cn=},${LDAP_ACCESSLOG_DB:-cn=accesslog}"
+export LDAP_ACCESSLOG_ADMIN_PASSWORD="${LDAP_ACCESSLOG_PASSWORD:-accesspassword}"
+export LDAP_ENABLE_SYNCPROV="${LDAP_ENABLE_SYNCPROV:-no}"
+export LDAP_SYNCPROV_CHECKPPOINT="${LDAP_SYNCPROV_CHECKPPOINT:-100 10}"
+export LDAP_SYNCPROV_SESSIONLOG="${LDAP_SYNCPROV_SESSIONLOG:-100}"
 
 # By setting an environment variable matching *_FILE to a file path, the prefixed environment
 # variable will be overridden with the value specified in that file
 ldap_env_vars=(
     LDAP_ADMIN_PASSWORD
     LDAP_CONFIG_ADMIN_PASSWORD
+    LDAP_ACCESSLOG_ADMIN_PASSWORD
 )
 for env_var in "${ldap_env_vars[@]}"; do
     file_env_var="${env_var}_FILE"
@@ -98,6 +113,7 @@ unset ldap_env_vars
 # Setting encrypted admin passwords
 export LDAP_ENCRYPTED_ADMIN_PASSWORD="$(echo -n $LDAP_ADMIN_PASSWORD | slappasswd -n -T /dev/stdin)"
 export LDAP_ENCRYPTED_CONFIG_ADMIN_PASSWORD="$(echo -n $LDAP_CONFIG_ADMIN_PASSWORD | slappasswd -n -T /dev/stdin)"
+export LDAP_ENCRYPTED_ACCESSLOG_ADMIN_PASSWORD="$(echo -n $LDAP_ACCESSLOG_ADMIN_PASSWORD | slappasswd -n -T /dev/stdin)"
 EOF
 }
 
@@ -623,6 +639,14 @@ ldap_initialize() {
         if is_boolean_yes "$LDAP_CONFIGURE_PPOLICY"; then
             ldap_configure_ppolicy
         fi
+        # enable accesslog overlay
+        if is_boolean_yes "$LDAP_ENABLE_ACCESSLOG"; then
+            ldap_enable_accesslog
+        fi
+        # enable syncprov overlay
+        if is_boolean_yes "$LDAP_ENABLE_SYNCPROV"; then
+            ldap_enable_syncprov
+        fi
         # enable tls
         if is_boolean_yes "$LDAP_ENABLE_TLS"; then
             ldap_configure_tls
@@ -809,4 +833,85 @@ add: olcPasswordHash
 olcPasswordHash: $LDAP_PASSWORD_HASH
 EOF
     debug_execute ldapmodify -Y EXTERNAL -H "ldapi:///" -f "${LDAP_SHARE_DIR}/password_hash.ldif"
+}
+
+########################
+# OpenLDAP configure Access Logging
+# Globals:
+#   LDAP_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+ldap_enable_accesslog() {
+    info "Configure Access Logging"
+    # Add indexes
+    cat > "${LDAP_SHARE_DIR}/accesslog_add_indexes.ldif" << EOF
+dn: olcDatabase={2}mdb,cn=config
+changetype: modify
+add: olcDbIndex
+olcDbIndex: entryCSN eq
+-
+add: olcDbIndex
+olcDbIndex: entryUUID eq
+EOF
+    debug_execute ldapmodify -Y EXTERNAL -H "ldapi:///" -f "${LDAP_SHARE_DIR}/accesslog_add_indexes.ldif"
+    # Load module
+    ldap_load_module "/opt/bitnami/openldap/lib/openldap" "accesslog.so"
+    # Create AccessLog database
+    cat > "${LDAP_SHARE_DIR}/accesslog_create_accesslog_database.ldif" << EOF
+dn: olcDatabase={3}mdb,cn=config
+objectClass: olcDatabaseConfig
+objectClass: olcMdbConfig
+olcDatabase: {3}mdb
+olcDbDirectory: $LDAP_ACCESSLOG_DATA_DIR
+olcSuffix: $LDAP_ACCESSLOG_DB
+olcRootDN: $LDAP_ACCESSLOG_ADMIN_DN
+olcRootPW: $LDAP_ENCRYPTED_ACCESSLOG_ADMIN_PASSWORD
+olcDbIndex: default eq
+olcDbIndex: entryCSN,objectClass,reqEnd,reqResult,reqStart
+EOF
+    mkdir /bitnami/openldap/data/accesslog
+    debug_execute ldapadd -Q -Y EXTERNAL -H "ldapi:///" -f "${LDAP_SHARE_DIR}/accesslog_create_accesslog_database.ldif"
+    # Add AccessLog overlay
+    cat > "${LDAP_SHARE_DIR}/accesslog_create_overlay_configuration.ldif" << EOF
+dn: olcOverlay=accesslog,olcDatabase={2}mdb,cn=config
+objectClass: olcOverlayConfig
+objectClass: olcAccessLogConfig
+olcOverlay: accesslog
+olcAccessLogDB: $LDAP_ACCESSLOG_DB
+olcAccessLogOps: $LDAP_ACCESSLOG_LOGOPS
+olcAccessLogSuccess: $LDAP_ACCESSLOG_LOGSUCCESS
+olcAccessLogPurge: $LDAP_ACCESSLOG_LOGPURGE
+olcAccessLogOld: $LDAP_ACCESSLOG_LOGOLD
+olcAccessLogOldAttr: $LDAP_ACCESSLOG_LOGOLDATTR
+EOF
+    info "adding accesslog_create_overlay_configuration.ldif"
+    debug_execute ldapadd -Q -Y EXTERNAL -H "ldapi:///" -f "${LDAP_SHARE_DIR}/accesslog_create_overlay_configuration.ldif"
+}
+
+########################
+# OpenLDAP configure Sync Provider
+# Globals:
+#   LDAP_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+ldap_enable_syncprov() {
+    info "Configure Sync Provider"
+    # Load module
+    ldap_load_module "/opt/bitnami/openldap/lib/openldap" "syncprov.so"
+    # Add Sync Provider overlay
+    cat > "${LDAP_SHARE_DIR}/syncprov_create_overlay_configuration.ldif" << EOF
+dn: olcOverlay=syncprov,olcDatabase={2}mdb,cn=config
+objectClass: olcOverlayConfig
+objectClass: olcSyncProvConfig
+olcOverlay: syncprov
+olcSpCheckpoint: $LDAP_SYNCPROV_CHECKPPOINT
+olcSpSessionLog: $LDAP_SYNCPROV_SESSIONLOG
+EOF
+    debug_execute ldapadd -Q -Y EXTERNAL -H "ldapi:///" -f "${LDAP_SHARE_DIR}/syncprov_create_overlay_configuration.ldif"
 }

--- a/bitnami/openldap/README.md
+++ b/bitnami/openldap/README.md
@@ -204,6 +204,34 @@ You can bootstrap the contents of your database by putting LDIF files in the dir
 
 Check the official [OpenLDAP Configuration Reference](https://www.openldap.org/doc/admin26/guide.html) for more information about how to configure OpenLDAP.
 
+### Overlays
+
+Overlays are dynamic modules that can be added to an OpenLDAP server to extend or modify its functionality.
+
+#### Access Logging
+
+This overlay can record accesses to a given backend database on another database.
+
+* `LDAP_ENABLE_ACCESSLOG`: Enables the accesslog module with the following configuration defaults unless specified otherwise. Default: **no**.
+* `LDAP_ACCESSLOG_ADMIN_USERNAME`: Admin user for accesslog database. Default: **admin**.
+* `LDAP_ACCESSLOG_ADMIN_PASSWORD`: Admin password for accesslog database. Default: **accesspassword**.
+* `LDAP_ACCESSLOG_DB`: The DN (Distinguished Name) of the database where the access log entries will be stored. Will only be applied with `LDAP_ENABLE_ACCESSLOG` active. Default: **cn=accesslog**.
+* `LDAP_ACCESSLOG_LOGOPS`: Specify which types of operations to log. Valid aliases for common sets of operations are: writes, reads, session or all. Will only be applied with `LDAP_ENABLE_ACCESSLOG` active. Default: **writes**.
+* `LDAP_ACCESSLOG_LOGSUCCESS`: Whether successful operations should be logged. Will only be applied with `LDAP_ENABLE_ACCESSLOG` active. Default: **TRUE**.
+* `LDAP_ACCESSLOG_LOGPURGE`: When and how often old access log entries should be purged. Format `"dd+hh:mm"`. Will only be applied with `LDAP_ENABLE_ACCESSLOG` active. Default: **07+00:00 01+00:00**.
+* `LDAP_ACCESSLOG_LOGOLD`: An LDAP filter that determines which entries should be logged. Will only be applied with `LDAP_ENABLE_ACCESSLOG` active. Default: **(objectClass=*)**.
+* `LDAP_ACCESSLOG_LOGOLDATTR`: Specifies an attribute that should be logged. Will only be applied with `LDAP_ENABLE_ACCESSLOG` active. Default: **objectClass**.
+
+Check the official page [OpenLDAP, Overlays, Access Logging](https://www.openldap.org/doc/admin26/overlays.html#Access%20Logging) for detailed configuration information.
+
+#### Sync Provider
+
+* `LDAP_ENABLE_SYNCPROV`: Enables the syncrepl module with the following configuration defaults unless specified otherwise. Default: **no**.
+* `LDAP_SYNCPROV_CHECKPPOINT`: For every 100 operations or 10 minutes, which ever is sooner, the contextCSN will be checkpointed. Will only be applied with `LDAP_ENABLE_SYNCPROV` active. Default: **100 10**.
+* `LDAP_SYNCPROV_SESSIONLOG`: The maximum number of session log entries the session log can record. Will only be applied with `LDAP_ENABLE_SYNCPROV` active. Default: **100**.
+
+Check the official page [OpenLDAP, Overlays, Sync Provider](https://www.openldap.org/doc/admin26/overlays.html#Sync%20Provider) for detailed configuration information.
+
 ### Securing OpenLDAP traffic
 
 OpenLDAP clients and servers are capable of using the Transport Layer Security (TLS) framework to provide integrity and confidentiality protections and to support LDAP authentication using the SASL EXTERNAL mechanism. Should you desire to enable this optional feature, you may use the following environment variables to configure the application:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This change extends the existing [bitnami/openldap:2.6] container deployment with configurable support for 2 already packaged modules:

- Access Logging `accesslog`
- Sync Provider `syncprov`

### Benefits

Future users of the [bitnami/openldap] container will be able to access the `accesslog` & `syncprov` modules and functionality with minimal configuration.

### Possible drawbacks

The `accesslog` & `syncprov`modules are commonly implemented as part of a directory replication topology in a multi-node deployment. 
This PR only provides capabilities for a single node deployment and does not expose possible configurations requirements for a replicated or multi-node deployment.
It would then however provide the building blocks for future enhancements to support multi node deployments.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
