### PR TITLE
Update openldap libopenldap.sh

### DIFF
--- a/bitnami/openldap/2.6/debian-11/rootfs/opt/bitnami/scripts/libopenldap.sh
+++ b/bitnami/openldap/2.6/debian-11/rootfs/opt/bitnami/scripts/libopenldap.sh
@@ -646,19 +646,19 @@ ldap_initialize() {
         if is_boolean_yes "$LDAP_ENABLE_SYNCPROV"; then
             ldap_enable_syncprov
         fi
-        if ! is_dir_empty "$LDAP_CUSTOM_LDIF_DIR"; then
-            ldap_add_custom_ldifs
-        elif ! is_boolean_yes "$LDAP_SKIP_DEFAULT_TREE"; then
-            ldap_create_tree
-        else
-            info "Skipping default schemas/tree structure"
-        fi
         # enable tls
         if is_boolean_yes "$LDAP_ENABLE_TLS"; then
             ldap_configure_tls
             if is_boolean_yes "$LDAP_REQUIRE_TLS"; then
                 ldap_configure_tls_required
             fi
+        fi
+        if ! is_dir_empty "$LDAP_CUSTOM_LDIF_DIR"; then
+            ldap_add_custom_ldifs
+        elif ! is_boolean_yes "$LDAP_SKIP_DEFAULT_TREE"; then
+            ldap_create_tree
+        else
+            info "Skipping default schemas/tree structure"
         fi
         ldap_stop
     fi


### PR DESCRIPTION


### Description of the change

During Openldap init, this change does the TLS configuration before adding custom LDIFs. 

### Benefits

Using this [helm chart](https://github.com/jp-gouin/helm-openldap), this change fixes a replication issue.
This chart allows users to spin up Openldap in K8S in a high availability mode. In a multi-node scenario, the first one starts without issue, other ones are in a race condition when setting up the tree (`ldap_create_tree`) and ldif `ldap_add_custom_ldifs`) due to the replication. This is an expected behaviour and once the replication kicks in all nodes are running.

By doing the TLS initialisation at the end of `ldap_initialize()` the TLS is not properly configured when Openldap restart.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes https://github.com/jp-gouin/helm-openldap/issues/136 
- fixes https://github.com/jp-gouin/helm-openldap/issues/120

