### PR TITLE
[bitnami/tomcat] TOMCAT_EXTRA_JAVA_OPTS are added multiple times to tomcat-env.sh #53082 (Version 2)

### DIFF
--- a/bitnami/tomcat/10.1/debian-11/rootfs/opt/bitnami/scripts/libtomcat.sh
+++ b/bitnami/tomcat/10.1/debian-11/rootfs/opt/bitnami/scripts/libtomcat.sh
@@ -162,10 +162,12 @@ tomcat_enable_application() {
 #   None
 #########################
 tomcat_initialize() {
-    if ! is_empty_value "$TOMCAT_EXTRA_JAVA_OPTS"; then
-        cat >>"${TOMCAT_BIN_DIR}/setenv.sh" <<EOF
+    if ! is_empty_value "$TOMCAT_EXTRA_JAVA_OPTS"; then      
+        if ! grep -q "Additional configuration from TOMCAT_EXTRA_JAVA_OPTS" "$TOMCAT_BIN_DIR/setenv.sh"; then        
+            cat >> "$TOMCAT_BIN_DIR/setenv.sh" <<EOF
 
-# Additional configuration
+
+# Additional configuration from TOMCAT_EXTRA_JAVA_OPTS
 export JAVA_OPTS="\${JAVA_OPTS} ${TOMCAT_EXTRA_JAVA_OPTS}"
 EOF
     fi


### PR DESCRIPTION
Preventing `TOMCAT_EXTRA_JAVA_OPTS` to be added multiple times to _tomcat-env.sh_ when the container is restarted.

Signed-off-by: Christian Scheible <christian.scheible@uni-konstanz.de>

### Description of the change

This changes checks if the additional **TOMCAT_EXTRA_JAVA_OPTS** have allready been added to _tomcat-env.sh_ before adding them. Otherwise every restart will add them again to the file.

### Benefits

This prevents adding options multiple times to the **JAVA_OPTS** which fails for example if someone want's to attach a debugger like this: `-agentlib:jdwp=transport=dt_socket,address=*:9543,suspend=n,server=y`

### Possible drawbacks

-

### Applicable issues

#53082

### Additional information

It looks like the code for Tomcat **10.1**, **9.0** and **8.5** is exactly the same. So the problem probably exists for all three Tomcat versions. This only fixes **10.1**.