### PR TITLE
[bitnami/cassandra] Remove yq binary from tests

### DIFF
--- a/.vib/cassandra/goss/vars.yaml
+++ b/.vib/cassandra/goss/vars.yaml
@@ -3,7 +3,6 @@ binaries:
   - cqlsh
   - python
   - java
-  - yq
 files:
   - mode: "0755"
     paths:


### PR DESCRIPTION
`yq` is not needed anymore