### PR TITLE
[bitnami/openldap] #49575 Move requiring TLS to the very end of the configuration and remove duplicate call to enable TLS

### DIFF
--- a/bitnami/openldap/2.5/debian-11/rootfs/opt/bitnami/scripts/libopenldap.sh
+++ b/bitnami/openldap/2.5/debian-11/rootfs/opt/bitnami/scripts/libopenldap.sh
@@ -612,9 +612,6 @@ ldap_initialize() {
         if ! is_boolean_yes "$LDAP_ALLOW_ANON_BINDING"; then
             ldap_disable_anon_binding
         fi
-        if is_boolean_yes "$LDAP_ENABLE_TLS"; then
-            ldap_configure_tls
-        fi
         # Initialize OpenLDAP with schemas/tree structure
         if is_boolean_yes "$LDAP_ADD_SCHEMAS"; then
             ldap_add_schemas
@@ -640,19 +637,19 @@ ldap_initialize() {
         if is_boolean_yes "$LDAP_ENABLE_SYNCPROV"; then
             ldap_enable_syncprov
         fi
-        # enable tls
-        if is_boolean_yes "$LDAP_ENABLE_TLS"; then
-            ldap_configure_tls
-            if is_boolean_yes "$LDAP_REQUIRE_TLS"; then
-                ldap_configure_tls_required
-            fi
-        fi
         if ! is_dir_empty "$LDAP_CUSTOM_LDIF_DIR"; then
             ldap_add_custom_ldifs
         elif ! is_boolean_yes "$LDAP_SKIP_DEFAULT_TREE"; then
             ldap_create_tree
         else
             info "Skipping default schemas/tree structure"
+        fi
+        # enable tls
+        if is_boolean_yes "$LDAP_ENABLE_TLS"; then
+            ldap_configure_tls
+            if is_boolean_yes "$LDAP_REQUIRE_TLS"; then
+                ldap_configure_tls_required
+            fi
         fi
         ldap_stop
     fi

--- a/bitnami/openldap/2.6/debian-11/rootfs/opt/bitnami/scripts/libopenldap.sh
+++ b/bitnami/openldap/2.6/debian-11/rootfs/opt/bitnami/scripts/libopenldap.sh
@@ -612,9 +612,6 @@ ldap_initialize() {
         if ! is_boolean_yes "$LDAP_ALLOW_ANON_BINDING"; then
             ldap_disable_anon_binding
         fi
-        if is_boolean_yes "$LDAP_ENABLE_TLS"; then
-            ldap_configure_tls
-        fi
         # Initialize OpenLDAP with schemas/tree structure
         if is_boolean_yes "$LDAP_ADD_SCHEMAS"; then
             ldap_add_schemas
@@ -640,19 +637,19 @@ ldap_initialize() {
         if is_boolean_yes "$LDAP_ENABLE_SYNCPROV"; then
             ldap_enable_syncprov
         fi
-        # enable tls
-        if is_boolean_yes "$LDAP_ENABLE_TLS"; then
-            ldap_configure_tls
-            if is_boolean_yes "$LDAP_REQUIRE_TLS"; then
-                ldap_configure_tls_required
-            fi
-        fi
         if ! is_dir_empty "$LDAP_CUSTOM_LDIF_DIR"; then
             ldap_add_custom_ldifs
         elif ! is_boolean_yes "$LDAP_SKIP_DEFAULT_TREE"; then
             ldap_create_tree
         else
             info "Skipping default schemas/tree structure"
+        fi
+        # enable tls
+        if is_boolean_yes "$LDAP_ENABLE_TLS"; then
+            ldap_configure_tls
+            if is_boolean_yes "$LDAP_REQUIRE_TLS"; then
+                ldap_configure_tls_required
+            fi
         fi
         ldap_stop
     fi


### PR DESCRIPTION
Requiring TLS prevents the various configuration upload functions from working and therefore it must be the last task run. See #49575 .

### Description of the change

Moves TLS enable and require configuration ot the end of the configuration process as no further configuration can be run after this step.

### Benefits

It is once again possible to require TLS.

### Possible drawbacks

None.

### Applicable issues

- fixes #49575 

### Additional information

N/A
