### PR TITLE
[bitnami/spring-cloud-dataflow] Modify version test for spring-cloud-dataflow

### DIFF
--- a/.vib/spring-cloud-dataflow/goss/spring-cloud-dataflow.yaml
+++ b/.vib/spring-cloud-dataflow/goss/spring-cloud-dataflow.yaml
@@ -8,8 +8,12 @@ command:
     exec: timeout --preserve-status 30 java -jar /opt/bitnami/spring-cloud-dataflow/spring-cloud-dataflow.jar
     exit-status: 143
     stdout:
-      - {{ .Env.APP_VERSION }}
       - Started DataFlowServerApplication
+  check-spring-cloud-dataflow-version:
+    exec: output=$(mktemp -d); cd $output; jar xf /opt/bitnami/spring-cloud-dataflow/spring-cloud-dataflow.jar; cat ./BOOT-INF/classes/application.yml
+    exit-status: 0
+    stdout:
+      - {{ .Env.APP_VERSION }}
 file:
   /opt/bitnami/spring-cloud-dataflow/spring-cloud-dataflow.jar:
     exists: true

--- a/bitnami/spring-cloud-dataflow/2/debian-11/docker-compose.yml
+++ b/bitnami/spring-cloud-dataflow/2/debian-11/docker-compose.yml
@@ -3,8 +3,6 @@
 
 version: '2'
 
-#Trigger
-
 services:
   spring-cloud-dataflow:
     image: docker.io/bitnami/spring-cloud-dataflow:2

--- a/bitnami/spring-cloud-dataflow/2/debian-11/docker-compose.yml
+++ b/bitnami/spring-cloud-dataflow/2/debian-11/docker-compose.yml
@@ -3,6 +3,8 @@
 
 version: '2'
 
+#Trigger
+
 services:
   spring-cloud-dataflow:
     image: docker.io/bitnami/spring-cloud-dataflow:2


### PR DESCRIPTION

### Description of the change

Modifies version test for spring-cloud-dataflow, which fails in the latest version 2.11.0

The test consists of:

- Uncompressing the jar file in a temporary directory
- Checks the content of `./BOOT-INF/classes/application.yml` which should look like this:

```yaml
info:
  app:
    name: "spring-cloud-dataflow-server"
    description: "Spring Cloud Data Flow Server"
    version: "2.11.0"
spring:
  jpa:
    hibernate:
      ddl-auto: none
```