### PR TITLE
[bitnami/mastodon] Fix initJob.createAdmin is true and the init container never finish

### DIFF
--- a/bitnami/mastodon/4/debian-11/rootfs/opt/bitnami/scripts/libmastodon.sh
+++ b/bitnami/mastodon/4/debian-11/rootfs/opt/bitnami/scripts/libmastodon.sh
@@ -259,7 +259,7 @@ user.reset_password!
 user.reset_password('${MASTODON_ADMIN_PASSWORD}', '${MASTODON_ADMIN_PASSWORD}')
 EOF
 
-    elif [[ "$res" =~ "been taken" ]]; then
+    elif [[ "$res" =~ "taken" ]]; then
         info "Admin user already exists. Skipping"
     else
         error "Error creating admin user"


### PR DESCRIPTION
See https://github.com/bitnami/charts/issues/14485.

If the admin user/email  is already exist, the current code exists with error instead of skipping account creation,  because the testing expects "been taken" string from tootctl command, however tootctl in  the 4.2.0 release that I tested, return different string:

```
res=$(tootctl accounts create "$MASTODON_ADMIN_USERNAME" --email "$MASTODON_ADMIN_EMAIL" "--confirmed" "--role" "Owner")
$ echo $res
Failure/Error: email taken Failure/Error: account.username taken
```

Simply change the testing string to "taken" fix this issue.

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
