### PR TITLE
[bitnami/kibana] Add clamav action allowing false positive

### DIFF
--- a/.vib/kibana/vib-verify.json
+++ b/.vib/kibana/vib-verify.json
@@ -70,7 +70,9 @@
         {
           "action_id": "clamav",
           "params": {
-            "allowlist": ["Win.Tool.UACBypass-5474404-0"]
+            "allowlist": [
+              "Win.Tool.UACBypass-5474404-0"
+            ]
           }
         }
       ]

--- a/.vib/kibana/vib-verify.json
+++ b/.vib/kibana/vib-verify.json
@@ -66,6 +66,12 @@
               "OS"
             ]
           }
+        },
+        {
+          "action_id": "clamav",
+          "params": {
+            "allowlist": ["Win.Tool.UACBypass-5474404-0"]
+          }
         }
       ]
     }


### PR DESCRIPTION
This PR adds the ClamAV action which is executed by default in every container just to be able to set the `allowlist` parameter.

With that parameter in place, we are allowing a specific vulnerability already reported to Kibana maintainers which confirms the false positive