### PR TITLE
[bitnami/fluentd] Add sed_in_place.exclude_paths

### DIFF
--- a/.vib/fluentd/goss/vars.yaml
+++ b/.vib/fluentd/goss/vars.yaml
@@ -38,3 +38,7 @@ version:
   bin_name: fluentd
   flag: --version
 root_dir: /opt/bitnami
+# We can't control what third-party devs include in their internal scripts.
+sed_in_place:
+  exclude_paths:
+    - /opt/bitnami/fluentd/gems


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Updates `sed_in_place.exclude_paths` array to avoid false positives with third-party scripts like the one below

```
$ grep sed /opt/bitnami/fluentd/gems/ffi-1.16.3/ext/ffi_c/libffi/testsuite/emscripten/build-tests.sh
ls *c | sed 's!\(.*\)\.c!sed -i "s/main/test__\1/g" \0!g' | bash
ls *.c | sed 's/\(.*\)\.c/emcc $CFLAGS -c \1.c -o \1.o /g' | bash
ls *.cc | sed 's/\(.*\)\.cc/em++ $CXXFLAGS -c \1.cc -o \1.o /g' | bash
```

### Benefits

False positives won't prevent future Fluentd releases.

### Possible drawbacks

Not expected.
