### PR TITLE
Update to fix pg_rewind can't find postgresql.conf file in data directory via the librepmgr.sh script

### DIFF
--- a/bitnami/postgresql-repmgr/16/debian-11/rootfs/opt/bitnami/scripts/librepmgr.sh
+++ b/bitnami/postgresql-repmgr/16/debian-11/rootfs/opt/bitnami/scripts/librepmgr.sh
@@ -641,7 +641,7 @@ repmgr_clone_primary() {
 #########################
 repmgr_pgrewind() {
     info "Running pg_rewind data to primary node..."
-    local -r flags=("-D" "$POSTGRESQL_DATA_DIR" "--source-server" "host=${REPMGR_CURRENT_PRIMARY_HOST} port=${REPMGR_CURRENT_PRIMARY_PORT} user=${REPMGR_USERNAME} dbname=${REPMGR_DATABASE}")
+    local -r flags=("-D" "$POSTGRESQL_DATA_DIR" "--source-server" "host=${REPMGR_CURRENT_PRIMARY_HOST} port=${REPMGR_CURRENT_PRIMARY_PORT} user=${REPMGR_USERNAME} dbname=${REPMGR_DATABASE}" "--config-file=postgresql.auto.conf")
 
     if [[ "$REPMGR_USE_PASSFILE" = "true" ]]; then
         PGPASSFILE="$REPMGR_PASSFILE_PATH" debug_execute "${POSTGRESQL_BIN_DIR}/pg_rewind" "${flags[@]}"


### PR DESCRIPTION
This fixes the issues of the not found postgresql.conf file in the pg data directory. The actual file name there is postgresql.auto.conf.

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

The change uses the actual file name in the pg data directory. By default it would be postgresql.conf but the actual file name is postgresql.auto.conf

### Benefits

prevent the error seens as pg_rewind can't find pg conf file. 

```bash
postgresql-repmgr 04:00:49.64 DEBUG ==> Schema repmgr.repmgr exists!
postgresql-repmgr 04:00:49.65 INFO  ==> Rejoining node...
postgresql-repmgr 04:00:49.65 INFO  ==> Using pg_rewind to primary node...
postgresql-repmgr 04:00:49.65 INFO  ==> Running pg_rewind data to primary node...
pg_rewind: executing "/opt/bitnami/postgresql/bin/postgres" for target server to complete crash recovery
postgres: could not access the server configuration file "/bitnami/postgresql/data/postgresql.conf": No such file or directory
pg_rewind: error: postgres single-user mode in target cluster failed
pg_rewind: detail: Command was: /opt/bitnami/postgresql/bin/postgres --single -F -D /bitnami/postgresql/data template1 < /dev/null
postgresql-repmgr 04:00:49.72 WARN  ==> pg_rewind failed, resorting to data cloning
postgresql-repmgr 04:00:49.72 INFO  ==> Cloning data from primary node...
WARNING: following problems with command line parameters detected:
  -D/--pgdata will be ignored if a repmgr configuration file is provided
```
Issue seems to be from this code in the repmgr script `librepmgr.sh`
```bash
repmgr_pgrewind() {
    info "Running pg_rewind data to primary node..."
    local -r flags=("-D" "$POSTGRESQL_DATA_DIR" "--source-server" "host=${REPMGR_CURRENT_PRIMARY_HOST} port=${REPMGR_CURRENT_PRIMARY_PORT} user=${REPMGR_USERNAME} dbname=${REPMGR_DATABASE}")

    if [[ "$REPMGR_USE_PASSFILE" = "true" ]]; then
        PGPASSFILE="$REPMGR_PASSFILE_PATH" debug_execute "${POSTGRESQL_BIN_DIR}/pg_rewind" "${flags[@]}"
    else
        PGPASSWORD="$REPMGR_PASSWORD" debug_execute "${POSTGRESQL_BIN_DIR}/pg_rewind" "${flags[@]}"
    fi
}
```

Other posts related
https://github.com/bitnami/charts/issues/20998
https://github.com/bitnami/containers/issues/52213
https://github.com/bitnami/charts/pull/8933
And probably many more issues where a user is using pg_rewind

### Possible drawbacks

It will continue not working so nothing from my perspective. 

### Applicable issues

The issue is that upon failing a node and it trying to come back as primary it will not know the repmgr_slot_nodeName and will error continuously. The returning node is never put on the right timeline and does not enter back into the HA setup correctly. 

### Additional information

[Dos for pg_rewind](https://www.postgresql.org/docs/current/app-pgrewind.html)

> --config-file=filename
Use the specified main server configuration file for the target cluster. This affects pg_rewind when it uses internally the postgres command for the rewind operation on this cluster (when retrieving restore_command with the option -c/--restore-target-wal and when forcing a completion of crash recovery).
