### PR TITLE
[bitnami/etcd] removed repeated call of etcdctl_get_endpoints

### DIFF
--- a/bitnami/etcd/3.4/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
+++ b/bitnami/etcd/3.4/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
@@ -352,7 +352,6 @@ etcd_configure_rbac() {
                 info "Authentication already enabled"
             else
                 info "Enabling etcd authentication"
-                extra_flags=("--endpoints=$(etcdctl_get_endpoints)")
                 etcdctl "${extra_flags[@]}" user add root --interactive=false <<<"$ETCD_ROOT_PASSWORD"
                 etcdctl "${extra_flags[@]}" user grant-role root root
                 etcdctl "${extra_flags[@]}" auth enable

--- a/bitnami/etcd/3.5/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
+++ b/bitnami/etcd/3.5/debian-11/rootfs/opt/bitnami/scripts/libetcd.sh
@@ -352,7 +352,6 @@ etcd_configure_rbac() {
                 info "Authentication already enabled"
             else
                 info "Enabling etcd authentication"
-                extra_flags=("--endpoints=$(etcdctl_get_endpoints)")
                 etcdctl "${extra_flags[@]}" user add root --interactive=false <<<"$ETCD_ROOT_PASSWORD"
                 etcdctl "${extra_flags[@]}" user grant-role root root
                 etcdctl "${extra_flags[@]}" auth enable


### PR DESCRIPTION
### Description of the change

Removed repeated call of etcdctl_get_endpoints.

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #53068

### Additional information

It was added under https://github.com/bitnami/containers/pull/53027/files#diff-07368b28143102cccfaa06e002972378fe78c854e5ec2308fc935f529077abcaR355.

Actually etcdctl_get_endpoints is already called above, but with ETCD_ON_K8S condition. This method is meant to be only for k8s, so it shouldn't be called without conditions.
