### PR TITLE
[bitnami/mastodon] Add sed-in-place excluded path

### DIFF
--- a/.vib/mastodon/goss/vars.yaml
+++ b/.vib/mastodon/goss/vars.yaml
@@ -16,3 +16,7 @@ directories:
       - /opt/bitnami/mastodon/public/system
       - /opt/bitnami/mastodon/public/assets
 root_dir: /opt/bitnami
+sed_in_place:
+  exclude_paths:
+    # Ignore PyLib directory (not bitnami-related)
+    - \/opt\/bitnami\/mastodon\/node_modules\/.*

--- a/.vib/mastodon/goss/vars.yaml
+++ b/.vib/mastodon/goss/vars.yaml
@@ -18,5 +18,5 @@ directories:
 root_dir: /opt/bitnami
 sed_in_place:
   exclude_paths:
-    # Ignore PyLib directory (not bitnami-related)
+    # Ignore Mastodon node_modules directory (not bitnami-related)
     - \/opt\/bitnami\/mastodon\/node_modules\/.*


### PR DESCRIPTION
### Description of the change

Latest release is failing because 'sed-in-place' test is detecting the following path:
```
/opt/bitnami/mastodon/node_modules/babel-preset-current-node-syntax/scripts/check-yarn-bug.sh
```

Adding it to the list of excluded paths
