### PR TITLE
[SPARK] lang.NullPointerException: invalid null input: name

### DIFF
--- a/bitnami/spark/3.5/debian-11/rootfs/opt/bitnami/scripts/spark-env.sh
+++ b/bitnami/spark/3.5/debian-11/rootfs/opt/bitnami/scripts/spark-env.sh
@@ -95,4 +95,9 @@ export SPARK_METRICS_ENABLED="${SPARK_METRICS_ENABLED:-false}"
 export SPARK_DAEMON_USER="spark"
 export SPARK_DAEMON_GROUP="spark"
 
+# NSS LD_PRELOAD setting
+if [ ! $EUID -eq 0 ] && [ -e "$LIBNSS_WRAPPER_PATH" ]; then
+    export LD_PRELOAD=$LIBNSS_WRAPPER_PATH
+fi
+    
 # Custom environment variables may be defined below

--- a/bitnami/spark/3.5/debian-11/rootfs/opt/bitnami/scripts/spark/entrypoint.sh
+++ b/bitnami/spark/3.5/debian-11/rootfs/opt/bitnami/scripts/spark/entrypoint.sh
@@ -21,7 +21,6 @@ print_welcome_page
 if [ ! $EUID -eq 0 ] && [ -e "$LIBNSS_WRAPPER_PATH" ]; then
     echo "spark:x:$(id -u):$(id -g):Spark:$SPARK_HOME:/bin/false" > "$NSS_WRAPPER_PASSWD"
     echo "spark:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
-    echo "LD_PRELOAD=$LIBNSS_WRAPPER_PATH" >> "$SPARK_CONF_DIR/spark-env.sh"
 fi
 
 if [[ "$1" = "/opt/bitnami/scripts/spark/run.sh" ]]; then


### PR DESCRIPTION
### Description of the change
I found a bug in the startup procedure of the spark-executor usage of the spark image.  

The bug was located in this piece of code:

```shell
if [ ! $EUID -eq 0 ] && [ -e "$LIBNSS_WRAPPER_PATH" ]; then
    echo "spark:x:$(id -u):$(id -g):Spark:$SPARK_HOME:/bin/false" > "$NSS_WRAPPER_PASSWD"
    echo "spark:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
    echo "LD_PRELOAD=$LIBNSS_WRAPPER_PATH" >> "$SPARK_CONF_DIR/spark-env.sh"
fi
```

this was perfect, unless the fact that `spark-env.sh` has permissions root:root and 644.  This code is executed with user 1001.  So, the first 2 lines of the then clause work perfectly, but the last part doesn't work.

This will result in the fact that the "whoami" command that is executed further down the start-up path will fail, since the user will not have an entry in the /etc/passwd file.  This file is the actively chosen file by whoami, since the LD_PRELOAD variable did not get set due to permission errors.  In that case, the pod will fail if it is started as a "spark executor".

### Code fix
So, what I did is remove this last line in that previous piece of code:

```shell
if [ ! $EUID -eq 0 ] && [ -e "$LIBNSS_WRAPPER_PATH" ]; then
    echo "spark:x:$(id -u):$(id -g):Spark:$SPARK_HOME:/bin/false" > "$NSS_WRAPPER_PASSWD"
    echo "spark:x:$(id -g):" > "$NSS_WRAPPER_GROUP"
fi
```

and add another `if` to the spark-env.sh file:

```shell
# NSS LD_PRELOAD setting
if [ ! $EUID -eq 0 ] && [ -e "$LIBNSS_WRAPPER_PATH" ]; then
    export LD_PRELOAD=$LIBNSS_WRAPPER_PATH
fi
```

The same test is done at runtime, so the same variables will be filled in as in the other `if`.  It then loads the LD_PRELOAD variable in case the `if` succeeds.

### Benefits
The Spark executor pod will succeed during startup and execute the spark application instead of crashing

### Possible drawbacks
Not that I know of

### Applicable issues

- fixes https://github.com/bitnami/containers/issues/52698

### Additional information

None
