### PR TITLE
[bitnami/rclone] Add fuse as dep

### DIFF
--- a/bitnami/rclone/1/debian-11/Dockerfile
+++ b/bitnami/rclone/1/debian-11/Dockerfile
@@ -23,7 +23,7 @@ ENV HOME="/" \
 COPY prebuildfs /
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Install required system packages and dependencies
-RUN install_packages ca-certificates curl procps
+RUN install_packages ca-certificates curl procps fuse3
 RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ && \
     COMPONENTS=( \
       "rclone-1.64.0-0-linux-${OS_ARCH}-debian-11" \


### PR DESCRIPTION
rclone supports mounting using fuse, but depends on the fusermount3 command, which is provided by the package fuse3.

More info here:
https://rclone.org/commands/rclone_mount/
