### PR TITLE
Added optional binding of listening address.

### DIFF
--- a/bitnami/openldap/2.5/debian-11/rootfs/opt/bitnami/scripts/libopenldap.sh
+++ b/bitnami/openldap/2.5/debian-11/rootfs/opt/bitnami/scripts/libopenldap.sh
@@ -49,6 +49,7 @@ export LDAP_TLS_DH_PARAMS_FILE="${LDAP_TLS_DH_PARAMS_FILE:-}"
 export LDAP_DAEMON_USER="slapd"
 export LDAP_DAEMON_GROUP="slapd"
 # Settings
+export LDAP_BIND_ADDR="{LDAP_BIND_ADDR:}"
 export LDAP_PORT_NUMBER="${LDAP_PORT_NUMBER:-1389}"
 export LDAP_LDAPS_PORT_NUMBER="${LDAP_LDAPS_PORT_NUMBER:-1636}"
 export LDAP_ROOT="${LDAP_ROOT:-dc=example,dc=org}"
@@ -198,7 +199,7 @@ is_ldap_not_running() {
 ldap_start_bg() {
     local -r retries="${1:-12}"
     local -r sleep_time="${2:-1}"
-    local -a flags=("-h" "ldap://:${LDAP_PORT_NUMBER}/ ldapi:/// " "-F" "${LDAP_CONF_DIR}/slapd.d" "-d" "$LDAP_LOGLEVEL")
+    local -a flags=("-h" "ldap://${LDAP_BIND_ADDR}:${LDAP_PORT_NUMBER}/ ldapi:/// " "-F" "${LDAP_CONF_DIR}/slapd.d" "-d" "$LDAP_LOGLEVEL")
 
     if is_ldap_not_running; then
         info "Starting OpenLDAP server in background"

--- a/bitnami/openldap/2.5/debian-11/rootfs/opt/bitnami/scripts/openldap/run.sh
+++ b/bitnami/openldap/2.5/debian-11/rootfs/opt/bitnami/scripts/openldap/run.sh
@@ -21,10 +21,10 @@ command="$(command -v slapd)"
 # https://github.com/docker/docker/issues/8231
 ulimit -n "$LDAP_ULIMIT_NOFILES"
 
-flags=("-h" "ldap://:${LDAP_PORT_NUMBER}/ ldapi:///")
+flags=("-h" "ldap://${LDAP_BIND_ADDR}:${LDAP_PORT_NUMBER}/ ldapi:///")
 
 # Add LDAPS URI when TLS is enabled
-is_boolean_yes "$LDAP_ENABLE_TLS" && flags=("-h" "ldap://:${LDAP_PORT_NUMBER}/ ldaps://:${LDAP_LDAPS_PORT_NUMBER}/ ldapi:///")
+is_boolean_yes "$LDAP_ENABLE_TLS" && flags=("-h" "ldap://${LDAP_BIND_ADDR}:${LDAP_PORT_NUMBER}/ ldaps://${LDAP_BIND_ADDR}:${LDAP_LDAPS_PORT_NUMBER}/ ldapi:///")
 
 # Add "@" so users can add extra command line flags
 flags+=("-F" "${LDAP_CONF_DIR}/slapd.d" "-d" "$LDAP_LOGLEVEL" "$@")

--- a/bitnami/openldap/2.6/debian-11/rootfs/opt/bitnami/scripts/libopenldap.sh
+++ b/bitnami/openldap/2.6/debian-11/rootfs/opt/bitnami/scripts/libopenldap.sh
@@ -49,6 +49,7 @@ export LDAP_TLS_DH_PARAMS_FILE="${LDAP_TLS_DH_PARAMS_FILE:-}"
 export LDAP_DAEMON_USER="slapd"
 export LDAP_DAEMON_GROUP="slapd"
 # Settings
+export LDAP_BIND_ADDR="{LDAP_BIND_ADDR:}"
 export LDAP_PORT_NUMBER="${LDAP_PORT_NUMBER:-1389}"
 export LDAP_LDAPS_PORT_NUMBER="${LDAP_LDAPS_PORT_NUMBER:-1636}"
 export LDAP_ROOT="${LDAP_ROOT:-dc=example,dc=org}"
@@ -198,7 +199,7 @@ is_ldap_not_running() {
 ldap_start_bg() {
     local -r retries="${1:-12}"
     local -r sleep_time="${2:-1}"
-    local -a flags=("-h" "ldap://:${LDAP_PORT_NUMBER}/ ldapi:/// " "-F" "${LDAP_CONF_DIR}/slapd.d" "-d" "$LDAP_LOGLEVEL")
+    local -a flags=("-h" "ldap://${LDAP_BIND_ADDR}:${LDAP_PORT_NUMBER}/ ldapi:/// " "-F" "${LDAP_CONF_DIR}/slapd.d" "-d" "$LDAP_LOGLEVEL")
 
     if is_ldap_not_running; then
         info "Starting OpenLDAP server in background"

--- a/bitnami/openldap/2.6/debian-11/rootfs/opt/bitnami/scripts/openldap/run.sh
+++ b/bitnami/openldap/2.6/debian-11/rootfs/opt/bitnami/scripts/openldap/run.sh
@@ -21,10 +21,10 @@ command="$(command -v slapd)"
 # https://github.com/docker/docker/issues/8231
 ulimit -n "$LDAP_ULIMIT_NOFILES"
 
-flags=("-h" "ldap://:${LDAP_PORT_NUMBER}/ ldapi:///")
+flags=("-h" "ldap://${LDAP_BIND_ADDR}:${LDAP_PORT_NUMBER}/ ldapi:///")
 
 # Add LDAPS URI when TLS is enabled
-is_boolean_yes "$LDAP_ENABLE_TLS" && flags=("-h" "ldap://:${LDAP_PORT_NUMBER}/ ldaps://:${LDAP_LDAPS_PORT_NUMBER}/ ldapi:///")
+is_boolean_yes "$LDAP_ENABLE_TLS" && flags=("-h" "ldap://${LDAP_BIND_ADDR}:${LDAP_PORT_NUMBER}/ ldaps://${LDAP_BIND_ADDR}:${LDAP_LDAPS_PORT_NUMBER}/ ldapi:///")
 
 # Add "@" so users can add extra command line flags
 flags+=("-F" "${LDAP_CONF_DIR}/slapd.d" "-d" "$LDAP_LOGLEVEL" "$@")


### PR DESCRIPTION
### Description of the change

This enables the ability to disable/enable IPv6 or IPv4 independently of each other, since default is to listen on both.

### Benefits

This allows us to follow some recommendations from https://www.openldap.org/doc/admin25/security.html as well as use the container on IPv6 disabled host machines.