### PR TITLE
[bitnami/redis-cluster] add info severity to logs

### DIFF
--- a/bitnami/appsmith/1/debian-11/Dockerfile
+++ b/bitnami/appsmith/1/debian-11/Dockerfile
@@ -7,10 +7,10 @@ ARG TARGETARCH
 
 LABEL com.vmware.cp.artifact.flavor="sha256:1e1b4657a77f0d47e9220f0c37b9bf7802581b93214fff7d1bd2364c8bf22e8e" \
       org.opencontainers.image.base.name="docker.io/bitnami/minideb:bullseye" \
-      org.opencontainers.image.created="2023-10-25T14:04:14Z" \
+      org.opencontainers.image.created="2023-11-02T09:56:06Z" \
       org.opencontainers.image.description="Application packaged by VMware, Inc" \
       org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.ref.name="1.9.42-debian-11-r0" \
+      org.opencontainers.image.ref.name="1.9.42-debian-11-r1" \
       org.opencontainers.image.title="appsmith" \
       org.opencontainers.image.vendor="VMware, Inc." \
       org.opencontainers.image.version="1.9.42"
@@ -26,14 +26,14 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN install_packages acl ca-certificates curl gettext libbz2-1.0 libcom-err2 libcrypt1 libffi7 libgcc-s1 libgeoip1 libgssapi-krb5-2 libk5crypto3 libkeyutils1 libkrb5-3 libkrb5support0 liblzma5 libncursesw6 libnsl2 libpcre3 libreadline8 libsqlite3-0 libssl1.1 libstdc++6 libtinfo6 libtirpc3 openssl procps zlib1g
 RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ && \
     COMPONENTS=( \
-      "python-3.11.6-6-linux-${OS_ARCH}-debian-11" \
+      "python-3.11.6-8-linux-${OS_ARCH}-debian-11" \
       "wait-for-port-1.0.7-2-linux-${OS_ARCH}-debian-11" \
       "render-template-1.0.6-2-linux-${OS_ARCH}-debian-11" \
       "node-18.18.2-0-linux-${OS_ARCH}-debian-11" \
       "nginx-1.25.3-0-linux-${OS_ARCH}-debian-11" \
       "mongodb-shell-2.0.2-0-linux-${OS_ARCH}-debian-11" \
       "java-17.0.9-11-1-linux-${OS_ARCH}-debian-11" \
-      "appsmith-1.9.42-0-linux-${OS_ARCH}-debian-11" \
+      "appsmith-1.9.42-3-linux-${OS_ARCH}-debian-11" \
     ) && \
     for COMPONENT in "${COMPONENTS[@]}"; do \
       if [ ! -f "${COMPONENT}.tar.gz" ]; then \

--- a/bitnami/appsmith/1/debian-11/prebuildfs/opt/bitnami/.bitnami_components.json
+++ b/bitnami/appsmith/1/debian-11/prebuildfs/opt/bitnami/.bitnami_components.json
@@ -3,7 +3,7 @@
         "arch": "amd64",
         "distro": "debian-11",
         "type": "NAMI",
-        "version": "1.9.42-0"
+        "version": "1.9.42-3"
     },
     "java": {
         "arch": "amd64",
@@ -33,7 +33,7 @@
         "arch": "amd64",
         "distro": "debian-11",
         "type": "NAMI",
-        "version": "3.11.6-6"
+        "version": "3.11.6-8"
     },
     "render-template": {
         "arch": "amd64",

--- a/bitnami/ghost/5/debian-11/Dockerfile
+++ b/bitnami/ghost/5/debian-11/Dockerfile
@@ -7,13 +7,13 @@ ARG TARGETARCH
 
 LABEL com.vmware.cp.artifact.flavor="sha256:1e1b4657a77f0d47e9220f0c37b9bf7802581b93214fff7d1bd2364c8bf22e8e" \
       org.opencontainers.image.base.name="docker.io/bitnami/minideb:bullseye" \
-      org.opencontainers.image.created="2023-10-30T12:19:11Z" \
+      org.opencontainers.image.created="2023-11-02T09:50:29Z" \
       org.opencontainers.image.description="Application packaged by VMware, Inc" \
       org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.ref.name="5.71.0-debian-11-r0" \
+      org.opencontainers.image.ref.name="5.71.1-debian-11-r0" \
       org.opencontainers.image.title="ghost" \
       org.opencontainers.image.vendor="VMware, Inc." \
-      org.opencontainers.image.version="5.71.0"
+      org.opencontainers.image.version="5.71.1"
 
 ENV HOME="/" \
     OS_ARCH="${TARGETARCH:-amd64}" \
@@ -29,7 +29,7 @@ RUN mkdir -p /tmp/bitnami/pkg/cache/ && cd /tmp/bitnami/pkg/cache/ && \
       "python-3.11.6-8-linux-${OS_ARCH}-debian-11" \
       "node-18.18.2-0-linux-${OS_ARCH}-debian-11" \
       "mysql-client-10.11.5-1-linux-${OS_ARCH}-debian-11" \
-      "ghost-5.71.0-0-linux-${OS_ARCH}-debian-11" \
+      "ghost-5.71.1-1-linux-${OS_ARCH}-debian-11" \
     ) && \
     for COMPONENT in "${COMPONENTS[@]}"; do \
       if [ ! -f "${COMPONENT}.tar.gz" ]; then \
@@ -47,7 +47,7 @@ RUN chmod g+rwX /opt/bitnami
 COPY rootfs /
 RUN /opt/bitnami/scripts/ghost/postunpack.sh
 RUN /opt/bitnami/scripts/mysql-client/postunpack.sh
-ENV APP_VERSION="5.71.0" \
+ENV APP_VERSION="5.71.1" \
     BITNAMI_APP_NAME="ghost" \
     PATH="/opt/bitnami/python/bin:/opt/bitnami/node/bin:/opt/bitnami/mysql/bin:/opt/bitnami/ghost/bin:$PATH"
 

--- a/bitnami/ghost/5/debian-11/prebuildfs/opt/bitnami/.bitnami_components.json
+++ b/bitnami/ghost/5/debian-11/prebuildfs/opt/bitnami/.bitnami_components.json
@@ -3,7 +3,7 @@
         "arch": "amd64",
         "distro": "debian-11",
         "type": "NAMI",
-        "version": "5.71.0-0"
+        "version": "5.71.1-1"
     },
     "mysql-client": {
         "arch": "amd64",

--- a/bitnami/ghost/5/debian-11/tags-info.yaml
+++ b/bitnami/ghost/5/debian-11/tags-info.yaml
@@ -1,5 +1,5 @@
 rolling-tags:
 - "5"
 - 5-debian-11
-- 5.71.0
+- 5.71.1
 - latest

--- a/bitnami/redis-cluster/7.2/debian-11/prebuildfs/opt/bitnami/scripts/libbitnami.sh
+++ b/bitnami/redis-cluster/7.2/debian-11/prebuildfs/opt/bitnami/scripts/libbitnami.sh
@@ -45,9 +45,9 @@ print_image_welcome_page() {
     local github_url="https://github.com/bitnami/containers"
 
     log ""
-    log "${BOLD}Welcome to the Bitnami ${BITNAMI_APP_NAME} container${RESET}"
-    log "Subscribe to project updates by watching ${BOLD}${github_url}${RESET}"
-    log "Submit issues and feature requests at ${BOLD}${github_url}/issues${RESET}"
+    info "${BOLD}Welcome to the Bitnami ${BITNAMI_APP_NAME} container${RESET}"
+    info "Subscribe to project updates by watching ${BOLD}${github_url}${RESET}"
+    info "Submit issues and feature requests at ${BOLD}${github_url}/issues${RESET}"
     log ""
 }
 

--- a/bitnami/redis-cluster/7.2/debian-11/rootfs/opt/bitnami/scripts/librediscluster.sh
+++ b/bitnami/redis-cluster/7.2/debian-11/rootfs/opt/bitnami/scripts/librediscluster.sh
@@ -224,7 +224,7 @@ redis_cluster_update_ips() {
             newIP=$(wait_for_dns_lookup "${host_and_port[0]}" "$REDIS_DNS_RETRIES" 5)
             # The node can be new if we are updating the cluster, so catch the unbound variable error
             if [[ ${host_2_ip_array[$node]+true} ]]; then
-                echo "Changing old IP ${host_2_ip_array[$node]} by the new one ${newIP}"
+                info "Changing old IP ${host_2_ip_array[$node]} by the new one ${newIP}"
                 nodesFile=$(sed "s/ ${host_2_ip_array[$node]}:/ $newIP<NEWIP>:/g" "${REDIS_DATA_DIR}/nodes.conf")
                 echo "$nodesFile" >"${REDIS_DATA_DIR}/nodes.conf"
             fi


### PR DESCRIPTION
## Name and Version
bitnami/redis-cluster:7.2.1-debian-11-r0

## What is the problem this feature will solve?
We are collecting our logs via open telemetry. I have seen that there are log entries without severity.
e.g.

```
redis-cluster 09:09:59.12 Subscribe to project updates by watching https://github.com/bitnami/containers
redis-cluster 09:09:59.12 Submit issues and feature requests at https://github.com/bitnami/containers/issues 
Changing old IP x.x.x.x by the new one x.x.x.x 
```

see also Issue: https://github.com/bitnami/containers/issues/51496

## Changing to 
```
redis-cluster 09:09:59.12 INFO Subscribe to project updates by watching https://github.com/bitnami/containers
redis-cluster 09:09:59.12 INFO Submit issues and feature requests at https://github.com/bitnami/containers/issues
09:09:59.12 INFO Changing old IP x.x.x.x by the new one x.x.x.x
```
