### PR TITLE
[bitnami/mongodb] Check for MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD when setting auth config

### DIFF
--- a/bitnami/mongodb/5.0/debian-11/rootfs/opt/bitnami/scripts/libmongodb.sh
+++ b/bitnami/mongodb/5.0/debian-11/rootfs/opt/bitnami/scripts/libmongodb.sh
@@ -606,7 +606,7 @@ mongodb_set_auth_conf() {
     local authorization
 
     if ! mongodb_is_file_external "$conf_file_name"; then
-        if [[ -n "$MONGODB_ROOT_PASSWORD" ]] || [[ -n "$MONGODB_PASSWORD" ]]; then
+        if [[ -n "$MONGODB_ROOT_PASSWORD" ]] || [[ -n "$MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD" ]] || [[ -n "$MONGODB_PASSWORD" ]]; then
             authorization="$(yq eval .security.authorization "$MONGODB_CONF_FILE")"
             if [[ "$authorization" = "disabled" ]]; then
 

--- a/bitnami/mongodb/6.0/debian-11/rootfs/opt/bitnami/scripts/libmongodb.sh
+++ b/bitnami/mongodb/6.0/debian-11/rootfs/opt/bitnami/scripts/libmongodb.sh
@@ -606,7 +606,7 @@ mongodb_set_auth_conf() {
     local authorization
 
     if ! mongodb_is_file_external "$conf_file_name"; then
-        if [[ -n "$MONGODB_ROOT_PASSWORD" ]] || [[ -n "$MONGODB_PASSWORD" ]]; then
+        if [[ -n "$MONGODB_ROOT_PASSWORD" ]] || [[ -n "$MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD" ]] || [[ -n "$MONGODB_PASSWORD" ]]; then
             authorization="$(yq eval .security.authorization "$MONGODB_CONF_FILE")"
             if [[ "$authorization" = "disabled" ]]; then
 

--- a/bitnami/mongodb/7.0/debian-11/rootfs/opt/bitnami/scripts/libmongodb.sh
+++ b/bitnami/mongodb/7.0/debian-11/rootfs/opt/bitnami/scripts/libmongodb.sh
@@ -606,7 +606,7 @@ mongodb_set_auth_conf() {
     local authorization
 
     if ! mongodb_is_file_external "$conf_file_name"; then
-        if [[ -n "$MONGODB_ROOT_PASSWORD" ]] || [[ -n "$MONGODB_PASSWORD" ]]; then
+        if [[ -n "$MONGODB_ROOT_PASSWORD" ]] || [[ -n "$MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD" ]] || [[ -n "$MONGODB_PASSWORD" ]]; then
             authorization="$(yq eval .security.authorization "$MONGODB_CONF_FILE")"
             if [[ "$authorization" = "disabled" ]]; then
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This change will check for the environment variable `MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD` when setting the auth config to enabled. 

### Benefits

This ensures that the auth for the secondary and hidden nodes for a replica set match the intended setting.

### Possible drawbacks

Perhaps there is a reason not to set auth to true here, but i am not aware of it. 

### Additional information

The reason for this change is that we noticed authentication wasn't being enabled on non-primary nodes. We considered this a risk since in a fail-over scenario a non-authenticated connection may be possible. 

The cause of this was tricky to find but was from these sections of code: 
https://github.com/bitnami/charts/blob/79261efe92efeed696bc103c5cfe7b905debb1b9/bitnami/mongodb/templates/replicaset/scripts-configmap.yaml#L150C1-L161C7
https://github.com/bitnami/containers/blob/f0b4bb159750ebf73a34dfc3e6fa5f3ed042bdb8/bitnami/mongodb/5.0/debian-11/rootfs/opt/bitnami/scripts/libmongodb.sh#L609C11-L609C11

It appears that the chart was unsetting the `MONGODB_ROOT_PASSWORD` environment variable in favor of the `MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD` in non-primary nodes. My guess here is that this is to signal during node initialization that the root user credentials will be replicated from the primary, and to not attempt to make a root user on the non-primary node. 

However without the `MONGODB_ROOT_PASSWORD` environment variable, and in the case where additional usernames and passwords are being provided, the `mongodb_set_auth_conf()` function was not executing. 

In our opinion this should execute on non-primary nodes when authentication is enabled. 


