### PR TITLE
[bitnami/apache] check mod-proxy-html is disabled in goss tests

### DIFF
--- a/.vib/apache/goss/vars.yaml
+++ b/.vib/apache/goss/vars.yaml
@@ -33,6 +33,7 @@ modules:
     # Explicitly disabled in postunpack
     - http2
     - proxy_hcheck
+    - proxy_html
   extra:
     # Not enabled, but compiled
     - mpm_event


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Checks `mod-proxy-html` is disabled by default in Goss tests.

### Possible drawbacks

Not expected

### Applicable issues

- #41361
