### PR TITLE
[bitnami/opensearch] Fix: Set correct `LD_LIBRARY_PATH` for OpenSearch

### DIFF
--- a/bitnami/opensearch/1/debian-11/Dockerfile
+++ b/bitnami/opensearch/1/debian-11/Dockerfile
@@ -52,7 +52,7 @@ RUN /opt/bitnami/scripts/java/postunpack.sh
 ENV APP_VERSION="1.3.13" \
     BITNAMI_APP_NAME="opensearch" \
     JAVA_HOME="/opt/bitnami/java" \
-    LD_LIBRARY_PATH="/opt/bitnami/opensearch/jdk/lib:/opt/bitnami/opensearch/jdk/lib/server:$LD_LIBRARY_PATH" \
+    LD_LIBRARY_PATH="/opt/bitnami/opensearch/jdk/lib:/opt/bitnami/opensearch/jdk/lib/server:/opt/bitnami/opensearch/plugins/opensearch-knn/lib:$LD_LIBRARY_PATH" \
     OPENSEARCH_JAVA_HOME="/opt/bitnami/java"
 
 EXPOSE 9200 9300

--- a/bitnami/opensearch/2/debian-11/Dockerfile
+++ b/bitnami/opensearch/2/debian-11/Dockerfile
@@ -52,7 +52,7 @@ RUN /opt/bitnami/scripts/java/postunpack.sh
 ENV APP_VERSION="2.11.1" \
     BITNAMI_APP_NAME="opensearch" \
     JAVA_HOME="/opt/bitnami/java" \
-    LD_LIBRARY_PATH="/opt/bitnami/opensearch/jdk/lib:/opt/bitnami/opensearch/jdk/lib/server:$LD_LIBRARY_PATH" \
+    LD_LIBRARY_PATH="/opt/bitnami/opensearch/jdk/lib:/opt/bitnami/opensearch/jdk/lib/server:/opt/bitnami/opensearch/plugins/opensearch-knn/lib:$LD_LIBRARY_PATH" \
     OPENSEARCH_JAVA_HOME="/opt/bitnami/java"
 
 EXPOSE 9200 9300


### PR DESCRIPTION
### Description of the change

Set correct `LD_LIBRARY_PATH` for OpenSearch v1 and v2. The `LD_LIBRARY_PATH` has been adjusted to ensure compatibility with both OpenSearch versions.

This change fixes the following runtime error:
> java.lang.UnsatisfiedLinkError:  no opensearchknn_nmslib in java.library.path: /usr/java/packages/lib:/usr/lib64:/lib64:/lib:/usr/lib

More details can be found here: https://github.com/opensearch-project/k-NN/issues/508