### PR TITLE
[bitnami/airflow] Fix airflow connectivity issue when redis is in ssl mode

### DIFF
--- a/bitnami/airflow-scheduler/2/debian-11/rootfs/opt/bitnami/scripts/libairflow.sh
+++ b/bitnami/airflow-scheduler/2/debian-11/rootfs/opt/bitnami/scripts/libairflow.sh
@@ -402,6 +402,7 @@ airflow_configure_celery_executor() {
     local -r redis_user=$(airflow_encode_url "$REDIS_USER")
     local -r redis_password=$(airflow_encode_url "$REDIS_PASSWORD")
     airflow_conf_set "celery" "broker_url" "redis://${redis_user}:${redis_password}@${REDIS_HOST}:${REDIS_PORT_NUMBER}/${REDIS_DATABASE}"
+    is_boolean_yes "$AIRFLOW_REDIS_USE_SSL" && airflow_conf_set "celery" "broker_url" "rediss://${redis_user}:${redis_password}@${REDIS_HOST}:${REDIS_PORT_NUMBER}/${REDIS_DATABASE}"
     is_boolean_yes "$AIRFLOW_REDIS_USE_SSL" && airflow_conf_set "celery" "redis_backend_use_ssl" "true"
 
     # Configure celery backend

--- a/bitnami/airflow-worker/2/debian-11/rootfs/opt/bitnami/scripts/libairflow.sh
+++ b/bitnami/airflow-worker/2/debian-11/rootfs/opt/bitnami/scripts/libairflow.sh
@@ -402,6 +402,7 @@ airflow_configure_celery_executor() {
     local -r redis_user=$(airflow_encode_url "$REDIS_USER")
     local -r redis_password=$(airflow_encode_url "$REDIS_PASSWORD")
     airflow_conf_set "celery" "broker_url" "redis://${redis_user}:${redis_password}@${REDIS_HOST}:${REDIS_PORT_NUMBER}/${REDIS_DATABASE}"
+    is_boolean_yes "$AIRFLOW_REDIS_USE_SSL" && airflow_conf_set "celery" "broker_url" "rediss://${redis_user}:${redis_password}@${REDIS_HOST}:${REDIS_PORT_NUMBER}/${REDIS_DATABASE}"
     is_boolean_yes "$AIRFLOW_REDIS_USE_SSL" && airflow_conf_set "celery" "redis_backend_use_ssl" "true"
 
     # Configure celery backend

--- a/bitnami/airflow/2/debian-11/rootfs/opt/bitnami/scripts/libairflow.sh
+++ b/bitnami/airflow/2/debian-11/rootfs/opt/bitnami/scripts/libairflow.sh
@@ -402,6 +402,7 @@ airflow_configure_celery_executor() {
     local -r redis_user=$(airflow_encode_url "$REDIS_USER")
     local -r redis_password=$(airflow_encode_url "$REDIS_PASSWORD")
     airflow_conf_set "celery" "broker_url" "redis://${redis_user}:${redis_password}@${REDIS_HOST}:${REDIS_PORT_NUMBER}/${REDIS_DATABASE}"
+    is_boolean_yes "$AIRFLOW_REDIS_USE_SSL" && airflow_conf_set "celery" "broker_url" "rediss://${redis_user}:${redis_password}@${REDIS_HOST}:${REDIS_PORT_NUMBER}/${REDIS_DATABASE}"
     is_boolean_yes "$AIRFLOW_REDIS_USE_SSL" && airflow_conf_set "celery" "redis_backend_use_ssl" "true"
 
     # Configure celery backend


### PR DESCRIPTION


### Description of the change
It will set redis prefix as `rediss://` when `AIRFLOW_REDIS_USE_SSL` is enabled 

### Benefits


### Possible drawbacks


### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #49325 

### Additional information


