### PR TITLE
[bitnami/moodle] Handle --prefix (table prefix) being overridden via MOODLE_INSTALL_EXTRA_ARGS

### DIFF
--- a/bitnami/moodle/4.2/debian-11/rootfs/opt/bitnami/scripts/libmoodle.sh
+++ b/bitnami/moodle/4.2/debian-11/rootfs/opt/bitnami/scripts/libmoodle.sh
@@ -164,20 +164,6 @@ moodle_initialize() {
                 break
             fi
         done
-        for extra_arg in "${extra_args[@]}"; do
-            if [[ $extra_arg == --prefix=* ]]; then
-                parts=$( echo $extra_arg | tr "=" "\n" )
-                declare -i i=1
-                for part in $parts ; do
-                    if [[ $i -eq 2 ]] ; then
-                        mdl_prefix=$part
-                    else
-                        mdl_prefix=""
-                    fi
-                    i+=1
-                done
-            fi
-        done
         
         # Setup Moodle
         if ! is_boolean_yes "$MOODLE_SKIP_BOOTSTRAP"; then

--- a/bitnami/moodle/4.2/debian-11/rootfs/opt/bitnami/scripts/libmoodle.sh
+++ b/bitnami/moodle/4.2/debian-11/rootfs/opt/bitnami/scripts/libmoodle.sh
@@ -160,6 +160,12 @@ moodle_initialize() {
         mdl_prefix="mdl_"
         for extra_arg in "${extra_args[@]}"; do
             if [[ $extra_arg == --prefix=* ]]; then
+                mdl_prefix=${extra_arg#--prefix=}
+                break
+            fi
+        done
+        for extra_arg in "${extra_args[@]}"; do
+            if [[ $extra_arg == --prefix=* ]]; then
                 parts=$( echo $extra_arg | tr "=" "\n" )
                 declare -i i=1
                 for part in $parts ; do

--- a/bitnami/moodle/4.2/debian-11/rootfs/opt/bitnami/scripts/libmoodle.sh
+++ b/bitnami/moodle/4.2/debian-11/rootfs/opt/bitnami/scripts/libmoodle.sh
@@ -183,17 +183,17 @@ moodle_initialize() {
             [[ "$db_type" = "pgsql" ]] && db_remote_execute="postgresql_remote_execute"
             local -a db_execute_args=("$db_host" "$db_port" "$db_name" "$db_user" "$db_pass")
             # Configure no-reply e-mail address for SMTP
-            echo "INSERT INTO mdl_config (name, value) VALUES ('noreplyaddress', '${MOODLE_EMAIL}')" | "$db_remote_execute" "${db_execute_args[@]}"
+            echo "INSERT INTO ${mdl_prefix}config (name, value) VALUES ('noreplyaddress', '${MOODLE_EMAIL}')" | "$db_remote_execute" "${db_execute_args[@]}"
             # Additional Bitnami customizations
-            echo "UPDATE mdl_course SET summary='Moodle powered by Bitnami' WHERE id='1'" | "$db_remote_execute" "${db_execute_args[@]}"
+            echo "UPDATE ${mdl_prefix}course SET summary='Moodle powered by Bitnami' WHERE id='1'" | "$db_remote_execute" "${db_execute_args[@]}"
             # SMTP configuration
             if ! is_empty_value "$MOODLE_SMTP_HOST"; then
                 info "Configuring SMTP credentials"
                 "$db_remote_execute" "${db_execute_args[@]}" <<EOF
-UPDATE mdl_config SET value='${MOODLE_SMTP_HOST}:${MOODLE_SMTP_PORT_NUMBER}' WHERE name='smtphosts';
-UPDATE mdl_config SET value='${MOODLE_SMTP_USER}' WHERE name='smtpuser';
-UPDATE mdl_config SET value='${MOODLE_SMTP_PASSWORD}' WHERE name='smtppass';
-UPDATE mdl_config SET value='${MOODLE_SMTP_PROTOCOL}' WHERE name='smtpsecure';
+UPDATE ${mdl_prefix}config SET value='${MOODLE_SMTP_HOST}:${MOODLE_SMTP_PORT_NUMBER}' WHERE name='smtphosts';
+UPDATE ${mdl_prefix}config SET value='${MOODLE_SMTP_USER}' WHERE name='smtpuser';
+UPDATE ${mdl_prefix}config SET value='${MOODLE_SMTP_PASSWORD}' WHERE name='smtppass';
+UPDATE ${mdl_prefix}config SET value='${MOODLE_SMTP_PROTOCOL}' WHERE name='smtpsecure';
 EOF
             fi
         else

--- a/bitnami/moodle/4.2/debian-11/rootfs/opt/bitnami/scripts/libmoodle.sh
+++ b/bitnami/moodle/4.2/debian-11/rootfs/opt/bitnami/scripts/libmoodle.sh
@@ -156,6 +156,23 @@ moodle_initialize() {
         read -r -a extra_args <<<"$MOODLE_INSTALL_EXTRA_ARGS"
         [[ "${#extra_args[@]}" -gt 0 ]] && moodle_install_args+=("${extra_args[@]}")
 
+        # Handle --prefix (table prefix) being overridden via MOODLE_INSTALL_EXTRA_ARGS
+        mdl_prefix="mdl_"
+        for extra_arg in "${extra_args[@]}"; do
+            if [[ $extra_arg == --prefix=* ]]; then
+                parts=$( echo $extra_arg | tr "=" "\n" )
+                declare -i i=1
+                for part in $parts ; do
+                    if [[ $i -eq 2 ]] ; then
+                        mdl_prefix=$part
+                    else
+                        mdl_prefix=""
+                    fi
+                    i+=1
+                done
+            fi
+        done
+        
         # Setup Moodle
         if ! is_boolean_yes "$MOODLE_SKIP_BOOTSTRAP"; then
             info "Running Moodle install script"


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Capture the --prefix value from MOODLE_INSTALL_EXTRA_ARGS.  Use that value when running sql statements to update the moodle database instead of assuming mdl_.

### Benefits

<!-- What benefits will be realized by the code change? -->
Allows support for --prefix which makes it easier to migrate from an existing moodle install to a container based one.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
