### PR TITLE
[bitnami/kafka] embedded jmx exporter agent

### DIFF
--- a/bitnami/kafka/3.6/debian-11/Dockerfile
+++ b/bitnami/kafka/3.6/debian-11/Dockerfile
@@ -31,6 +31,7 @@ RUN mkdir -p /tmp/bitnami/pkg/cache/ ; cd /tmp/bitnami/pkg/cache/ ; \
       "java-17.0.9-11-6-linux-${OS_ARCH}-debian-11" \
       "render-template-1.0.6-4-linux-${OS_ARCH}-debian-11" \
       "kafka-3.6.1-0-linux-${OS_ARCH}-debian-11" \
+      "jmx-exporter-0.20.0-1-linux-${OS_ARCH}-debian-11" \
     ) ; \
     for COMPONENT in "${COMPONENTS[@]}"; do \
       if [ ! -f "${COMPONENT}.tar.gz" ]; then \


### PR DESCRIPTION
### Description of the change

Add the jmx exporter for prometheus in the Kafka container. This allows running it as an embedded java agent in the Kafka broker JVM.

### Benefits

This is a prerequisite for https://github.com/bitnami/charts/issues/21309, see details there.

fixes #53816

### Possible drawbacks

The image is now slightly larger.

### Applicable issues

None

### Additional information

None