### PR TITLE
feat(keycloak): expose default ports

### DIFF
--- a/bitnami/keycloak/23/debian-11/Dockerfile
+++ b/bitnami/keycloak/23/debian-11/Dockerfile
@@ -53,6 +53,8 @@ ENV APP_VERSION="23.0.6" \
     JAVA_HOME="/opt/bitnami/java" \
     PATH="/opt/bitnami/common/bin:/opt/bitnami/java/bin:/opt/bitnami/keycloak/bin:$PATH"
 
+EXPOSE 8080 8443
+
 USER 1001
 ENTRYPOINT [ "/opt/bitnami/scripts/keycloak/entrypoint.sh" ]
 CMD [ "/opt/bitnami/scripts/keycloak/run.sh" ]


### PR DESCRIPTION
### Description of the change

Expose default keycloak ports 8080 and 8443
Taken from here:
- https://github.com/keycloak/keycloak/blob/eb184a8554a2ed59203f65965df85d1165742359/quarkus/container/Dockerfile#L33

### Benefits

Use this image as a service in gitlab CI
Docker best practices

### Possible drawbacks

NONE

### Applicable issues

NONE

### Additional information

NONE
