### PR TITLE
[bitnami/nginx] Add ngx_http_dav_module to NGINX modules (testing)

### DIFF
--- a/.vib/nginx/goss/vars.yaml
+++ b/.vib/nginx/goss/vars.yaml
@@ -40,6 +40,7 @@ modules:
     - mail_ssl
     - http_gunzip
     - http_auth_request
+    - http_dav
     - http_sub
     - http_geoip
     - stream_realip


### PR DESCRIPTION
### Description of the change

We are now building NGINX with [ngx_http_dav_module](http://nginx.org/en/docs/http/ngx_http_dav_module.html). This PR updates the Goss tests.

### Applicable issues

- related to #48384