### PR TITLE
[bitnami/grafana] Replace deprecated grafana command usage

### DIFF
--- a/.vib/grafana/goss/grafana.yaml
+++ b/.vib/grafana/goss/grafana.yaml
@@ -4,7 +4,7 @@
 command:
   check-grafana-plugins:
     exit-status: 0
-    exec: grafana-cli --pluginsDir /opt/bitnami/grafana/default-plugins/ plugins ls
+    exec: grafana cli --pluginsDir /opt/bitnami/grafana/default-plugins/ plugins ls
     stdout:
     {{ range $plugin := .Vars.plugins }}
       - "{{ $plugin }}"

--- a/.vib/grafana/goss/vars.yaml
+++ b/.vib/grafana/goss/vars.yaml
@@ -1,6 +1,5 @@
 binaries:
   - grafana
-  - grafana-cli
 root_dir: /opt/bitnami
 version:
   bin_name: grafana

--- a/bitnami/grafana/10/debian-11/rootfs/opt/bitnami/scripts/grafana/postunpack.sh
+++ b/bitnami/grafana/10/debian-11/rootfs/opt/bitnami/scripts/grafana/postunpack.sh
@@ -63,7 +63,7 @@ grafana_plugin_list=(
 )
 for plugin in "${grafana_plugin_list[@]}"; do
     info "Installing ${plugin} plugin"
-    grafana-cli --pluginsDir "$(grafana_env_var_value PATHS_PLUGINS)" plugins install "$plugin"
+    grafana cli --pluginsDir "$(grafana_env_var_value PATHS_PLUGINS)" plugins install "$plugin"
 done
 
 # The Grafana Helm chart mounts the data directory at "/opt/bitnami/grafana/data"

--- a/bitnami/grafana/10/debian-11/rootfs/opt/bitnami/scripts/grafana/run.sh
+++ b/bitnami/grafana/10/debian-11/rootfs/opt/bitnami/scripts/grafana/run.sh
@@ -16,8 +16,9 @@ set -o pipefail
 . /opt/bitnami/scripts/libos.sh
 . /opt/bitnami/scripts/liblog.sh
 
-declare cmd="grafana-server"
+declare cmd="grafana"
 declare -a args=(
+    "server"
     # Based on https://github.com/grafana/grafana/blob/v8.2.5/packaging/docker/run.sh
     "--homepath=${GF_PATHS_HOME}"
     "--config=${GF_PATHS_CONFIG}"

--- a/bitnami/grafana/10/debian-11/rootfs/opt/bitnami/scripts/libgrafana.sh
+++ b/bitnami/grafana/10/debian-11/rootfs/opt/bitnami/scripts/libgrafana.sh
@@ -223,8 +223,9 @@ EOF
 #   None
 #########################
 grafana_start_bg() {
-    local cmd="grafana-server"
+    local cmd="grafana"
     local -a args=(
+        "server"
         # Based on https://github.com/grafana/grafana/blob/v8.2.5/packaging/docker/run.sh
         "--homepath=${GF_PATHS_HOME}"
         "--config=${GF_PATHS_CONFIG}"
@@ -339,7 +340,7 @@ grafana_install_plugins() {
         if [[ -n "$plugin_version" ]]; then
             grafana_plugin_install_args+=("$plugin_version")
         fi
-        grafana-cli "${grafana_plugin_install_args[@]}"
+        grafana cli "${grafana_plugin_install_args[@]}"
     done
 }
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Replaces `grafana-cli` and `grafana-server` with `grafana cli` and `grafana server`, respectively, per the warnings logged in the image during build and run.

### Benefits
No more deprecation warnings emitted.

### Possible drawbacks
None

### Applicable issues
- fixes #52256

### Additional information

Change in commands and deprecation warnings appears to have been introduced in Grafana v10: https://github.com/grafana/grafana/pull/66976
