### PR TITLE
[bitnami/nginx] Remove deprecated TLS version

### DIFF
--- a/bitnami/nginx/1.25/debian-11/rootfs/opt/bitnami/nginx/conf/nginx.conf
+++ b/bitnami/nginx/1.25/debian-11/rootfs/opt/bitnami/nginx/conf/nginx.conf
@@ -33,7 +33,7 @@ http {
     gzip_proxied       any;
     gzip_types         text/plain text/css application/javascript text/xml application/xml+rss;
     keepalive_timeout  65;
-    ssl_protocols      TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
+    ssl_protocols      TLSv1.2 TLSv1.3;
     ssl_ciphers        HIGH:!aNULL:!MD5;
     client_max_body_size 80M;
     server_tokens off;


### PR DESCRIPTION
## TLS 1.0 and TLS 1.1 should be avoided at all cost.

-> https://www.ssl.com/guide/ssl-best-practices/#ftoc-heading-4

I removed TLS 1.0 and TLS 1.1 because it is deprecated and should not be used anymore.
