### PR TITLE
Add support for memberOf overlay

### DIFF
--- a/bitnami/openldap/2.6/debian-11/rootfs/opt/bitnami/scripts/libopenldap.sh
+++ b/bitnami/openldap/2.6/debian-11/rootfs/opt/bitnami/scripts/libopenldap.sh
@@ -86,6 +86,14 @@ export LDAP_ACCESSLOG_LOGOLDATTR="${LDAP_ACCESSLOG_LOGOLDATTR:-objectClass}"
 export LDAP_ACCESSLOG_ADMIN_USERNAME="${LDAP_ACCESSLOG_ADMIN_USERNAME:-admin}"
 export LDAP_ACCESSLOG_ADMIN_DN="${LDAP_ACCESSLOG_ADMIN_USERNAME/#/cn=},${LDAP_ACCESSLOG_DB:-cn=accesslog}"
 export LDAP_ACCESSLOG_ADMIN_PASSWORD="${LDAP_ACCESSLOG_PASSWORD:-accesspassword}"
+export LDAP_ENABLE_MEMBEROF="${LDAP_ENABLE_MEMBEROF:-no}"
+export LDAP_MEMBEROF_DN="${LDAP_MEMBEROF_DN:-${LDAP_ROOT}}"
+export LDAP_MEMBEROF_DANGLING="${LDAP_MEMBEROF_DANGLING:-ignore}"
+export LDAP_MEMBEROF_DANGLINGERROR="${LDAP_MEMBEROF_DANGLINGERROR:-80}"
+export LDAP_MEMBEROF_REFINT="${LDAP_MEMBEROF_REFINT:-FALSE}"
+export LDAP_MEMBEROF_GROUPOC="${LDAP_MEMBEROF_GROUPOC:-groupOfNames}"
+export LDAP_MEMBEROF_MEMBERAD="${LDAP_MEMBEROF_MEMBERAD:-member}"
+export LDAP_MEMBEROF_MEMBEROFAD="${LDAP_MEMBEROF_MEMBEROFAD:-memberOf}"
 export LDAP_ENABLE_SYNCPROV="${LDAP_ENABLE_SYNCPROV:-no}"
 export LDAP_SYNCPROV_CHECKPPOINT="${LDAP_SYNCPROV_CHECKPPOINT:-100 10}"
 export LDAP_SYNCPROV_SESSIONLOG="${LDAP_SYNCPROV_SESSIONLOG:-100}"
@@ -636,6 +644,10 @@ ldap_initialize() {
         if is_boolean_yes "$LDAP_ENABLE_ACCESSLOG"; then
             ldap_enable_accesslog
         fi
+        # enable memberof overlay
+        if is_boolean_yes "$LDAP_ENABLE_MEMBEROF"; then
+            ldap_enable_memberof
+        fi
         # enable syncprov overlay
         if is_boolean_yes "$LDAP_ENABLE_SYNCPROV"; then
             ldap_enable_syncprov
@@ -889,6 +901,37 @@ olcAccessLogOldAttr: $LDAP_ACCESSLOG_LOGOLDATTR
 EOF
     info "adding accesslog_create_overlay_configuration.ldif"
     debug_execute ldapadd -Q -Y EXTERNAL -H "ldapi:///" -f "${LDAP_SHARE_DIR}/accesslog_create_overlay_configuration.ldif"
+}
+
+########################
+# OpenLDAP configure Reverse Group Membership Maintenance
+# Globals:
+#   LDAP_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+ldap_enable_memberof() {
+    info "Configure Reverse Group Membership Maintenance"
+    # Load module
+    ldap_load_module "/opt/bitnami/openldap/lib/openldap" "memberof.so"
+    # Add Reverse Group Membership Maintenance overlay
+    cat > "${LDAP_SHARE_DIR}/memberof_create_overlay_configuration.ldif" << EOF
+dn: olcOverlay=memberof,olcDatabase={2}mdb,cn=config
+objectClass: olcOverlayConfig
+objectClass: olcMemberOfConfig
+olcOverlay: memberof
+olcMemberOfDN: $LDAP_MEMBEROF_DN
+olcMemberOfDangling: $LDAP_MEMBEROF_DANGLING
+olcMemberOfDanglingError: $LDAP_MEMBEROF_DANGLINGERROR
+olcMemberOfRefInt: $LDAP_MEMBEROF_REFINT
+olcMemberOfGroupOC: $LDAP_MEMBEROF_GROUPOC
+olcMemberOfMemberAD: $LDAP_MEMBEROF_MEMBERAD
+olcMemberOfMemberOfAD: $LDAP_MEMBEROF_MEMBEROFAD
+EOF
+    cat "${LDAP_SHARE_DIR}/memberof_create_overlay_configuration.ldif"
+    debug_execute ldapadd -Q -Y EXTERNAL -H "ldapi:///" -f "${LDAP_SHARE_DIR}/memberof_create_overlay_configuration.ldif"
 }
 
 ########################

--- a/bitnami/openldap/README.md
+++ b/bitnami/openldap/README.md
@@ -226,6 +226,19 @@ This overlay can record accesses to a given backend database on another database
 
 Check the official page [OpenLDAP, Overlays, Access Logging](https://www.openldap.org/doc/admin26/overlays.html#Access%20Logging) for detailed configuration information.
 
+#### Reverse Group Membership Maintenance
+
+* `LDAP_ENABLE_MEMBEROF`: Enables the memberof module with the following configuration defaults unless specified otherwise. Default: **no**.
+* `LDAP_MEMBEROF_DN` : The DN that is used as modifiersName for internal modifications performed to update the reverse group membership. Will only be applied with `LDAP_ENABLE_MEMBEROF` active. Default: **rootdn of the underlying database**.
+* `LDAP_MEMBEROF_DANGLING` : Specifies the behavior when a member is deleted or modified in a way that would break the group membership. Will only be applied with `LDAP_ENABLE_MEMBEROF` active. Default: **ignore**.
+* `LDAP_MEMBEROF_DANGLINGERROR` : Can be used to modify the response code returned in case of violation. Will only be applied with `LDAP_ENABLE_MEMBEROF` active. Default: {constraint violation} **80**.
+* `LDAP_MEMBEROF_REFINT` : Determines whether the overlay will try to preserve referential integrity or not. Will only be applied with `LDAP_ENABLE_MEMBEROF` active. Must be {true|false}. Default: **FALSE**.
+* `LDAP_MEMBEROF_GROUPOC` : The name of the objectClass that triggers the reverse group membership update. Will only be applied with `LDAP_ENABLE_MEMBEROF` active. Default: **groupOfNames**.
+* `LDAP_MEMBEROF_MEMBERAD` : The name of the attribute that contains the names of the members in the group objects; it must be DN-valued. Will only be applied with `LDAP_ENABLE_MEMBEROF` active. Default: **member**.
+* `LDAP_MEMBEROF_MEMBEROFAD` : The name of  the attribute that contains the names of the groups an entry is member of; it must be DN-valued. Will only be applied with `LDAP_ENABLE_MEMBEROF` active. Default: **memberOf**.
+
+Check the official page [OpenLDAP, Overlays, Reverse Group Membership Maintenance](https://www.openldap.org/doc/admin26/overlays.html#Reverse%20Group%20Membership%20Maintenance) for detailed configuration information.
+
 #### Sync Provider
 
 * `LDAP_ENABLE_SYNCPROV`: Enables the syncrepl module with the following configuration defaults unless specified otherwise. Default: **no**.


### PR DESCRIPTION
### Description of the change

This change extends the existing [bitnami/openldap:2.6] container deployment with configurable support for the existing memberOf module:

- Reverse Group Membership Maintenance `memberOf`

### Benefits

Future users of the [bitnami/openldap] container will be able to access the Reverse Group Membership Maintenance module and functionality with minimal configuration.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

This change enabled the capability required to support the use case described in [this](https://github.com/bitnami/containers/issues/50524) issue
