### PR TITLE
Update Goss scripts making it compatible with Goss 4

### DIFF
--- a/.vib/apache/goss/apache.yaml
+++ b/.vib/apache/goss/apache.yaml
@@ -22,7 +22,7 @@ file:
   /opt/bitnami/apache/conf/httpd.conf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - /^Include.*/opt/bitnami/apache/conf/bitnami/bitnami.conf/
       - /^Include.*/opt/bitnami/apache/conf/vhosts/\*.conf/
       - /^Include.*/opt/bitnami/apache/conf/deflate.conf/
@@ -30,13 +30,13 @@ file:
   /opt/bitnami/apache/conf/bitnami/bitnami.conf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - /DocumentRoot.*/opt/bitnami/apache/htdocs/
   # Main Bitnami ssl config file was correctly generated
   /opt/bitnami/apache/conf/bitnami/bitnami-ssl.conf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - "SSLProtocol all -SSLv2 -SSLv3"
       - /SSLCertificateFile.*bitnami/certs/server.crt/
       - /SSLCertificateKeyFile.*bitnami/certs/server.key/

--- a/.vib/appsmith/goss/appsmith.yaml
+++ b/.vib/appsmith/goss/appsmith.yaml
@@ -9,7 +9,7 @@ file:
   /opt/bitnami/appsmith/templates/docker.env.sh:
     exists: true
     filetype: file
-    contains:
+    contents:
       - /cat.*EOF/
       - APPSMITH_SUPERVISOR_USER
 command:

--- a/.vib/clickhouse/goss/clickhouse.yaml
+++ b/.vib/clickhouse/goss/clickhouse.yaml
@@ -24,7 +24,7 @@ file:
   /opt/bitnami/clickhouse/etc/config.xml:
     exists: true
     filetype: file
-    contains:
+    contents:
       - /data dir.*\/bitnami\/clickhouse\/data/
       - /http_port.*from_env.*CLICKHOUSE_HTTP_PORT/
       - "!remote_servers"
@@ -32,7 +32,7 @@ file:
   /opt/bitnami/clickhouse/etc/users.xml:
     exists: true
     filetype: file
-    contains:
+    contents:
       - /password.*from_env.*CLICKHOUSE_ADMIN_PASSWORD/
 group:
   clickhouse:

--- a/.vib/common/goss/templates/check-apache-libphp.yaml
+++ b/.vib/common/goss/templates/check-apache-libphp.yaml
@@ -19,11 +19,11 @@ file:
   /opt/bitnami/apache/conf/httpd.conf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - "Include \"/opt/bitnami/apache/conf/bitnami/php.conf\""
   /opt/bitnami/apache/conf/bitnami/php.conf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - "AddType application/x-httpd-php .php"
       - "DirectoryIndex index.html index.htm index.php"

--- a/.vib/common/goss/templates/check-nginx-php-fpm.yaml
+++ b/.vib/common/goss/templates/check-nginx-php-fpm.yaml
@@ -10,7 +10,7 @@ file:
   /opt/bitnami/nginx/conf/bitnami/php-fpm.conf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - "location ~ \\.php$ {"
       - "fastcgi_pass   unix:/opt/bitnami/php/var/run/www.sock;"
       - "include        fastcgi_params;"

--- a/.vib/common/goss/templates/check-php-fpm.yaml
+++ b/.vib/common/goss/templates/check-php-fpm.yaml
@@ -9,7 +9,7 @@
 file:
   /opt/bitnami/php/etc/php.ini:
     exists: true
-    contains:
+    contents:
       - /^opcache.interned_strings_buffer = 16/
       - /^opcache.memory_consumption = 192/
       - /^opcache.file_cache = \/opt\/bitnami\/php\/var\/run\/opcache_file/
@@ -18,7 +18,7 @@ file:
       - /^error_log = \/dev\/stderr/
   /opt/bitnami/php/etc/php-fpm.d/www.conf:
     exists: true
-    contains:
+    contents:
       - /^listen = \/opt\/bitnami\/php\/var\/run\/www.sock/
   /opt/bitnami/php/logs/php-fpm.log:
     exists: true

--- a/.vib/couchdb/goss/couchdb.yaml
+++ b/.vib/couchdb/goss/couchdb.yaml
@@ -6,7 +6,7 @@ file:
   /opt/bitnami/couchdb/etc/vm.args:
     exists: true
     filetype: file
-    contains:
+    contents:
       - /-kernel.*inet_dist_listen_min.*9100/
 command:
   check-library-path:

--- a/.vib/discourse/goss/discourse.yaml
+++ b/.vib/discourse/goss/discourse.yaml
@@ -20,7 +20,7 @@ file:
   /opt/bitnami/discourse/.image_optim.yml:
     exists: true
     filetype: file
-    contains:
+    contents:
       - "!timeout:"
       - "svgo: false"
 group:

--- a/.vib/dokuwiki/goss/dokuwiki.yaml
+++ b/.vib/dokuwiki/goss/dokuwiki.yaml
@@ -5,7 +5,7 @@ file:
   /opt/bitnami/apache/conf/vhosts/dokuwiki-vhost.conf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - /DocumentRoot.*/opt/bitnami/dokuwiki/
       - "RewriteEngine on"
       - "RewriteCond %{REQUEST_URI}            !^/server-status$"
@@ -13,7 +13,7 @@ file:
   /opt/bitnami/apache/conf/vhosts/dokuwiki-https-vhost.conf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - "SSLEngine on"
       - /DocumentRoot.*/opt/bitnami/dokuwiki/
       - "RewriteEngine on"
@@ -22,7 +22,7 @@ file:
   /opt/bitnami/php/etc/php.ini:
     exists: true
     filetype: file
-    contains:
+    contents:
       - /^memory_limit = 256M/
 group:
   daemon:

--- a/.vib/drupal-nginx/goss/drupal-nginx.yaml
+++ b/.vib/drupal-nginx/goss/drupal-nginx.yaml
@@ -6,28 +6,28 @@ file:
   /opt/bitnami/nginx/conf/server_blocks/drupal-server-block.conf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - /root\s+/opt/bitnami/drupal/
   # HTTPs server block should have been properly rendered
   /opt/bitnami/nginx/conf/server_blocks/drupal-https-server-block.conf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - /listen \d+ ssl/
       - /root\s+/opt/bitnami/drupal/
   /opt/bitnami/drupal/sites/default/settings.php:
     exists: true
     filetype: file
-    contains:
+    contents:
       - "$settings['trusted_host_patterns'] = array('^.*$');"
   /opt/bitnami/php/etc/php.ini:
     exists: true
     filetype: file
-    contains:
+    contents:
       - /^memory_limit = 256M/
   /opt/bitnami/nginx/conf/bitnami/php-fpm.conf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - "location ~ \\.php$|^/update.php {"
       - "fastcgi_split_path_info ^(.+?.php)(|/.*)$;"

--- a/.vib/drupal/goss/drupal.yaml
+++ b/.vib/drupal/goss/drupal.yaml
@@ -6,19 +6,19 @@ file:
   /opt/bitnami/apache/conf/vhosts/drupal-vhost.conf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - /DocumentRoot.*/opt/bitnami/drupal/
   # HTTPs vhost should have been properly rendered
   /opt/bitnami/apache/conf/vhosts/drupal-https-vhost.conf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - "SSLEngine on"
       - /DocumentRoot.*/opt/bitnami/drupal/
   /opt/bitnami/apache/conf/vhosts/htaccess/drupal-htaccess.conf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - "Options -Indexes -ExecCGI -Includes -MultiViews"
       - "SetHandler Drupal_Security_Do_Not_Remove_See_SA_2006_006"
       - "SetHandler Drupal_Security_Do_Not_Remove_See_SA_2013_003"
@@ -26,10 +26,10 @@ file:
   /opt/bitnami/drupal/sites/default/settings.php:
     exists: true
     filetype: file
-    contains:
+    contents:
       - "$settings['trusted_host_patterns'] = array('^.*$');"
   /opt/bitnami/php/etc/php.ini:
     exists: true
     filetype: file
-    contains:
+    contents:
       - /^memory_limit = 256M/

--- a/.vib/elasticsearch/goss/elasticsearch.yaml
+++ b/.vib/elasticsearch/goss/elasticsearch.yaml
@@ -15,7 +15,7 @@ file:
   /opt/bitnami/elasticsearch/config/log4j2.properties:
     exists: true
     filetype: file
-    contains:
+    contents:
       - "Console"
       - "!RollingFile"
       - "!_old"

--- a/.vib/harbor-portal/goss/harbor-portal.yaml
+++ b/.vib/harbor-portal/goss/harbor-portal.yaml
@@ -17,7 +17,7 @@ file:
     filetype: directory
   /opt/bitnami/nginx/conf/nginx.conf:
     exists: true
-    contains:
+    contents:
       - "/opt/bitnami/harbor"
       - "/opt/bitnami/nginx/conf/mime.types"
 command:

--- a/.vib/jasperreports/goss/jasperreports.yaml
+++ b/.vib/jasperreports/goss/jasperreports.yaml
@@ -9,13 +9,13 @@ file:
   /opt/bitnami/jasperreports/buildomatic/default_master.properties:
     exists: true
     filetype: file
-    contains:
+    contents:
       - appServerDir=/opt/bitnami/tomcat
       - jdbcDriverClass=org.mariadb.jdbc.Driver
   /opt/bitnami/jasperreports/buildomatic/bin/app-server.xml:
     exists: true
     filetype: file
-    contains:
+    contents:
       - '!<var name="warTargetDirDel"'
 group:
   tomcat:

--- a/.vib/joomla/goss/joomla.yaml
+++ b/.vib/joomla/goss/joomla.yaml
@@ -16,26 +16,26 @@ file:
   /opt/bitnami/joomla/configuration.php:
     exists: true
     filetype: file
-    contains:
+    contents:
       - "public $db = 'bitnami_joomla'"
   # PHP settings should have been configured
   /opt/bitnami/php/etc/php.ini:
     exists: true
     filetype: file
-    contains:
+    contents:
       - "memory_limit = 256M"
   # HTTP vhost should have been properly rendered
   /opt/bitnami/apache/conf/vhosts/joomla-vhost.conf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - /DocumentRoot.*/opt/bitnami/joomla/
       - "^/administrator$"
   # HTTPs vhost should have been properly rendered
   /opt/bitnami/apache/conf/vhosts/joomla-https-vhost.conf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - "SSLEngine on"
       - /DocumentRoot.*/opt/bitnami/joomla/
       - "^/administrator$"
@@ -43,7 +43,7 @@ file:
   /opt/bitnami/apache/conf/vhosts/htaccess/joomla-htaccess.conf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - 'RewriteRule "^administrator$"'
 group:
   daemon:

--- a/.vib/kafka/goss/kafka.yaml
+++ b/.vib/kafka/goss/kafka.yaml
@@ -10,7 +10,7 @@ file:
   /opt/bitnami/kafka/config/log4j.properties:
     exists: true
     filetype: file
-    contains:
+    contents:
       - "log4j.appender.stdout.Threshold=OFF"
       - "!DailyRollingFileAppender"
       - "ConsoleAppender"
@@ -19,5 +19,5 @@ file:
   /opt/bitnami/kafka/bin/kafka-server-start.sh:
     exists: true
     filetype: file
-    contains:
+    contents:
       - "![-]loggc"

--- a/.vib/keycloak/goss/keycloak.yaml
+++ b/.vib/keycloak/goss/keycloak.yaml
@@ -62,7 +62,7 @@ file:
     filetype: directory
   /opt/bitnami/keycloak/modules/system/layers/keycloak/org/postgresql/jdbc/main/module.xml:
     exists: true
-    contains:
+    contents:
       - "<module xmlns=\"urn:jboss:module:1.0\" name=\"org.postgresql.jdbc\">"
 command:
   check-app-version:

--- a/.vib/kibana/goss/kibana.yaml
+++ b/.vib/kibana/goss/kibana.yaml
@@ -5,5 +5,5 @@ file:
   /opt/bitnami/kibana/config/kibana.yml:
     exists: true
     filetype: file
-    contains:
+    contents:
       - "data: /bitnami/kibana/data"

--- a/.vib/kong/goss/kong.yaml
+++ b/.vib/kong/goss/kong.yaml
@@ -10,17 +10,17 @@ user:
 file:
   /opt/bitnami/kong/conf/kong.conf:
     exists: true
-    contains:
+    contents:
       - "prefix = /opt/bitnami/kong/server"
       - "nginx_daemon = off"
       - "nginx_user = kong"
   /opt/bitnami/scripts/kong-env.sh:
     exists: true
-    contains:
+    contents:
       - "'luarocks path' configuration"
   /etc/bash.bashrc:
     exists: true
-    contains:
+    contents:
       - "'luarocks path' configuration"
   /usr/local/kong/include/opentelemetry:
     exists: true

--- a/.vib/ksql/goss/ksql.yaml
+++ b/.vib/ksql/goss/ksql.yaml
@@ -6,11 +6,11 @@ file:
   /opt/bitnami/ksql/etc/ksqldb/ksql-server.properties.default:
     exists: true
     filetype: file
-    contains:
+    contents:
       - http://0.0.0.0:8088
       - ksql.streams.state.dir = /bitnami/ksql/data
   # ksql does not have a version flag so we check the version.txt
   /opt/bitnami/ksql/share/doc/confluent-kafka-mqtt/version.txt:
     exists: true
-    contains:
+    contents:
       - {{ .Env.APP_VERSION }}

--- a/.vib/kubeapps-dashboard/goss/kubeapps-dashboard.yaml
+++ b/.vib/kubeapps-dashboard/goss/kubeapps-dashboard.yaml
@@ -4,6 +4,6 @@
 file:
   /app/site.webmanifest:
     exists: true
-    contains:
+    contents:
       - "Kubeapps Dashboard"
 

--- a/.vib/logstash/goss/logstash.yaml
+++ b/.vib/logstash/goss/logstash.yaml
@@ -7,12 +7,12 @@ file:
   /opt/bitnami/logstash/config/logstash.yml:
     exists: true
     filetype: file
-    contains:
+    contents:
       - "path.data: /bitnami/logstash/data"
   /opt/bitnami/logstash/config/log4j2.properties:
     exists: true
     filetype: file
-    contains:
+    contents:
       - "Console"
 group:
   logstash:

--- a/.vib/magento/goss/magento.yaml
+++ b/.vib/magento/goss/magento.yaml
@@ -12,7 +12,7 @@ file:
   /opt/bitnami/apache/conf/vhosts/magento-https-vhost.conf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - "SSLEngine on"
       - /DocumentRoot.*/opt/bitnami/magento/
   /opt/bitnami/apache/conf/vhosts/htaccess/magento-htaccess.conf:
@@ -20,7 +20,7 @@ file:
   /opt/bitnami/php/etc/php.ini:
     exists: true
     filetype: file
-    contains:
+    contents:
       - "opcache.consistency_checks = 0"
       - "opcache.validate_timestamps = 0"
       - "opcache.enable_cli = 1"

--- a/.vib/mariadb-galera/goss/mariadb-galera.yaml
+++ b/.vib/mariadb-galera/goss/mariadb-galera.yaml
@@ -5,7 +5,7 @@ file:
   /opt/bitnami/mariadb/conf/my.cnf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - "socket=/opt/bitnami/mariadb/tmp/mysql.sock"
       - "wsrep_provider=/opt/bitnami/mariadb/lib/libgalera_smm.so"
       - "plugin_load_add = auth_pam"

--- a/.vib/mariadb/goss/mariadb.yaml
+++ b/.vib/mariadb/goss/mariadb.yaml
@@ -6,7 +6,7 @@ file:
   /opt/bitnami/mariadb/conf/my.cnf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - socket=/opt/bitnami/mariadb/tmp/mysql.sock
   # Checks the postunpack phase properly creates the plugin's symlink
   /opt/bitnami/mariadb/lib/plugin:

--- a/.vib/mastodon/goss/mastodon.yaml
+++ b/.vib/mastodon/goss/mastodon.yaml
@@ -11,13 +11,13 @@ file:
   /opt/bitnami/mastodon/config/initializers/1_hosts.rb:
     exists: true
     filetype: file
-    contains:
+    contents:
       - "https = ENV['MASTODON_HTTPS_ENABLED'] == 'true'"
       - "config.hosts.clear if ENV['MASTODON_ALLOW_ALL_DOMAINS'] == 'true'"
   /opt/bitnami/mastodon/config/environments/production.rb:
     exists: true
     filetype: file
-    contains:
+    contents:
       - "config.force_ssl = ENV['MASTODON_HTTPS_ENABLED'] == 'true'"
   /opt/mastodon:
     exists: true

--- a/.vib/matomo/goss/matomo.yaml
+++ b/.vib/matomo/goss/matomo.yaml
@@ -12,7 +12,7 @@ file:
   /opt/bitnami/apache/conf/vhosts/matomo-https-vhost.conf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - "SSLEngine on"
       - /DocumentRoot.*/opt/bitnami/matomo/
   /opt/bitnami/apache/conf/vhosts/htaccess/matomo-htaccess.conf:
@@ -20,7 +20,7 @@ file:
   /opt/bitnami/php/etc/php.ini:
     exists: true
     filetype: file
-    contains:
+    contents:
       - "memory_limit = 256M"
       - "mysqli.allow_local_infile = 1"
       - "extension = maxminddb.so"

--- a/.vib/mediawiki/goss/mediawiki.yaml
+++ b/.vib/mediawiki/goss/mediawiki.yaml
@@ -35,12 +35,12 @@ file:
   /opt/bitnami/php/etc/php.ini:
     exists: true
     filetype: file
-    contains:
+    contents:
       - "memory_limit = 256M"
   /opt/bitnami/apache/conf/vhosts/mediawiki-vhost.conf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - "RewriteEngine On"
       - "RewriteRule ^/?wiki(/.*)?$ %{DOCUMENT_ROOT}/index.php [L]"
   /opt/bitnami/mediawiki/extensions/Scribunto:

--- a/.vib/mongodb-sharded/goss/mongodb-sharded.yaml
+++ b/.vib/mongodb-sharded/goss/mongodb-sharded.yaml
@@ -4,20 +4,20 @@
 file:
   /opt/bitnami/mongodb/mongodb_get_source.txt:
     exists: true
-    contains:
+    contents:
       - This solution ships the official MongoDB Community binaries
   /opt/bitnami/mongodb/conf/mongodb.conf:
     exists: true
     filetype: file
     mode: "0664"
-    contains:
+    contents:
       - /dbPath.*/bitnami/mongodb/data/db/
       - /pidFilePath.*/opt/bitnami/mongodb/tmp/mongodb.pid/
   /opt/bitnami/mongodb/conf/mongos.conf:
     exists: true
     filetype: file
     mode: "0664"
-    contains:
+    contents:
       - /pidFilePath.*/opt/bitnami/mongodb/tmp/mongodb.pid/
   /opt/bitnami/mongodb/logs/mongodb.log:
     exists: true

--- a/.vib/mongodb/goss/mongodb.yaml
+++ b/.vib/mongodb/goss/mongodb.yaml
@@ -5,7 +5,7 @@ file:
   /opt/bitnami/mongodb/mongodb_get_source.txt:
     mode: "0644"
     exists: true
-    contains:
+    contents:
       - This solution ships the official MongoDB Community binaries
   /opt/bitnami/mongodb/logs/mongodb.log:
     exists: true
@@ -14,7 +14,7 @@ file:
   /opt/bitnami/mongodb/conf/mongodb.conf:
     mode: "0660"
     exists: true
-    contains:
+    contents:
       - /port.*27017/
       - /pidFilePath.*opt/bitnami/mongodb/tmp/mongodb.pid/
       - /path.*/opt/bitnami/mongodb/logs/mongodb.log/

--- a/.vib/moodle/goss/moodle.yaml
+++ b/.vib/moodle/goss/moodle.yaml
@@ -4,20 +4,20 @@
 file:
   /opt/bitnami/apache/conf/vhosts/moodle-vhost.conf:
     exists: true
-    contains:
+    contents:
     {{ range $rule := .Vars.apache.rules }}
       - {{ $rule }}
     {{ end }}
   /opt/bitnami/php/etc/php.ini:
     exists: true
-    contains:
+    contents:
       # Checking if the php.ini keys and pqsql extension are set
       - extension = pgsql
       - /^memory_limit/
       - /^max_input_vars/
   /opt/bitnami/apache/conf/vhosts/moodle-https-vhost.conf:
     exists: true
-    contains:
+    contents:
       - "SSLEngine on"
     {{ range $rule := .Vars.apache.rules }}
       - {{ $rule }}

--- a/.vib/mysql/goss/mysql.yaml
+++ b/.vib/mysql/goss/mysql.yaml
@@ -6,7 +6,7 @@ file:
   /opt/bitnami/mysql/conf/my.cnf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - socket=/opt/bitnami/mysql/tmp/mysql.sock
   /opt/bitnami/mysql/logs/mysqld.log:
     exists: true

--- a/.vib/nats/goss/nats.yaml
+++ b/.vib/nats/goss/nats.yaml
@@ -14,7 +14,7 @@ file:
     exists: true
     filetype: file
     mode: "0664"
-    contains:
+    contents:
       - /listen.*4222/
   /opt/bitnami/nats/logs/nats-server.log:
     exists: true

--- a/.vib/neo4j/goss/neo4j.yaml
+++ b/.vib/neo4j/goss/neo4j.yaml
@@ -7,12 +7,12 @@ file:
     exists: true
     filetype: file
     mode: "0664"
-    contains:
+    contents:
       - /file\.enabled.*true/
   /opt/bitnami/neo4j/conf/neo4j.conf:
     exists: true
     filetype: file
-    contains:
+    contents:
     {{ if regexMatch "^4.+" .Env.APP_VERSION }}
       - /dbms\.directories\.data.*\/bitnami\/neo4j\/data/
     {{ else if regexMatch "^5.+" .Env.APP_VERSION }}

--- a/.vib/nginx/goss/nginx.yaml
+++ b/.vib/nginx/goss/nginx.yaml
@@ -28,12 +28,12 @@ file:
   /opt/bitnami/nginx/conf/nginx.conf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - /listen.*{{ .Vars.ports.http }}/
   /opt/bitnami/nginx/conf/fastcgi_params:
     exists: true
     filetype: file
-    contains:
+    contents:
       - /Unset.*HTTP_PROXY/
 command:
   test-config:

--- a/.vib/opencart/goss/opencart.yaml
+++ b/.vib/opencart/goss/opencart.yaml
@@ -20,13 +20,13 @@ file:
   /opt/bitnami/apache/conf/vhosts/opencart-vhost.conf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - /DocumentRoot.*/opt/bitnami/opencart/
   # HTTPS vhost should have been properly rendered
   /opt/bitnami/apache/conf/vhosts/opencart-https-vhost.conf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - "SSLEngine on"
       - /DocumentRoot.*/opt/bitnami/opencart/
 group:

--- a/.vib/openresty/goss/openresty.yaml
+++ b/.vib/openresty/goss/openresty.yaml
@@ -22,12 +22,12 @@ file:
   /opt/bitnami/openresty/nginx/conf/nginx.conf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - /listen.*8080/
   /opt/bitnami/openresty/nginx/conf/fastcgi_params:
     exists: true
     filetype: file
-    contains:
+    contents:
       - /fastcgi_param.*HTTP_PROXY.*""/
 command:
   # Revisions are displayed as "x.y.z.r" instead of "x.y.z-r"

--- a/.vib/osclass/goss/osclass.yaml
+++ b/.vib/osclass/goss/osclass.yaml
@@ -19,14 +19,14 @@ file:
   /opt/bitnami/apache/conf/vhosts/osclass-vhost.conf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - /DocumentRoot.*/opt/bitnami/osclass/
       - 'RewriteRule "^/oc-admin$"'
   # HTTPS vhost should have been properly rendered
   /opt/bitnami/apache/conf/vhosts/osclass-https-vhost.conf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - "SSLEngine on"
       - /DocumentRoot.*/opt/bitnami/osclass/
       - 'RewriteRule "^/oc-admin$"'

--- a/.vib/percona-mysql/goss/percona-mysql.yaml
+++ b/.vib/percona-mysql/goss/percona-mysql.yaml
@@ -6,7 +6,7 @@ file:
   /opt/bitnami/mysql/conf/my.cnf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - socket=/opt/bitnami/mysql/tmp/mysql.sock
   /opt/bitnami/mysql/logs/mysqld.log:
     exists: true

--- a/.vib/php-fpm/goss/php-fpm.yaml
+++ b/.vib/php-fpm/goss/php-fpm.yaml
@@ -10,23 +10,23 @@ file:
   /opt/bitnami/php/etc/php.ini:
     exists: true
     filetype: file
-    contains:
+    contents:
       - upload_max_filesize = 40M
       - opcache.revalidate_freq = 60
   /opt/bitnami/php/etc/common.conf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - user=daemon
   /opt/bitnami/php/etc/php-fpm.conf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - error_log = /opt/bitnami/php/logs/php-fpm.log
   /opt/bitnami/php/etc/php-fpm.d/www.conf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - listen = 9000
       - include=/opt/bitnami/php/etc/environment.conf
       - include=/opt/bitnami/php/etc/common.conf

--- a/.vib/phpbb/goss/phpbb.yaml
+++ b/.vib/phpbb/goss/phpbb.yaml
@@ -14,14 +14,14 @@ file:
   /opt/bitnami/apache/conf/vhosts/phpbb-vhost.conf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - /DocumentRoot.*/opt/bitnami/phpbb/
       - Alias /bitnami/phpbb /bitnami/phpbb
   # HTTPS vhost should have been properly rendered
   /opt/bitnami/apache/conf/vhosts/phpbb-https-vhost.conf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - "SSLEngine on"
       - /DocumentRoot.*/opt/bitnami/phpbb/
       - Alias /bitnami/phpbb /bitnami/phpbb

--- a/.vib/phpmyadmin/goss/phpmyadmin.yaml
+++ b/.vib/phpmyadmin/goss/phpmyadmin.yaml
@@ -18,27 +18,27 @@ file:
   /opt/bitnami/php/etc/php.ini:
     exists: true
     filetype: file
-    contains:
+    contents:
       - post_max_size = 80M
       - upload_max_filesize = 80M
   # HTTP vhost should have been properly rendered
   /opt/bitnami/apache/conf/vhosts/phpmyadmin-vhost.conf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - /DocumentRoot.*/opt/bitnami/phpmyadmin/
   # HTTPS vhost should have been properly rendered
   /opt/bitnami/apache/conf/vhosts/phpmyadmin-https-vhost.conf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - "SSLEngine on"
       - /DocumentRoot.*/opt/bitnami/phpmyadmin/
   # Default phpMyAdmin configurations
   /opt/bitnami/phpmyadmin/config.inc.php:
     exists: true
     filetype: file
-    contains:
+    contents:
       - "$cfg['Servers'][$i]['host'] = 'mariadb';"
       - "$cfg['AllowArbitraryServer'] = false;"
       - "$cfg['Servers'][$i]['AllowNoPassword'] = true;"

--- a/.vib/postgresql/goss/postgresql.yaml
+++ b/.vib/postgresql/goss/postgresql.yaml
@@ -17,5 +17,5 @@ file:
   /opt/bitnami/postgresql/conf/postgresql.conf:
     exists: true
     mode: "0664"
-    contains:
+    contents:
       - /^include_dir = 'conf.d'/

--- a/.vib/prestashop/goss/prestashop.yaml
+++ b/.vib/prestashop/goss/prestashop.yaml
@@ -18,26 +18,26 @@ file:
   /opt/bitnami/php/etc/php.ini:
     exists: true
     filetype: file
-    contains:
+    contents:
       - post_max_size = 128M
       - upload_max_filesize = 128M
   # Ensure that .htaccess file contents have not been moved to /opt/bitnami/apache/conf/vhosts/htaccess
   /opt/bitnami/prestashop/app/.htaccess:
     exists: true
     filetype: file
-    contains:
+    contents:
       - Require all denied
   # HTTP vhost should have been properly rendered
   /opt/bitnami/apache/conf/vhosts/prestashop-vhost.conf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - /DocumentRoot.*/opt/bitnami/prestashop/
   # HTTPS vhost should have been properly rendered
   /opt/bitnami/apache/conf/vhosts/prestashop-https-vhost.conf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - "SSLEngine on"
       - /DocumentRoot.*/opt/bitnami/prestashop/
 group:

--- a/.vib/redis-cluster/goss/redis-cluster.yaml
+++ b/.vib/redis-cluster/goss/redis-cluster.yaml
@@ -4,7 +4,7 @@
 file:
   /opt/bitnami/redis/etc/redis.conf:
     exists: true
-    contains:
+    contents:
       - /port.*6379/
       - /dir.*/bitnami/redis/data/
       - /pidfile.*/opt/bitnami/redis/tmp/redis.pid/

--- a/.vib/redis-sentinel/goss/redis-sentinel.yaml
+++ b/.vib/redis-sentinel/goss/redis-sentinel.yaml
@@ -4,7 +4,7 @@
 file:
   /opt/bitnami/redis-sentinel/etc/sentinel.conf:
     exists: true
-    contains:
+    contents:
       - port 26379
       - bind 0.0.0.0
       - /pidfile.*/opt/bitnami/redis-sentinel/tmp/redis-sentinel.pid/

--- a/.vib/redis/goss/redis.yaml
+++ b/.vib/redis/goss/redis.yaml
@@ -5,7 +5,7 @@ file:
   /opt/bitnami/redis/etc/redis.conf:
     exists: true
     mode: "0664"
-    contains:
+    contents:
       - /port.*6379/
       - /dir.*/bitnami/redis/data/
       - /pidfile.*/opt/bitnami/redis/tmp/redis.pid/

--- a/.vib/schema-registry/goss/schema-registry.yaml
+++ b/.vib/schema-registry/goss/schema-registry.yaml
@@ -9,7 +9,7 @@ file:
   /opt/bitnami/schema-registry/etc/schema-registry/schema-registry.properties.default:
     exists: true
     filetype: file
-    contains:
+    contents:
       - /kafkastore.bootstrap.servers.*9092/
 command:
   check-schema-registry-initialization:

--- a/.vib/solr/goss/solr.yaml
+++ b/.vib/solr/goss/solr.yaml
@@ -6,7 +6,7 @@ file:
   /opt/bitnami/solr/bin/solr.in.sh:
     exists: true
     filetype: file
-    contains:
+    contents:
       - "SOLR_JAVA_HOME=/opt/bitnami/java"
       - "SOLR_PID_DIR=/opt/bitnami/solr/tmp"
       - "SOLR_LOGS_DIR=/opt/bitnami/solr/logs"

--- a/.vib/sonarqube/goss/sonarqube.yaml
+++ b/.vib/sonarqube/goss/sonarqube.yaml
@@ -5,7 +5,7 @@ file:
   /opt/bitnami/sonarqube/bin/linux-x86-64/sonar.sh:
     exists: true
     filetype: file
-    contains:
+    contents:
     {{ if regexMatch "^8.+" .Env.APP_VERSION }}
       - "PIDDIR=\"../../pids\""
     {{ else if regexMatch "^9.+" .Env.APP_VERSION }}
@@ -16,7 +16,7 @@ file:
   /opt/bitnami/sonarqube/conf/wrapper.conf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - "wrapper.logfile.rollmode=NONE"
   {{ end }}
 group:

--- a/.vib/suitecrm/goss/suitecrm.yaml
+++ b/.vib/suitecrm/goss/suitecrm.yaml
@@ -19,7 +19,7 @@ file:
   /opt/bitnami/php/etc/php.ini:
     exists: true
     filetype: file
-    contains:
+    contents:
       - post_max_size = 60M
       - upload_max_filesize = 128M
   /opt/bitnami/suitecrm/node_modules:
@@ -28,19 +28,19 @@ file:
   /opt/bitnami/php/etc/php.ini:
     exists: true
     filetype: file
-    contains:
+    contents:
       - opcache.enable = Off
   # HTTP vhost should have been properly rendered
   /opt/bitnami/apache/conf/vhosts/suitecrm-vhost.conf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - /DocumentRoot.*/opt/bitnami/suitecrm/
   # HTTPS vhost should have been properly rendered
   /opt/bitnami/apache/conf/vhosts/suitecrm-https-vhost.conf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - "SSLEngine on"
       - /DocumentRoot.*/opt/bitnami/suitecrm/
 group:

--- a/.vib/supabase-postgres/goss/supabase-postgres.yaml
+++ b/.vib/supabase-postgres/goss/supabase-postgres.yaml
@@ -14,5 +14,5 @@ file:
   /opt/bitnami/postgresql/conf/postgresql.conf:
     exists: true
     mode: "0664"
-    contains:
+    contents:
       - /^include_dir = 'conf.d'/

--- a/.vib/wordpress-nginx/goss/wordpress-nginx.yaml
+++ b/.vib/wordpress-nginx/goss/wordpress-nginx.yaml
@@ -27,14 +27,14 @@ file:
   /opt/bitnami/nginx/conf/server_blocks/wordpress-server-block.conf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - /root\s+/opt/bitnami/wordpress/
       - "rewrite ^/bitnami/wordpress(/.*) $1 last;"
   # HTTPs vhost should have been properly rendered
   /opt/bitnami/nginx/conf/server_blocks/wordpress-https-server-block.conf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - /listen \d+ ssl/
       - /root\s+/opt/bitnami/wordpress/
       - "rewrite ^/bitnami/wordpress(/.*) $1 last;"
@@ -42,7 +42,7 @@ file:
   /opt/bitnami/wp-cli/conf/wp-cli.yml:
     exists: true
     filetype: file
-    contains:
+    contents:
       - /path.*/opt/bitnami/wordpress/
 group:
   daemon:

--- a/.vib/wordpress/goss/wordpress.yaml
+++ b/.vib/wordpress/goss/wordpress.yaml
@@ -27,14 +27,14 @@ file:
   /opt/bitnami/apache/conf/vhosts/wordpress-vhost.conf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - "RewriteRule ^bitnami/wordpress(/.*) $1"
       - /DocumentRoot.*/opt/bitnami/wordpress/
   # HTTPs vhost should have been properly rendered
   /opt/bitnami/apache/conf/vhosts/wordpress-https-vhost.conf:
     exists: true
     filetype: file
-    contains:
+    contents:
       - "SSLEngine on"
       - "RewriteRule ^bitnami/wordpress(/.*) $1"
       - /DocumentRoot.*/opt/bitnami/wordpress/
@@ -42,7 +42,7 @@ file:
   /opt/bitnami/wp-cli/conf/wp-cli.yml:
     exists: true
     filetype: file
-    contains:
+    contents:
       - /path.*/opt/bitnami/wordpress/
 group:
   daemon:


### PR DESCRIPTION
Looking at Goss v4 [migration instructions](https://github.com/goss-org/goss/blob/master/docs/v4_migration.md), there are several breaking changes but changes in this PR are the only ones affecting our tests.

In summary, `file.contains` is now `file.contents` we have a large amount of references to `file.contains` that should be updated.