### PR TITLE
Enable pw-sha2. This partly implements #52373

### DIFF
--- a/bitnami/openldap/2.5/debian-11/rootfs/opt/bitnami/scripts/libopenldap.sh
+++ b/bitnami/openldap/2.5/debian-11/rootfs/opt/bitnami/scripts/libopenldap.sh
@@ -281,6 +281,16 @@ olcArgsFile: /opt/bitnami/openldap/var/run/slapd.args
 olcPidFile: /opt/bitnami/openldap/var/run/slapd.pid
 
 #
+# Enable pw-sha2 module
+#
+
+dn: cn=module,cn=config
+cn: module
+objectClass: olcModuleList
+olcModulePath: /opt/bitnami/openldap/libexec/openldap
+olcModuleLoad: pw-sha2.so
+
+#
 # Schema settings
 #
 

--- a/bitnami/openldap/2.6/debian-11/rootfs/opt/bitnami/scripts/libopenldap.sh
+++ b/bitnami/openldap/2.6/debian-11/rootfs/opt/bitnami/scripts/libopenldap.sh
@@ -281,6 +281,16 @@ olcArgsFile: /opt/bitnami/openldap/var/run/slapd.args
 olcPidFile: /opt/bitnami/openldap/var/run/slapd.pid
 
 #
+# Enable pw-sha2 module
+#
+
+dn: cn=module,cn=config
+cn: module
+objectClass: olcModuleList
+olcModulePath: /opt/bitnami/openldap/libexec/openldap
+olcModuleLoad: pw-sha2.so
+
+#
 # Schema settings
 #
 


### PR DESCRIPTION
### Description of the change
Enables the pw-sha2 openldap module in the openldap container.

### Benefits
There are more secure hashing algorithms enabled.

### Possible drawbacks
Nothing disabled or unloaded. No drawbacks expected.

### Applicable issues
- partly fixes #52373

### Additional information
Although this merge request does not solve the ticket 100%, it should already be integrated as a first step and additional security improvement.
