### PR TITLE
fix: Fix typo of priviledged port

### DIFF
--- a/bitnami/openldap/README.md
+++ b/bitnami/openldap/README.md
@@ -175,7 +175,7 @@ docker-compose up -d
 
 The Bitnami Docker OpenLDAP can be easily setup with the following environment variables:
 
-* `LDAP_PORT_NUMBER`: The port OpenLDAP is listening for requests. Priviledged port is supported (e.g. `1389`). Default: **1389** (non privileged port).
+* `LDAP_PORT_NUMBER`: The port OpenLDAP is listening for requests. Priviledged port is supported (e.g. `389`). Default: **1389** (non privileged port).
 * `LDAP_ROOT`: LDAP baseDN (or suffix) of the LDAP tree. Default: **dc=example,dc=org**
 * `LDAP_ADMIN_USERNAME`: LDAP database admin user. Default: **admin**
 * `LDAP_ADMIN_PASSWORD`: LDAP database admin password. Default: **adminpassword**


### PR DESCRIPTION
### Description of the change

tcp/1389 is not a privileged port in general.

### Benefits

The descriptions won't confuse users.

### Possible drawbacks

### Applicable issues

### Additional information
