### PR TITLE
[bitnami/odoo] Add database filter

### DIFF
--- a/bitnami/odoo/14/debian-11/rootfs/opt/bitnami/scripts/odoo-env.sh
+++ b/bitnami/odoo/14/debian-11/rootfs/opt/bitnami/scripts/odoo-env.sh
@@ -42,6 +42,7 @@ odoo_env_vars=(
     ODOO_DATABASE_NAME
     ODOO_DATABASE_USER
     ODOO_DATABASE_PASSWORD
+    ODOO_DATABASE_FILTER
     SMTP_HOST
     SMTP_PORT
     ODOO_SMTP_PORT
@@ -94,6 +95,7 @@ export ODOO_LONGPOLLING_PORT_NUMBER="${ODOO_LONGPOLLING_PORT_NUMBER:-8072}" # on
 export ODOO_SKIP_BOOTSTRAP="${ODOO_SKIP_BOOTSTRAP:-no}" # only used during the first initialization
 export ODOO_SKIP_MODULES_UPDATE="${ODOO_SKIP_MODULES_UPDATE:-no}" # only used during the first initialization
 export ODOO_LOAD_DEMO_DATA="${ODOO_LOAD_DEMO_DATA:-no}" # only used during the first initialization
+export ODOO_DATABASE_FILTER="${ODOO_DATABASE_FILTER:-.*}"
 
 # Odoo credentials
 export ODOO_EMAIL="${ODOO_EMAIL:-user@example.com}" # only used during the first initialization

--- a/bitnami/odoo/14/debian-11/rootfs/opt/bitnami/scripts/odoo/bitnami-templates/odoo.conf.tpl
+++ b/bitnami/odoo/14/debian-11/rootfs/opt/bitnami/scripts/odoo/bitnami-templates/odoo.conf.tpl
@@ -12,7 +12,7 @@ db_port = {{ODOO_DATABASE_PORT_NUMBER}}
 ; https://www.postgresql.org/docs/current/manage-ag-templatedbs.html
 db_template = template1
 db_user = {{ODOO_DATABASE_USER}}
-dbfilter = .*
+dbfilter = {{ODOO_DATABASE_FILTER}}
 debug_mode = False
 email_from = {{ODOO_EMAIL}}
 http_port = {{ODOO_PORT_NUMBER}}

--- a/bitnami/odoo/15/debian-11/rootfs/opt/bitnami/scripts/odoo-env.sh
+++ b/bitnami/odoo/15/debian-11/rootfs/opt/bitnami/scripts/odoo-env.sh
@@ -42,6 +42,7 @@ odoo_env_vars=(
     ODOO_DATABASE_NAME
     ODOO_DATABASE_USER
     ODOO_DATABASE_PASSWORD
+    ODOO_DATABASE_FILTER
     SMTP_HOST
     SMTP_PORT
     ODOO_SMTP_PORT
@@ -94,6 +95,7 @@ export ODOO_LONGPOLLING_PORT_NUMBER="${ODOO_LONGPOLLING_PORT_NUMBER:-8072}" # on
 export ODOO_SKIP_BOOTSTRAP="${ODOO_SKIP_BOOTSTRAP:-no}" # only used during the first initialization
 export ODOO_SKIP_MODULES_UPDATE="${ODOO_SKIP_MODULES_UPDATE:-no}" # only used during the first initialization
 export ODOO_LOAD_DEMO_DATA="${ODOO_LOAD_DEMO_DATA:-no}" # only used during the first initialization
+export ODOO_DATABASE_FILTER="${ODOO_DATABASE_FILTER:-.*}"
 
 # Odoo credentials
 export ODOO_EMAIL="${ODOO_EMAIL:-user@example.com}" # only used during the first initialization

--- a/bitnami/odoo/15/debian-11/rootfs/opt/bitnami/scripts/odoo/bitnami-templates/odoo.conf.tpl
+++ b/bitnami/odoo/15/debian-11/rootfs/opt/bitnami/scripts/odoo/bitnami-templates/odoo.conf.tpl
@@ -12,7 +12,7 @@ db_port = {{ODOO_DATABASE_PORT_NUMBER}}
 ; https://www.postgresql.org/docs/current/manage-ag-templatedbs.html
 db_template = template1
 db_user = {{ODOO_DATABASE_USER}}
-dbfilter = .*
+dbfilter = {{ODOO_DATABASE_FILTER}}
 debug_mode = False
 email_from = {{ODOO_EMAIL}}
 http_port = {{ODOO_PORT_NUMBER}}

--- a/bitnami/odoo/16/debian-11/rootfs/opt/bitnami/scripts/odoo-env.sh
+++ b/bitnami/odoo/16/debian-11/rootfs/opt/bitnami/scripts/odoo-env.sh
@@ -42,6 +42,7 @@ odoo_env_vars=(
     ODOO_DATABASE_NAME
     ODOO_DATABASE_USER
     ODOO_DATABASE_PASSWORD
+    ODOO_DATABASE_FILTER
     SMTP_HOST
     SMTP_PORT
     ODOO_SMTP_PORT
@@ -94,6 +95,7 @@ export ODOO_LONGPOLLING_PORT_NUMBER="${ODOO_LONGPOLLING_PORT_NUMBER:-8072}" # on
 export ODOO_SKIP_BOOTSTRAP="${ODOO_SKIP_BOOTSTRAP:-no}" # only used during the first initialization
 export ODOO_SKIP_MODULES_UPDATE="${ODOO_SKIP_MODULES_UPDATE:-no}" # only used during the first initialization
 export ODOO_LOAD_DEMO_DATA="${ODOO_LOAD_DEMO_DATA:-no}" # only used during the first initialization
+export ODOO_DATABASE_FILTER="${ODOO_DATABASE_FILTER:.*}"
 
 # Odoo credentials
 export ODOO_EMAIL="${ODOO_EMAIL:-user@example.com}" # only used during the first initialization

--- a/bitnami/odoo/16/debian-11/rootfs/opt/bitnami/scripts/odoo-env.sh
+++ b/bitnami/odoo/16/debian-11/rootfs/opt/bitnami/scripts/odoo-env.sh
@@ -95,7 +95,7 @@ export ODOO_LONGPOLLING_PORT_NUMBER="${ODOO_LONGPOLLING_PORT_NUMBER:-8072}" # on
 export ODOO_SKIP_BOOTSTRAP="${ODOO_SKIP_BOOTSTRAP:-no}" # only used during the first initialization
 export ODOO_SKIP_MODULES_UPDATE="${ODOO_SKIP_MODULES_UPDATE:-no}" # only used during the first initialization
 export ODOO_LOAD_DEMO_DATA="${ODOO_LOAD_DEMO_DATA:-no}" # only used during the first initialization
-export ODOO_DATABASE_FILTER="${ODOO_DATABASE_FILTER:.*}"
+export ODOO_DATABASE_FILTER="${ODOO_DATABASE_FILTER:-.*}"
 
 # Odoo credentials
 export ODOO_EMAIL="${ODOO_EMAIL:-user@example.com}" # only used during the first initialization

--- a/bitnami/odoo/16/debian-11/rootfs/opt/bitnami/scripts/odoo/bitnami-templates/odoo.conf.tpl
+++ b/bitnami/odoo/16/debian-11/rootfs/opt/bitnami/scripts/odoo/bitnami-templates/odoo.conf.tpl
@@ -12,7 +12,7 @@ db_port = {{ODOO_DATABASE_PORT_NUMBER}}
 ; https://www.postgresql.org/docs/current/manage-ag-templatedbs.html
 db_template = template1
 db_user = {{ODOO_DATABASE_USER}}
-dbfilter = .*
+dbfilter = {{ODOO_DATABASE_FILTER}}
 debug_mode = False
 email_from = {{ODOO_EMAIL}}
 http_port = {{ODOO_PORT_NUMBER}}

--- a/bitnami/odoo/README.md
+++ b/bitnami/odoo/README.md
@@ -223,6 +223,7 @@ Available environment variables:
 - `ODOO_DATABASE_PORT_NUMBER`: Port used by the PostgreSQL server. Default: **5432**
 - `ODOO_DATABASE_ADMIN_USER`: Database admin user that Odoo will use to connect with the database. Default: **postgres**
 - `ODOO_DATABASE_ADMIN_PASSWORD`: Database admin password that Odoo will use to connect with the database. No default.
+- `ODOO_DATABASE_FILTER`: Apply a regex to filter a specific pattern or match for a database name: Default: .*
 - `ALLOW_EMPTY_PASSWORD`: It can be used to allow blank passwords. Default: **no**
 
 #### Create a database for Odoo using postgresql-client


### PR DESCRIPTION
### Description of the change

The current [odoo.conf.tpl](https://github.com/bitnami/containers/blob/97a8d24dca0a93d1c5f23cb4fe332fbeb3615c76/bitnami/odoo/16/debian-11/rootfs/opt/bitnami/scripts/odoo/bitnami-templates/odoo.conf.tpl#L15C14-L15C14) template has by a default a wide range of values for database name.

```
dbfilter = .*
```

By adding the env var `ODOO_DATABASE_FILTER` it is possible to filter a specific regex for the database name.

### Benefits

It will allow to set a specific database name by using a regex

### Additional information

I made some changes on the bitnami helm chart for odoo, I added the [env var](https://github.com/kavichu/bitnami-charts/blob/ffd1aeab9127914c2d61173fcb861a65905c0096/bitnami/odoo/templates/deployment.yaml#L124C14-L124C14)
I was able to deploy this change and it works as expected.
How to use with helm chart:

```
helm upgrade --install -f values.yml \
     --set odooEmail="odoo@example.com" \
     --set odooPassword="password" \
     --set odooSkipInstall="true" \
     --set odooDatabaseFilter="^business_database\$" \
     --namespace default \
     odoo-aratiri ./bitnami-charts/bitnami/odoo
```