### PR TITLE
[bitnami/mxnet] Add deprecation notice

### DIFF
--- a/bitnami/mxnet/README.md
+++ b/bitnami/mxnet/README.md
@@ -1,5 +1,9 @@
 # Apache MXNet (Incubating) packaged by Bitnami
 
+## Deprecation Notice
+
+The Apache MXNet container is no longer maintained by upstream and is now deprecated. This image will no longer be released in our catalog, but already released container images will still persist in the registries.
+
 ## What is Apache MXNet (Incubating)?
 
 > Apache MXNet (Incubating) is a flexible and efficient library for deep learning designed to work as a neural network. Bitnami image ships OpenBLAS as math library.


### PR DESCRIPTION
### Description of the change

Deprecate notice for Apache MXNet. See from [upstream](https://mxnet.apache.org/versions/1.9.1/).