### PR TITLE
[bitnami/mastodon] Fix logic to detect admin user exists

### DIFF
--- a/bitnami/mastodon/4/debian-11/rootfs/opt/bitnami/scripts/libmastodon.sh
+++ b/bitnami/mastodon/4/debian-11/rootfs/opt/bitnami/scripts/libmastodon.sh
@@ -259,7 +259,7 @@ user.reset_password!
 user.reset_password('${MASTODON_ADMIN_PASSWORD}', '${MASTODON_ADMIN_PASSWORD}')
 EOF
 
-    elif [[ "$res" =~ "been taken" ]]; then
+    elif [[ "$res" =~ "taken" ]]; then
         info "Admin user already exists. Skipping"
     else
         error "Error creating admin user"


### PR DESCRIPTION
### Description of the change

This PR fixes the logic on Mastodon to detect whether admin user already exists or not. In the piece of code below we can see the returned message:

```console
$ tootctl accounts create user --email user@bitnami.org --confirmed --role Owner
Failure/Error: email
    taken
Failure/Error: account.username
    taken
```

### Benefits

Upgrade path works.

### Possible drawbacks

None

### Applicable issues

- fixes https://github.com/bitnami/containers/issues/49902

### Additional information

N/A