### PR TITLE
[bitnami/grafana] feat: handle space separated GF_INSTALL_PLUGINS

### DIFF
--- a/bitnami/grafana/10/debian-11/rootfs/opt/bitnami/scripts/libgrafana.sh
+++ b/bitnami/grafana/10/debian-11/rootfs/opt/bitnami/scripts/libgrafana.sh
@@ -302,7 +302,7 @@ grafana_install_plugins() {
     [[ -z "$GF_INSTALL_PLUGINS" ]] && return
 
     local -a plugin_list
-    read -r -a plugin_list <<< "$(tr ',;' ' ' <<< "${GF_INSTALL_PLUGINS}")"
+    IFS="," read -r -a plugin_list <<< "$(tr ';' ',' <<< "${GF_INSTALL_PLUGINS}")"
     if [[ "${#plugin_list[@]}" -le 0 ]]; then
         warn "There are no plugins to install"
         return
@@ -324,6 +324,11 @@ grafana_install_plugins() {
             grafana_plugin_install_args+=("--pluginUrl" "${plugin_url_array[1]}")
         elif grep ':' <<< "$plugin"; then
             read -r -a plugin_id_version_array <<< "$(tr ':' ' ' <<< "${plugin}")"
+            plugin_id="${plugin_id_version_array[0]}"
+            plugin_version="${plugin_id_version_array[1]}"
+            info "Installing plugin ${plugin_id} @ ${plugin_version}"
+        elif grep ' ' <<< "$plugin"; then
+            read -r -a plugin_id_version_array <<< $plugin
             plugin_id="${plugin_id_version_array[0]}"
             plugin_version="${plugin_id_version_array[1]}"
             info "Installing plugin ${plugin_id} @ ${plugin_version}"

--- a/bitnami/grafana/10/debian-11/rootfs/opt/bitnami/scripts/libgrafana.sh
+++ b/bitnami/grafana/10/debian-11/rootfs/opt/bitnami/scripts/libgrafana.sh
@@ -328,7 +328,7 @@ grafana_install_plugins() {
             plugin_version="${plugin_id_version_array[1]}"
             info "Installing plugin ${plugin_id} @ ${plugin_version}"
         elif grep ' ' <<< "$plugin"; then
-            read -r -a plugin_id_version_array <<< $plugin
+            read -r -a plugin_id_version_array <<< "$plugin"
             plugin_id="${plugin_id_version_array[0]}"
             plugin_version="${plugin_id_version_array[1]}"
             info "Installing plugin ${plugin_id} @ ${plugin_version}"


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Brings GF_INSTALL_PLUGINS handling inline with documented usage

Extract from: https://grafana.com/docs/grafana/latest/setup-grafana/installation/docker/

> Note: If you want to specify the version of a plugin, add the version number to the GF_INSTALL_PLUGINS environment variable. For example: -e "GF_INSTALL_PLUGINS=grafana-clock-panel 1.0.1,grafana-simple-json-datasource 1.3.5". If you do not specify a version number, the latest version is used.


### Benefits

Currently, the Bitnami Grafana image doesn't handle plugins installed via `Dashboard` or `Datasource` resources handled by the `grafana-operator`. This fixes that problem which is also mentioned in issue: https://github.com/grafana-operator/grafana-operator/issues/1269

### Possible drawbacks

<!-- Describe any known limitations with your change -->

Space-separated GF_INSTALL_PLUGINS will no longer work.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes https://github.com/grafana-operator/grafana-operator/issues/1269
- fixes https://github.com/bitnami/charts/issues/20242

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

I have tested this change with several different specifications of plugins:

```sh
sh-3.2$ export GF_INSTALL_PLUGINS="something 1.1.2,another 1.1.3,grafana-clock-panel:1.1.0,grafana-kubernetes-app,worldpring=https://github.com/raintank/worldping-app/releases/download/v1.2.6/worldping-app-release-1.2.6.zip"
sh-3.2$
sh-3.2$ grafana_plugin_test() {
>     [[ -z "$GF_INSTALL_PLUGINS" ]] && return
>
>     local -a plugin_list
>     IFS="," read -r -a plugin_list <<< "$(tr ';' ',' <<< "${GF_INSTALL_PLUGINS}")"
>     if [[ "${#plugin_list[@]}" -le 0 ]]; then
>         warn "There are no plugins to install"
>         return
>     fi
>
>     local plugin_id plugin_version
>     local -a grafana_plugin_install_args
>     local -a plugin_url_array
>     local -a plugin_id_version_array
>     for plugin in "${plugin_list[@]}"; do
>         plugin_id="$plugin"
>         plugin_version=""
>         grafana_plugin_install_args=("--pluginsDir" "/dummy")
>         if grep -q '=' <<< "$plugin"; then
>             read -r -a plugin_url_array <<< "$(tr '=' ' ' <<< "${plugin}")"
>             echo "Installing plugin ${plugin_url_array[0]} from URL ${plugin_url_array[1]}"
>             plugin_id="${plugin_url_array[0]}"
>             grafana_plugin_install_args+=("--pluginUrl" "${plugin_url_array[1]}")
>         elif grep ':' <<< "$plugin"; then
>             read -r -a plugin_id_version_array <<< "$(tr ':' ' ' <<< "${plugin}")"
>             plugin_id="${plugin_id_version_array[0]}"
>             plugin_version="${plugin_id_version_array[1]}"
>             echo "Installing plugin ${plugin_id} @ ${plugin_version}"
>         elif grep ' ' <<< "$plugin"; then
>             read -r -a plugin_id_version_array <<< $plugin
>             plugin_id="${plugin_id_version_array[0]}"
>             plugin_version="${plugin_id_version_array[1]}"
>             echo "Installing plugin ${plugin_id} @ ${plugin_version}"
>         else
>             echo "Installing plugin ${plugin_id}"
>         fi
>
>         grafana_plugin_install_args+=("plugins" "install" "${plugin_id}")
>         if [[ -n "$plugin_version" ]]; then
>             grafana_plugin_install_args+=("$plugin_version")
>         fi
>         echo "Would execute: grafana-cli ${grafana_plugin_install_args[@]}"
>         echo "---"
>     done
> }
sh-3.2$
sh-3.2$ grafana_plugin_test
something 1.1.2
Installing plugin something @ 1.1.2
Would execute: grafana-cli --pluginsDir /dummy plugins install something 1.1.2
---
another 1.1.3
Installing plugin another @ 1.1.3
Would execute: grafana-cli --pluginsDir /dummy plugins install another 1.1.3
---
grafana-clock-panel:1.1.0
Installing plugin grafana-clock-panel @ 1.1.0
Would execute: grafana-cli --pluginsDir /dummy plugins install grafana-clock-panel 1.1.0
---
Installing plugin grafana-kubernetes-app
Would execute: grafana-cli --pluginsDir /dummy plugins install grafana-kubernetes-app
---
Installing plugin worldpring from URL https://github.com/raintank/worldping-app/releases/download/v1.2.6/worldping-app-release-1.2.6.zip
Would execute: grafana-cli --pluginsDir /dummy --pluginUrl https://github.com/raintank/worldping-app/releases/download/v1.2.6/worldping-app-release-1.2.6.zip plugins install worldpring
```
