### PR TITLE
Fix configuration override section for docker-compose in clickhouse

### DIFF
--- a/bitnami/clickhouse/README.md
+++ b/bitnami/clickhouse/README.md
@@ -185,7 +185,7 @@ services:
   clickhouse:
     image: bitnami/clickhouse:latest
     volumes:
-      - /path/to/override.xml:/bitnami/clickhouse/conf/override.xml:ro
+      - /path/to/override.xml:/bitnami/clickhouse/etc/conf.d/override.xml:ro
 ```
 
 Check the [official ClickHouse configuration documentation](https://clickhouse.com/docs/en/operations/configuration-files/) for all the possible overrides and settings.


### PR DESCRIPTION
### Description of the change

Documentation fix. The docker example is correct while docker-compose is not.

### Benefits

n/a

### Possible drawbacks

n/a

### Applicable issues

n/a

### Additional information

Spent a couple of hours to realize there was a typo in the readme.