### PR TITLE
[bitnami/postegresql-repmgr] Added missing postgresql environment variables

### DIFF
--- a/bitnami/postgresql-repmgr/README.md
+++ b/bitnami/postgresql-repmgr/README.md
@@ -595,6 +595,11 @@ Please see the list of environment variables available in the Bitnami PostgreSQL
 | POSTGRESQL_TLS_CA_FILE                 | `nil`         |
 | POSTGRESQL_TLS_CRL_FILE                | `nil`         |
 | POSTGRESQL_TLS_PREFER_SERVER_CIPHERS   | `yes`         |
+| POSTGRESQL_MAX_CONNECTIONS             | `100`         |
+| POSTGRESQL_TCP_KEEPALIVES_IDLE         | `0`           |
+| POSTGRESQL_TCP_KEEPALIVES_INTERVAL     | `0`           |
+| POSTGRESQL_TCP_KEEPALIVES_COUNT        | `0`           |
+| POSTGRESQL_STATEMENT_TIMEOUT           | `0`           |
 
 ## Logging
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Added missing postgresql environment variables regarding connections to README.md

### Benefits

Developers can see them without looking into the code. 

### Possible drawbacks

None

### Applicable issues

- workarround for #52130

### Additional information

POSTGRESQL_EXTRA_FLAGS is ignored and it is not possible to pass start parameters to PostgreSQL server.
