### PR TITLE
[bitnami/redis-cluster] add info level to logs Signed-off-by: Schneidenwind Christine (LDC) <…

### DIFF
--- a/bitnami/redis-cluster/7.2/debian-11/prebuildfs/opt/bitnami/scripts/libbitnami.sh
+++ b/bitnami/redis-cluster/7.2/debian-11/prebuildfs/opt/bitnami/scripts/libbitnami.sh
@@ -44,10 +44,10 @@ print_welcome_page() {
 print_image_welcome_page() {
     local github_url="https://github.com/bitnami/containers"
 
-    log ""
+    info ""
     info "${BOLD}Welcome to the Bitnami ${BITNAMI_APP_NAME} container${RESET}"
     info "Subscribe to project updates by watching ${BOLD}${github_url}${RESET}"
     info "Submit issues and feature requests at ${BOLD}${github_url}/issues${RESET}"
-    log ""
+    info ""
 }
 

--- a/bitnami/redis-cluster/7.2/debian-11/prebuildfs/opt/bitnami/scripts/libbitnami.sh
+++ b/bitnami/redis-cluster/7.2/debian-11/prebuildfs/opt/bitnami/scripts/libbitnami.sh
@@ -45,9 +45,9 @@ print_image_welcome_page() {
     local github_url="https://github.com/bitnami/containers"
 
     log ""
-    log "${BOLD}Welcome to the Bitnami ${BITNAMI_APP_NAME} container${RESET}"
-    log "Subscribe to project updates by watching ${BOLD}${github_url}${RESET}"
-    log "Submit issues and feature requests at ${BOLD}${github_url}/issues${RESET}"
+    info "${BOLD}Welcome to the Bitnami ${BITNAMI_APP_NAME} container${RESET}"
+    info "Subscribe to project updates by watching ${BOLD}${github_url}${RESET}"
+    info "Submit issues and feature requests at ${BOLD}${github_url}/issues${RESET}"
     log ""
 }
 

--- a/bitnami/redis-cluster/7.2/debian-11/rootfs/opt/bitnami/scripts/librediscluster.sh
+++ b/bitnami/redis-cluster/7.2/debian-11/rootfs/opt/bitnami/scripts/librediscluster.sh
@@ -224,7 +224,7 @@ redis_cluster_update_ips() {
             newIP=$(wait_for_dns_lookup "${host_and_port[0]}" "$REDIS_DNS_RETRIES" 5)
             # The node can be new if we are updating the cluster, so catch the unbound variable error
             if [[ ${host_2_ip_array[$node]+true} ]]; then
-                echo "Changing old IP ${host_2_ip_array[$node]} by the new one ${newIP}"
+                info "Changing old IP ${host_2_ip_array[$node]} by the new one ${newIP}"
                 nodesFile=$(sed "s/ ${host_2_ip_array[$node]}:/ $newIP<NEWIP>:/g" "${REDIS_DATA_DIR}/nodes.conf")
                 echo "$nodesFile" >"${REDIS_DATA_DIR}/nodes.conf"
             fi


### PR DESCRIPTION
## Name and Version
bitnami/redis-cluster:7.2.1-debian-11-r0

## What is the problem this feature will solve?
We are collecting our logs via open telemetry. I have seen that there are log entries without severity.
e.g.

```
redis-cluster 09:09:59.12 Subscribe to project updates by watching https://github.com/bitnami/containers
redis-cluster 09:09:59.12 Submit issues and feature requests at https://github.com/bitnami/containers/issues 
Changing old IP x.x.x.x by the new one x.x.x.x 
```

see also Issue: https://github.com/bitnami/containers/issues/51496

## Changing to 
```
redis-cluster 09:09:59.12 INFO Subscribe to project updates by watching https://github.com/bitnami/containers
redis-cluster 09:09:59.12 INFO Submit issues and feature requests at https://github.com/bitnami/containers/issues
09:09:59.12 INFO Changing old IP x.x.x.x by the new one x.x.x.x
```
