### PR TITLE
Quote everything inside stdout/contents except regexp

### DIFF
--- a/.vib/airflow-scheduler/goss/airflow-scheduler.yaml
+++ b/.vib/airflow-scheduler/goss/airflow-scheduler.yaml
@@ -7,14 +7,14 @@ command:
     exec: airflow users list
     exit-status: 0
     stdout:
-      - No data found
+      - "No data found"
   check-subpackages:
     # Check python packages that should have been installed
     exec: . /opt/bitnami/airflow/venv/bin/activate && pip list
     exit-status: 0
     stdout:
     {{ range $subpackage := .Vars.subpackages }}
-      - {{ $subpackage }}
+      - "{{ $subpackage }}"
     {{ end }}
 file:
   /opt/bitnami/airflow/venv/lib/python3.9/site-packages/airflow/www/node_modules:

--- a/.vib/airflow-worker/goss/airflow-worker.yaml
+++ b/.vib/airflow-worker/goss/airflow-worker.yaml
@@ -7,14 +7,14 @@ command:
     exec: airflow users list
     exit-status: 0
     stdout:
-      - No data found
+      - "No data found"
   check-subpackages:
     # Check python packages that should have been installed
     exec: . /opt/bitnami/airflow/venv/bin/activate && pip list
     exit-status: 0
     stdout:
     {{ range $subpackage := .Vars.subpackages }}
-      - {{ $subpackage }}
+      - "{{ $subpackage }}"
     {{ end }}
 file:
   /opt/bitnami/airflow/venv/lib/python3.9/site-packages/airflow/www/node_modules:

--- a/.vib/airflow/goss/airflow.yaml
+++ b/.vib/airflow/goss/airflow.yaml
@@ -7,14 +7,14 @@ command:
     exec: airflow users list
     exit-status: 0
     stdout:
-      - No data found
+      - "No data found"
   check-subpackages:
     # Check python packages that should have been installed
     exec: . /opt/bitnami/airflow/venv/bin/activate && pip list
     exit-status: 0
     stdout:
     {{ range $subpackage := .Vars.subpackages }}
-      - {{ $subpackage }}
+      - "{{ $subpackage }}"
     {{ end }}
 file:
   /opt/bitnami/airflow/venv/lib/python3.9/site-packages/airflow/www/node_modules:

--- a/.vib/appsmith/goss/appsmith.yaml
+++ b/.vib/appsmith/goss/appsmith.yaml
@@ -11,14 +11,14 @@ file:
     filetype: file
     contents:
       - /cat.*EOF/
-      - APPSMITH_SUPERVISOR_USER
+      - "APPSMITH_SUPERVISOR_USER"
 command:
   check-server-init:
     exec: java -jar /opt/bitnami/appsmith/backend/server.jar
     exit-status: 1
     stdout:
-      - {{ .Env.APP_VERSION }}
-      - Starting ServerApplication
+      - "{{ .Env.APP_VERSION }}"
+      - "Starting ServerApplication"
   check-rts-init:
     exec: cd /opt/appsmith/rts/ && node --require source-map-support/register server.js
     exit-status: 1

--- a/.vib/argo-cd/goss/argo-cd.yaml
+++ b/.vib/argo-cd/goss/argo-cd.yaml
@@ -7,7 +7,7 @@ command:
     exec: argocd version
     exit-status: 1
     stdout:
-    - {{ .Env.APP_VERSION }}
+    - "{{ .Env.APP_VERSION }}"
 file:
   /opt/bitnami/argo-cd/bin/argocd-server:
     exists: true

--- a/.vib/aspnet-core/goss/aspnet-core.yaml
+++ b/.vib/aspnet-core/goss/aspnet-core.yaml
@@ -10,6 +10,6 @@ command:
   check-installed-runtimes:
     exec: dotnet --list-runtimes
     stdout:
-      - AspNetCore.App {{ .Env.APP_VERSION }}
-      - NETCore.App {{ .Env.APP_VERSION }}
+      - "AspNetCore.App {{ .Env.APP_VERSION }}"
+      - "NETCore.App {{ .Env.APP_VERSION }}"
     exit-status: 0

--- a/.vib/attu/goss/attu.yaml
+++ b/.vib/attu/goss/attu.yaml
@@ -16,10 +16,10 @@ command:
     exec: cd /opt/bitnami/attu; npm run
     exit-status: 0
     stdout:
-      - start:prod
+      - "start:prod"
   run-attu:
     exec: cd /opt/bitnami/attu; timeout --preserve-status 5 yarn start:prod  || true
     timeout: 8000
     exit-status: 0
     stdout:
-      - Attu server started
+      - "Attu server started"

--- a/.vib/clickhouse/goss/clickhouse.yaml
+++ b/.vib/clickhouse/goss/clickhouse.yaml
@@ -7,7 +7,7 @@ command:
     exec: timeout --preserve-status 5 clickhouse-server 2>&1 || true
     exit-status: 0
     stdout:
-      - Ready for connections
+      - "Ready for connections"
 file:
   /var/lib/clickhouse/tmp:
     exists: true

--- a/.vib/codeigniter/goss/codeigniter.yaml
+++ b/.vib/codeigniter/goss/codeigniter.yaml
@@ -7,4 +7,4 @@ command:
     exec: timeout 2s /opt/bitnami/codeigniter/spark serve | tail -n2
     exit-status: 0
     stdout:
-      - started
+      - "started"

--- a/.vib/common/goss/templates/check-app-version.yaml
+++ b/.vib/common/goss/templates/check-app-version.yaml
@@ -13,4 +13,4 @@ command:
     exec: {{ .Vars.version.bin_name }} {{ .Vars.version.flag }} 2>&1
     exit-status: 0
     stdout:
-    - {{ .Env.APP_VERSION }}
+    - "{{ .Env.APP_VERSION }}"

--- a/.vib/configurable-http-proxy/goss/configurable-http-proxy.yaml
+++ b/.vib/configurable-http-proxy/goss/configurable-http-proxy.yaml
@@ -7,5 +7,5 @@ command:
     timeout: 8000
     exit-status: 2
     stdout:
-      - Proxying
-      - Proxy API at
+      - "Proxying"
+      - "Proxy API at"

--- a/.vib/couchdb/goss/couchdb.yaml
+++ b/.vib/couchdb/goss/couchdb.yaml
@@ -12,7 +12,7 @@ command:
   check-library-path:
     exec: echo $LD_LIBRARY_PATH
     stdout:
-      - /opt/bitnami/common/lib
+      - "/opt/bitnami/common/lib"
     exit-status: 0
   check-libmozjs:
     exec: ls /opt/bitnami/common/lib | grep libmozjs

--- a/.vib/discourse/goss/discourse.yaml
+++ b/.vib/discourse/goss/discourse.yaml
@@ -15,7 +15,7 @@ command:
     exec: npm list -g
     exit-status: 0
     stdout:
-      - terser
+      - "terser"
 file:
   /opt/bitnami/discourse/.image_optim.yml:
     exists: true

--- a/.vib/dotnet-sdk/goss/dotnet-sdk.yaml
+++ b/.vib/dotnet-sdk/goss/dotnet-sdk.yaml
@@ -10,13 +10,13 @@ command:
   check-installed-runtimes:
     exec: dotnet --list-runtimes
     stdout:
-      - AspNetCore.App
-      - NETCore.App
+      - "AspNetCore.App"
+      - "NETCore.App"
     exit-status: 0
   check-installed-sdks:
     exec: dotnet --list-sdks
     stdout:
-    - {{ .Env.APP_VERSION }}
+    - "{{ .Env.APP_VERSION }}"
     exit-status: 0
   create-dotnet-project:
     exec: dotnet new -i CamundaProcessTemplate --force && dotnet new CamundaProcess -n VIBInstance --force

--- a/.vib/dotnet/goss/dotnet.yaml
+++ b/.vib/dotnet/goss/dotnet.yaml
@@ -10,5 +10,5 @@ command:
   check-installed-runtimes:
     exec: dotnet --list-runtimes
     stdout:
-      - NETCore.App {{ .Env.APP_VERSION }}
+      - "NETCore.App {{ .Env.APP_VERSION }}"
     exit-status: 0

--- a/.vib/elasticsearch-exporter/goss/elasticsearch-exporter.yaml
+++ b/.vib/elasticsearch-exporter/goss/elasticsearch-exporter.yaml
@@ -7,4 +7,4 @@ command:
     exit-status: 143
     timeout: 8000
     stdout:
-      - triggering initial cluster info call
+      - "triggering initial cluster info call"

--- a/.vib/flink/goss/flink.yaml
+++ b/.vib/flink/goss/flink.yaml
@@ -7,8 +7,8 @@ command:
     timeout: 8000
     exit-status: 143
     stdout:
-      - Rest endpoint listening
-      - Web frontend listening
+      - "Rest endpoint listening"
+      - "Web frontend listening"
 file:
   /opt/bitnami/flink/plugins/s3-fs-base/flink-s3-fs-base-{{ .Env.APP_VERSION }}.jar:
     exists: true

--- a/.vib/golang/goss/golang.yaml
+++ b/.vib/golang/goss/golang.yaml
@@ -14,4 +14,4 @@ command:
       ./{{ $filename }}
     exit-status: 0
     stdout:
-      - Hello VIB
+      - "Hello VIB"

--- a/.vib/grafana-image-renderer/goss/grafana-image-renderer.yaml
+++ b/.vib/grafana-image-renderer/goss/grafana-image-renderer.yaml
@@ -6,7 +6,7 @@ command:
     exec: grep -A2 '"version"' /opt/bitnami/grafana-image-renderer/plugin.json | grep -o "[0-9]*\.[0-9]*\.[0-9]"
     exit-status: 0
     stdout:
-      - {{ .Env.APP_VERSION }}
+      - "{{ .Env.APP_VERSION }}"
   check-build-app:
     exec: timeout --preserve-status 3 node /opt/bitnami/grafana-image-renderer/build/app.js server --config=/opt/bitnami/grafana-image-renderer/conf/config.json
     exit-status: 143

--- a/.vib/grafana/goss/grafana.yaml
+++ b/.vib/grafana/goss/grafana.yaml
@@ -7,7 +7,7 @@ command:
     exec: grafana-cli --pluginsDir /opt/bitnami/grafana/default-plugins/ plugins ls
     stdout:
     {{ range $plugin := .Vars.plugins }}
-      - {{ $plugin }}
+      - "{{ $plugin }}"
     {{ end }}
 user:
   grafana:

--- a/.vib/haproxy/goss/haproxy.yaml
+++ b/.vib/haproxy/goss/haproxy.yaml
@@ -7,5 +7,5 @@ command:
     exec: haproxy -vv
     exit-status: 0
     stdout:
-      - Built with Lua
-      - Built with the Prometheus
+      - "Built with Lua"
+      - "Built with the Prometheus"

--- a/.vib/jasperreports/goss/jasperreports.yaml
+++ b/.vib/jasperreports/goss/jasperreports.yaml
@@ -10,8 +10,8 @@ file:
     exists: true
     filetype: file
     contents:
-      - appServerDir=/opt/bitnami/tomcat
-      - jdbcDriverClass=org.mariadb.jdbc.Driver
+      - "appServerDir=/opt/bitnami/tomcat"
+      - "jdbcDriverClass=org.mariadb.jdbc.Driver"
   /opt/bitnami/jasperreports/buildomatic/bin/app-server.xml:
     exists: true
     filetype: file

--- a/.vib/java/goss/java.yaml
+++ b/.vib/java/goss/java.yaml
@@ -14,5 +14,5 @@ command:
   check-run-jar:
     exec: java -jar ./java/goss/testfiles/HelloTest.jar
     stdout:
-    - Hello VIB
+    - "Hello VIB"
     exit-status: 0

--- a/.vib/jax/goss/jax.yaml
+++ b/.vib/jax/goss/jax.yaml
@@ -12,4 +12,4 @@ command:
     timeout: 8000
     exit-status: 0
     stdout:
-      - 0.3721109
+      - "0.3721109"

--- a/.vib/jenkins-agent/goss/jenkins-agent.yaml
+++ b/.vib/jenkins-agent/goss/jenkins-agent.yaml
@@ -6,4 +6,4 @@ command:
     exec: java -cp /opt/bitnami/jenkins-agent/agent.jar hudson.remoting.jnlp.Main -version | echo "0.$(cut -d '.' -f 1).0"
     exit-status: 0
     stdout:
-      - {{ .Env.APP_VERSION }}
+      - "{{ .Env.APP_VERSION }}"

--- a/.vib/jruby/goss/jruby.yaml
+++ b/.vib/jruby/goss/jruby.yaml
@@ -19,13 +19,13 @@ command:
     exit-status: 0
     timeout: 30000
     stdout:
-      - Hello VIB
+      - "Hello VIB"
   check-mariadb-jdbc-driver:
     exec: jruby -e "puts Java::org.mariadb.jdbc.Driver"
     exit-status: 0
     timeout: 30000
     stdout:
-      - Java::OrgMariadbJdbc::Driver
+      - "Java::OrgMariadbJdbc::Driver"
 file:
   /opt/bitnami/jruby/bin/ruby:
     exists: true

--- a/.vib/jsonnet/goss/jsonnet.yaml
+++ b/.vib/jsonnet/goss/jsonnet.yaml
@@ -6,4 +6,4 @@ command:
     exec: jsonnet ./jsonnet/goss/testfiles/test_template.jsonnet
     exit-status: 0
     stdout:
-      - VIB
+      - "VIB"

--- a/.vib/jwt-cli/goss/jwt-cli.yaml
+++ b/.vib/jwt-cli/goss/jwt-cli.yaml
@@ -7,4 +7,4 @@ command:
     exec: jwt encode --secret=fake '{"hello":"world"}'
     exit-status: 0
     stdout:
-      - eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9
+      - "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9"

--- a/.vib/keycloak-config-cli/goss/keycloak-config-cli.yaml
+++ b/.vib/keycloak-config-cli/goss/keycloak-config-cli.yaml
@@ -9,7 +9,7 @@ command:
     exit-status: 1
     timeout: 10000
     stdout:
-      - Started KeycloakConfigApplication
+      - "Started KeycloakConfigApplication"
   # Besides the default one, we are packaging
   # one cli per keycloak major as done by upstream
   check-per-major-clis:

--- a/.vib/keycloak/goss/keycloak.yaml
+++ b/.vib/keycloak/goss/keycloak.yaml
@@ -70,4 +70,4 @@ command:
     exec: cat /opt/bitnami/keycloak/version.txt
     exit-status: 0
     stdout:
-    - {{ .Env.APP_VERSION }}
+    - "{{ .Env.APP_VERSION }}"

--- a/.vib/ksql/goss/ksql.yaml
+++ b/.vib/ksql/goss/ksql.yaml
@@ -7,10 +7,10 @@ file:
     exists: true
     filetype: file
     contents:
-      - http://0.0.0.0:8088
-      - ksql.streams.state.dir = /bitnami/ksql/data
+      - "http://0.0.0.0:8088"
+      - "ksql.streams.state.dir = /bitnami/ksql/data"
   # ksql does not have a version flag so we check the version.txt
   /opt/bitnami/ksql/share/doc/confluent-kafka-mqtt/version.txt:
     exists: true
     contents:
-      - {{ .Env.APP_VERSION }}
+      - "{{ .Env.APP_VERSION }}"

--- a/.vib/mariadb/goss/mariadb.yaml
+++ b/.vib/mariadb/goss/mariadb.yaml
@@ -7,7 +7,7 @@ file:
     exists: true
     filetype: file
     contents:
-      - socket=/opt/bitnami/mariadb/tmp/mysql.sock
+      - "socket=/opt/bitnami/mariadb/tmp/mysql.sock"
   # Checks the postunpack phase properly creates the plugin's symlink
   /opt/bitnami/mariadb/lib/plugin:
     exists: true

--- a/.vib/matomo/goss/matomo.yaml
+++ b/.vib/matomo/goss/matomo.yaml
@@ -38,7 +38,7 @@ command:
     exec: php /opt/bitnami/matomo/console --version
     exit-status: 1
     stdout:
-      - {{ .Env.APP_VERSION }}
+      - "{{ .Env.APP_VERSION }}"
   # Since it is not done with sudo, the exit code is 1
   check-app-run:
     exec: php /opt/bitnami/matomo/console config:get --section=database

--- a/.vib/metallb-controller/goss/metallb-controller.yaml
+++ b/.vib/metallb-controller/goss/metallb-controller.yaml
@@ -9,7 +9,7 @@ command:
     exec: controller -webhook-mode test
     exit-status: 1
     stdout:
-      - {{ .Env.APP_VERSION }}
+      - "{{ .Env.APP_VERSION }}"
   check-metallb-controller-help:
     exec: controller --help
     exit-status: 0

--- a/.vib/metallb-speaker/goss/metallb-speaker.yaml
+++ b/.vib/metallb-speaker/goss/metallb-speaker.yaml
@@ -7,7 +7,7 @@ command:
     exec: speaker
     exit-status: 1
     stdout:
-      - {{ .Env.APP_VERSION }}
+      - "{{ .Env.APP_VERSION }}"
   check-metallb-speaker-help:
     exec: speaker --help
     exit-status: 0

--- a/.vib/milvus/goss/milvus.yaml
+++ b/.vib/milvus/goss/milvus.yaml
@@ -25,4 +25,4 @@ command:
     timeout: 20000
     exit-status: 0
     stdout:
-      - running Milvus components
+      - "running Milvus components"

--- a/.vib/minio-client/goss/minio-client.yaml
+++ b/.vib/minio-client/goss/minio-client.yaml
@@ -6,4 +6,4 @@ command:
     exec: mc --version | sed "s/\-0*/./g"
     exit-status: 0
     stdout:
-      - {{ .Env.APP_VERSION }}
+      - "{{ .Env.APP_VERSION }}"

--- a/.vib/minio/goss/minio.yaml
+++ b/.vib/minio/goss/minio.yaml
@@ -11,4 +11,4 @@ command:
     exec: minio --version | sed "s/\-0*/./g"
     exit-status: 0
     stdout:
-      - {{ .Env.APP_VERSION }}
+      - "{{ .Env.APP_VERSION }}"

--- a/.vib/mongodb-sharded/goss/mongodb-sharded.yaml
+++ b/.vib/mongodb-sharded/goss/mongodb-sharded.yaml
@@ -5,7 +5,7 @@ file:
   /opt/bitnami/mongodb/mongodb_get_source.txt:
     exists: true
     contents:
-      - This solution ships the official MongoDB Community binaries
+      - "This solution ships the official MongoDB Community binaries"
   /opt/bitnami/mongodb/conf/mongodb.conf:
     exists: true
     filetype: file

--- a/.vib/mongodb/goss/mongodb.yaml
+++ b/.vib/mongodb/goss/mongodb.yaml
@@ -6,7 +6,7 @@ file:
     mode: "0644"
     exists: true
     contents:
-      - This solution ships the official MongoDB Community binaries
+      - "This solution ships the official MongoDB Community binaries"
   /opt/bitnami/mongodb/logs/mongodb.log:
     exists: true
     filetype: symlink

--- a/.vib/moodle/goss/moodle.yaml
+++ b/.vib/moodle/goss/moodle.yaml
@@ -6,13 +6,13 @@ file:
     exists: true
     contents:
     {{ range $rule := .Vars.apache.rules }}
-      - {{ $rule }}
+      - "{{ $rule }}"
     {{ end }}
   /opt/bitnami/php/etc/php.ini:
     exists: true
     contents:
       # Checking if the php.ini keys and pqsql extension are set
-      - extension = pgsql
+      - "extension = pgsql"
       - /^memory_limit/
       - /^max_input_vars/
   /opt/bitnami/apache/conf/vhosts/moodle-https-vhost.conf:

--- a/.vib/mxnet/goss/mxnet.yaml
+++ b/.vib/mxnet/goss/mxnet.yaml
@@ -6,7 +6,7 @@ command:
     exec: python -c 'import mxnet; print(mxnet.__version__)'
     exit-status: 0
     stdout:
-      - {{ .Env.APP_VERSION }}
+      - "{{ .Env.APP_VERSION }}"
   # From: https://mxnet.apache.org/versions/1.8.0/api/python/docs/tutorials/packages/ndarray/02-ndarray-operations.html
   check-mxnet-operation:
     exec: python -c 'import mxnet as mx; a = mx.nd.ones((2, 3)); b = a * 2 + 1; b.asnumpy()'

--- a/.vib/mysql/goss/mysql.yaml
+++ b/.vib/mysql/goss/mysql.yaml
@@ -7,7 +7,7 @@ file:
     exists: true
     filetype: file
     contents:
-      - socket=/opt/bitnami/mysql/tmp/mysql.sock
+      - "socket=/opt/bitnami/mysql/tmp/mysql.sock"
   /opt/bitnami/mysql/logs/mysqld.log:
     exists: true
     filetype: symlink

--- a/.vib/nginx/goss/nginx.yaml
+++ b/.vib/nginx/goss/nginx.yaml
@@ -45,11 +45,11 @@ command:
     exit-status: 0
     stdout:
     {{ range $added_module := .Vars.modules.added }}
-      - nginx-module-{{ $added_module }}
+      - "nginx-module-{{ $added_module }}"
     {{ end }}
     {{ range $enabled_module := .Vars.modules.enabled }}
-      - with-{{ $enabled_module }}_module
+      - "with-{{ $enabled_module }}_module"
     {{ end }}
     {{ range $additional_config := .Vars.config_opts }}
-      - with-{{ $additional_config }}
+      - "with-{{ $additional_config }}"
     {{ end }}

--- a/.vib/node/goss/node.yaml
+++ b/.vib/node/goss/node.yaml
@@ -7,11 +7,11 @@ command:
     exec: "node -e \"console.log('Hello World')\""
     exit-status: 0
     stdout:
-      - Hello World
+      - "Hello World"
   check-global-modules:
     exec: npm list -g
     exit-status: 0
     stdout:
     {{ range $module := .Vars.modules }}
-      - {{ $module }}
+      - "{{ $module }}"
     {{ end }}

--- a/.vib/opencart/goss/opencart.yaml
+++ b/.vib/opencart/goss/opencart.yaml
@@ -7,7 +7,7 @@ command:
     exec: grep -Eo "'VERSION', '[^']*'" /opt/bitnami/opencart/index.php | sed -E 's/([0-9]+\.[0-9]+\.[0-9]+)\.([0-9]+)/\1-\2/'
     exit-status: 0
     stdout:
-      - {{ .Env.APP_VERSION }}
+      - "{{ .Env.APP_VERSION }}"
   check-enabled-modules:
     exec: php -m
     exit-status: 0

--- a/.vib/openldap/goss/openldap.yaml
+++ b/.vib/openldap/goss/openldap.yaml
@@ -25,7 +25,7 @@ command:
     exec: slappasswd -o module-load=/opt/bitnami/openldap/libexec/openldap/pw-sha2.so -h '{SHA256}' -s bitnami123
     exit-status: 0
     stdout:
-      - zbRYwNWa5lwE8+I7W+YIdh2pA/UhaZWJB+eJ7euy5Fc=
+      - "zbRYwNWa5lwE8+I7W+YIdh2pA/UhaZWJB+eJ7euy5Fc="
   check-enabled-backends:
     exec: slapd -VVV 2>&1
     exit-status: 0

--- a/.vib/openresty/goss/openresty.yaml
+++ b/.vib/openresty/goss/openresty.yaml
@@ -44,5 +44,5 @@ command:
     exec: openresty -V 2>&1
     exit-status: 0
     stdout:
-      - pcre-jit
-      - compat
+      - "pcre-jit"
+      - "compat"

--- a/.vib/parse-dashboard/goss/parse-dashboard.yaml
+++ b/.vib/parse-dashboard/goss/parse-dashboard.yaml
@@ -12,4 +12,4 @@ command:
     exec: grep "version" /opt/bitnami/parse-dashboard/package.json
     exit-status: 0
     stdout:
-      - {{ .Env.APP_VERSION }}
+      - "{{ .Env.APP_VERSION }}"

--- a/.vib/pgpool/goss/pgpool.yaml
+++ b/.vib/pgpool/goss/pgpool.yaml
@@ -6,8 +6,8 @@ command:
     exec: ldd /opt/bitnami/pgpool/bin/pgpool
     exit-status: 0
     stdout:
-      - libpam.so
-      - libssl.so
+      - "libpam.so"
+      - "libssl.so"
 file:
   /opt/bitnami/pgpool/logs/pgpool.log:
     exists: true

--- a/.vib/php-fpm/goss/php-fpm.yaml
+++ b/.vib/php-fpm/goss/php-fpm.yaml
@@ -11,32 +11,32 @@ file:
     exists: true
     filetype: file
     contents:
-      - upload_max_filesize = 40M
-      - opcache.revalidate_freq = 60
+      - "upload_max_filesize = 40M"
+      - "opcache.revalidate_freq = 60"
   /opt/bitnami/php/etc/common.conf:
     exists: true
     filetype: file
     contents:
-      - user=daemon
+      - "user=daemon"
   /opt/bitnami/php/etc/php-fpm.conf:
     exists: true
     filetype: file
     contents:
-      - error_log = /opt/bitnami/php/logs/php-fpm.log
+      - "error_log = /opt/bitnami/php/logs/php-fpm.log"
   /opt/bitnami/php/etc/php-fpm.d/www.conf:
     exists: true
     filetype: file
     contents:
-      - listen = 9000
-      - include=/opt/bitnami/php/etc/environment.conf
-      - include=/opt/bitnami/php/etc/common.conf
+      - "listen = 9000"
+      - "include=/opt/bitnami/php/etc/environment.conf"
+      - "include=/opt/bitnami/php/etc/common.conf"
 command:
   check-used-config:
     exec: php --ini
     exit-status: 0
     stdout:
-      - /opt/bitnami/php/lib/php.ini
-      - /opt/bitnami/php/etc/conf.d
+      - "/opt/bitnami/php/lib/php.ini"
+      - "/opt/bitnami/php/etc/conf.d"
   check-config-syntax:
     exec: php -l /opt/bitnami/php/etc/php-fpm.conf
     exit-status: 0
@@ -48,5 +48,5 @@ command:
       - /{{ $module }}.*enabled/
     {{ end }}
     {{ range $module := .Vars.modules.disabled }}
-      - disable-{{ $module }}
+      - "disable-{{ $module }}"
     {{ end }}

--- a/.vib/phpmyadmin/goss/phpmyadmin.yaml
+++ b/.vib/phpmyadmin/goss/phpmyadmin.yaml
@@ -19,8 +19,8 @@ file:
     exists: true
     filetype: file
     contents:
-      - post_max_size = 80M
-      - upload_max_filesize = 80M
+      - "post_max_size = 80M"
+      - "upload_max_filesize = 80M"
   # HTTP vhost should have been properly rendered
   /opt/bitnami/apache/conf/vhosts/phpmyadmin-vhost.conf:
     exists: true

--- a/.vib/postgresql/goss/postgresql.yaml
+++ b/.vib/postgresql/goss/postgresql.yaml
@@ -7,7 +7,7 @@ command:
   check-version:
     exec: {{ .Vars.version.bin_name }} {{ .Vars.version.flag }} | awk '{ if (split($NF, ver, ".") == 2) { $NF = $NF ".0" } print }'
     stdout:
-      - {{ .Env.APP_VERSION }}
+      - "{{ .Env.APP_VERSION }}"
     exit-status: 0
 file:
   /opt/bitnami/postgresql/logs/postgresql.log:

--- a/.vib/prestashop/goss/prestashop.yaml
+++ b/.vib/prestashop/goss/prestashop.yaml
@@ -6,7 +6,7 @@ command:
     exec: grep -Eo "'_PS_INSTALL_VERSION_', '[^']*'" /opt/bitnami/prestashop/install/install_version.php
     exit-status: 0
     stdout:
-      - {{ .Env.APP_VERSION }}
+      - "{{ .Env.APP_VERSION }}"
   check-enabled-modules:
     exec: php -m
     exit-status: 0
@@ -19,14 +19,14 @@ file:
     exists: true
     filetype: file
     contents:
-      - post_max_size = 128M
-      - upload_max_filesize = 128M
+      - "post_max_size = 128M"
+      - "upload_max_filesize = 128M"
   # Ensure that .htaccess file contents have not been moved to /opt/bitnami/apache/conf/vhosts/htaccess
   /opt/bitnami/prestashop/app/.htaccess:
     exists: true
     filetype: file
     contents:
-      - Require all denied
+      - "Require all denied"
   # HTTP vhost should have been properly rendered
   /opt/bitnami/apache/conf/vhosts/prestashop-vhost.conf:
     exists: true

--- a/.vib/prometheus-rsocket-proxy/goss/prometheus-rsocket-proxy.yaml
+++ b/.vib/prometheus-rsocket-proxy/goss/prometheus-rsocket-proxy.yaml
@@ -7,13 +7,13 @@ command:
     exec: ls /opt/bitnami/prometheus-rsocket-proxy/prometheus-rsocket-proxy-*.jar
     exit-status: 0
     stdout:
-    - {{ .Env.APP_VERSION }}
+    - "{{ .Env.APP_VERSION }}"
   check-proxy-jar:
     exec: timeout --preserve-status 10 java -jar /opt/bitnami/prometheus-rsocket-proxy/prometheus-rsocket-proxy.jar
     exit-status: 143
     timeout: 20000
     stdout:
-      - Started PrometheusRSocketProxy
+      - "Started PrometheusRSocketProxy"
 file:
   /opt/bitnami/prometheus-rsocket-proxy/prometheus-rsocket-proxy.jar:
     exists: true

--- a/.vib/pytorch/goss/pytorch.yaml
+++ b/.vib/pytorch/goss/pytorch.yaml
@@ -6,7 +6,7 @@ command:
     exec: python -c 'import torch; print(torch.__version__)'
     exit-status: 0
     stdout:
-      - {{ .Env.APP_VERSION }}
+      - "{{ .Env.APP_VERSION }}"
   check-torchvision-version:
     exec: python -c 'import torchvision; print(torchvision.__version__)'
     exit-status: 0

--- a/.vib/rabbitmq/goss/rabbitmq.yaml
+++ b/.vib/rabbitmq/goss/rabbitmq.yaml
@@ -7,8 +7,8 @@ command:
     exit-status: 0
     timeout: 120000
     stdout:
-      - have been enabled
-      - have been disabled
+      - "have been enabled"
+      - "have been disabled"
 file:
   /etc/rabbitmq:
     exists: true

--- a/.vib/rails/goss/rails.yaml
+++ b/.vib/rails/goss/rails.yaml
@@ -8,7 +8,7 @@ command:
     exec: "rails new /app && cd /app && timeout 10s rails s -p 4000 || true"
     exit-status: 0
     stdout:
-      - Listening
+      - "Listening"
   check-app-version:
   # The `APP_VERSION` environment variable returns the version in the format of
   # Major.Minor.Patch-Build, such as 1.2.3-4 while the `rails -v` command returns
@@ -17,11 +17,11 @@ command:
     exec: {{ .Vars.version.bin_name }} {{ .Vars.version.flag }} | sed '/ [0-9]\+\.[0-9]\+\.[0-9]\+$/ s/$/-0/' | sed "s/\.\([0-9]\)$/-\1/"
     exit-status: 0
     stdout:
-    - {{ .Env.APP_VERSION }}
+    - "{{ .Env.APP_VERSION }}"
   check-installed-gems:
     exec: gem list
     exit-status: 0
     stdout:
       {{ range $module := .Vars.modules }}
-      - {{ $module }}
+      - "{{ $module }}"
       {{ end }}

--- a/.vib/redis-cluster/goss/redis-cluster.yaml
+++ b/.vib/redis-cluster/goss/redis-cluster.yaml
@@ -8,8 +8,8 @@ file:
       - /port.*6379/
       - /dir.*/bitnami/redis/data/
       - /pidfile.*/opt/bitnami/redis/tmp/redis.pid/
-      - daemonize no
-      - cluster-enabled yes
+      - "daemonize no"
+      - "cluster-enabled yes"
       - /cluster-config-file.*/bitnami/redis/data/nodes.conf/
 command:
   check-redis-server:
@@ -17,16 +17,16 @@ command:
     exit-status: 0
     timeout: 10000
     stdout:
-      - Ready to accept connections
+      - "Ready to accept connections"
   check-redis-server-ssl:
     exec: ldd /opt/bitnami/redis/bin/redis-server
     exit-status: 0
     stdout:
-      - libcrypto.so
-      - libssl.so
+      - "libcrypto.so"
+      - "libssl.so"
   check-redis-cli-ssl:
     exec: ldd /opt/bitnami/redis/bin/redis-cli
     exit-status: 0
     stdout:
-      - libcrypto.so
-      - libssl.so
+      - "libcrypto.so"
+      - "libssl.so"

--- a/.vib/redis-sentinel/goss/redis-sentinel.yaml
+++ b/.vib/redis-sentinel/goss/redis-sentinel.yaml
@@ -5,24 +5,24 @@ file:
   /opt/bitnami/redis-sentinel/etc/sentinel.conf:
     exists: true
     contents:
-      - port 26379
-      - bind 0.0.0.0
+      - "port 26379"
+      - "bind 0.0.0.0"
       - /pidfile.*/opt/bitnami/redis-sentinel/tmp/redis-sentinel.pid/
-      - daemonize no
-      - logfile ""
+      - "daemonize no"
+      - 'logfile ""'
 command:
   check-redis-server:
     exec: timeout --preserve-status 5 redis-server /opt/bitnami/redis-sentinel/etc/sentinel.conf --sentinel
     exit-status: 0
     timeout: 10000
     stdout:
-      - Configuration loaded
+      - "Configuration loaded"
       - /monitor.*quorum/
   {{ range $binary := .Vars.binaries }}
   check-{{ $binary }}-ssl:
     exec: ldd /opt/bitnami/redis-sentinel/bin/{{ $binary }}
     exit-status: 0
     stdout:
-      - libcrypto.so
-      - libssl.so
+      - "libcrypto.so"
+      - "libssl.so"
   {{ end }}

--- a/.vib/redis/goss/redis.yaml
+++ b/.vib/redis/goss/redis.yaml
@@ -9,7 +9,7 @@ file:
       - /port.*6379/
       - /dir.*/bitnami/redis/data/
       - /pidfile.*/opt/bitnami/redis/tmp/redis.pid/
-      - daemonize yes
+      - "daemonize yes"
 command:
   check-redis-server:
     exec: redis-server /opt/bitnami/redis/etc/redis.conf && ps aux
@@ -21,11 +21,11 @@ command:
     exec: ldd /opt/bitnami/redis/bin/redis-server
     exit-status: 0
     stdout:
-      - libcrypto.so
-      - libssl.so
+      - "libcrypto.so"
+      - "libssl.so"
   check-redis-cli-ssl:
     exec: ldd /opt/bitnami/redis/bin/redis-cli
     exit-status: 0
     stdout:
-      - libcrypto.so
-      - libssl.so
+      - "libcrypto.so"
+      - "libssl.so"

--- a/.vib/reportserver/goss/reportserver.yaml
+++ b/.vib/reportserver/goss/reportserver.yaml
@@ -6,7 +6,7 @@ command:
     exec: cat /opt/bitnami/reportserver/WEB-INF/classes/rsversion.properties
     exit-status: 0
     stdout:
-      - {{ .Env.APP_VERSION }}
+      - "{{ .Env.APP_VERSION }}"
 user:
   tomcat:
     exists: true

--- a/.vib/ruby/goss/ruby.yaml
+++ b/.vib/ruby/goss/ruby.yaml
@@ -7,7 +7,7 @@ command:
     exit-status: 0
     stdout:
       {{ range $module := .Vars.modules }}
-      - {{ $module }}
+      - "{{ $module }}"
       {{ end }}
   check-ssl:
     exec: ruby -rnet/https -e "Net::HTTP.get URI('https://bitnami.com')"
@@ -17,7 +17,7 @@ command:
     exit-status: 0
     exec: grep -r {{ $flag }} /opt/bitnami/ruby/include/
     stdout:
-      - config.h
+      - "config.h"
   {{ end }}
   check-bundle:
     exec: cd /tmp && echo "source 'https://rubygems.org'" > Gemfile && bundle
@@ -26,4 +26,4 @@ command:
     exec: echo "task :test do; puts 'Hello VIB'; end" > /tmp/test-rake.rb && rake -f /tmp/test-rake.rb test
     exit-status: 0
     stdout:
-      - Hello VIB
+      - "Hello VIB"

--- a/.vib/schema-registry/goss/schema-registry.yaml
+++ b/.vib/schema-registry/goss/schema-registry.yaml
@@ -17,4 +17,4 @@ command:
     exit-status: 143
     timeout: 10000
     stdout:
-      - Adding listener
+      - "Adding listener"

--- a/.vib/solr/goss/solr.yaml
+++ b/.vib/solr/goss/solr.yaml
@@ -15,7 +15,7 @@ command:
     exec: JAVA_HOME=/opt/bitnami/solr/java /opt/bitnami/solr/bin/solr version
     exit-status: 0
     stdout:
-    - {{ .Env.APP_VERSION }}
+    - "{{ .Env.APP_VERSION }}"
 group:
   solr:
     exists: true

--- a/.vib/spring-cloud-dataflow-composed-task-runner/goss/spring-cloud-dataflow-composed-task-runner.yaml
+++ b/.vib/spring-cloud-dataflow-composed-task-runner/goss/spring-cloud-dataflow-composed-task-runner.yaml
@@ -7,7 +7,7 @@ command:
     exec: timeout --preserve-status 15 java -jar /opt/bitnami/spring-cloud-dataflow-composed-task-runner/scdf-composed-task-runner.jar
     exit-status: 1
     stdout:
-      - {{ .Env.APP_VERSION }}
+      - "{{ .Env.APP_VERSION }}"
 file:
   /opt/bitnami/spring-cloud-dataflow-composed-task-runner/scdf-composed-task-runner.jar:
     exists: true

--- a/.vib/spring-cloud-dataflow/goss/spring-cloud-dataflow.yaml
+++ b/.vib/spring-cloud-dataflow/goss/spring-cloud-dataflow.yaml
@@ -8,12 +8,12 @@ command:
     exec: timeout --preserve-status 30 java -jar /opt/bitnami/spring-cloud-dataflow/spring-cloud-dataflow.jar
     exit-status: 143
     stdout:
-      - Started DataFlowServerApplication
+      - "Started DataFlowServerApplication"
   check-spring-cloud-dataflow-version:
     exec: output=$(mktemp -d); cd $output; jar xf /opt/bitnami/spring-cloud-dataflow/spring-cloud-dataflow.jar; cat ./BOOT-INF/classes/application.yml
     exit-status: 0
     stdout:
-      - {{ .Env.APP_VERSION }}
+      - "{{ .Env.APP_VERSION }}"
 file:
   /opt/bitnami/spring-cloud-dataflow/spring-cloud-dataflow.jar:
     exists: true

--- a/.vib/spring-cloud-skipper/goss/spring-cloud-skipper.yaml
+++ b/.vib/spring-cloud-skipper/goss/spring-cloud-skipper.yaml
@@ -7,7 +7,7 @@ command:
     exec: timeout --preserve-status 25 java -jar /opt/bitnami/spring-cloud-skipper/spring-cloud-skipper.jar
     exit-status: 143
     stdout:
-      - Started SkipperServerApplication
+      - "Started SkipperServerApplication"
 file:
   /opt/bitnami/spring-cloud-skipper/spring-cloud-skipper.jar:
     exists: true

--- a/.vib/suitecrm/goss/suitecrm.yaml
+++ b/.vib/suitecrm/goss/suitecrm.yaml
@@ -7,7 +7,7 @@ command:
     exec: find /opt/bitnami/suitecrm -maxdepth 3 -type f -name suitecrm_version.php -exec grep -Eo "version = '([0-9.]+)'" {} \;
     exit-status: 0
     stdout:
-      - version = '{{ .Env.APP_VERSION }}'
+      - 'version = "{{ .Env.APP_VERSION }}"'
   check-enabled-modules:
     exec: php -m
     exit-status: 0
@@ -20,8 +20,8 @@ file:
     exists: true
     filetype: file
     contents:
-      - post_max_size = 60M
-      - upload_max_filesize = 128M
+      - "post_max_size = 60M"
+      - "upload_max_filesize = 128M"
   /opt/bitnami/suitecrm/node_modules:
     exists: false
   # Disabling opcache to be able to modify parameters using the system setting panel
@@ -29,7 +29,7 @@ file:
     exists: true
     filetype: file
     contents:
-      - opcache.enable = Off
+      - "opcache.enable = Off"
   # HTTP vhost should have been properly rendered
   /opt/bitnami/apache/conf/vhosts/suitecrm-vhost.conf:
     exists: true

--- a/.vib/supabase-postgres-meta/goss/supabase-postgres-meta.yaml
+++ b/.vib/supabase-postgres-meta/goss/supabase-postgres-meta.yaml
@@ -7,5 +7,5 @@ command:
     timeout: 8000
     exit-status: 0
     stdout:
-      - node dist/server/server.js
-      - Server listening
+      - "node dist/server/server.js"
+      - "Server listening"

--- a/.vib/supabase-storage/goss/supabase-storage.yaml
+++ b/.vib/supabase-storage/goss/supabase-storage.yaml
@@ -6,4 +6,4 @@ command:
     exec: cd /opt/bitnami/supabase-storage; npm run
     exit-status: 0
     stdout:
-      - node dist/server.js
+      - "node dist/server.js"

--- a/.vib/supabase-studio/goss/supabase-studio.yaml
+++ b/.vib/supabase-studio/goss/supabase-studio.yaml
@@ -7,5 +7,5 @@ command:
     timeout: 8000
     exit-status: 0
     stdout:
-      - next start
-      - started server
+      - "next start"
+      - "started server"

--- a/.vib/tomcat-jdk-11/goss/tomcat-jdk-11.yaml
+++ b/.vib/tomcat-jdk-11/goss/tomcat-jdk-11.yaml
@@ -19,7 +19,7 @@ command:
     exec: version.sh
     exit-status: 0
     stdout:
-    - {{ .Env.APP_VERSION }}
+    - "{{ .Env.APP_VERSION }}"
 group:
   tomcat:
     exists: true

--- a/.vib/tomcat-jdk-17/goss/tomcat-jdk-17.yaml
+++ b/.vib/tomcat-jdk-17/goss/tomcat-jdk-17.yaml
@@ -19,7 +19,7 @@ command:
     exec: version.sh
     exit-status: 0
     stdout:
-    - {{ .Env.APP_VERSION }}
+    - "{{ .Env.APP_VERSION }}"
 group:
   tomcat:
     exists: true

--- a/.vib/tomcat/goss/tomcat.yaml
+++ b/.vib/tomcat/goss/tomcat.yaml
@@ -19,7 +19,7 @@ command:
     exec: version.sh
     exit-status: 0
     stdout:
-    - {{ .Env.APP_VERSION }}
+    - "{{ .Env.APP_VERSION }}"
 group:
   tomcat:
     exists: true

--- a/.vib/trivy/goss/trivy.yaml
+++ b/.vib/trivy/goss/trivy.yaml
@@ -7,4 +7,4 @@ command:
     timeout: 60000
     exit-status: 0
     stdout:
-      - CVE-2020-1751
+      - "CVE-2020-1751"

--- a/.vib/wordpress-nginx/goss/wordpress-nginx.yaml
+++ b/.vib/wordpress-nginx/goss/wordpress-nginx.yaml
@@ -6,7 +6,7 @@ command:
     exec: sed -nE "s/.wp_version\s*=\s*'([0-9\.]+)';/\1/p" /opt/bitnami/wordpress/wp-includes/version.php | sed -E 's/^[0-9]+\.[0-9]+$/&.0/'
     exit-status: 0
     stdout:
-      - {{ .Env.APP_VERSION }}
+      - "{{ .Env.APP_VERSION }}"
   # WP-CLI points to correct binaries and config file
   check-wp-cli-conf:
     exec: wp --info

--- a/.vib/wordpress/goss/wordpress.yaml
+++ b/.vib/wordpress/goss/wordpress.yaml
@@ -6,7 +6,7 @@ command:
     exec: sed -nE "s/.wp_version\s*=\s*'([0-9\.]+)';/\1/p" /opt/bitnami/wordpress/wp-includes/version.php | sed -E 's/^[0-9]+\.[0-9]+$/&.0/'
     exit-status: 0
     stdout:
-      - {{ .Env.APP_VERSION }}
+      - "{{ .Env.APP_VERSION }}"
   # WP-CLI points to correct binaries and config file
   check-wp-cli-conf:
     exec: wp --info


### PR DESCRIPTION
In this new version, the output is expected as a string instead of as an integer

Without quotes:
```console
$ goss --gossfile .vib/clickhouse/goss/goss.yaml --vars .vib/clickhouse/runtime-parameters.yaml render
...
  check-cluster-status:
    stdout:
    - 4
  create-database-in-cluster:
    stdout:
    - 23
```

Quoting the value:
```console
$ goss --gossfile .vib/clickhouse/goss/goss.yaml --vars .vib/clickhouse/runtime-parameters.yaml render
...
  check-cluster-status:
    stdout:
    - "4"
  create-database-in-cluster:
    stdout:
    - "23"
```

Since any integer in `contents:` and `stdout:` is expected to be treated as a string, we opted for quoting any variable or hardcoded value except regexps so we don't need to care about the type.