### PR TITLE
[bitnami/spark] Update to /bitnami/spark/README.md "Installing additional Jars" example

### DIFF
--- a/bitnami/spark/README.md
+++ b/bitnami/spark/README.md
@@ -215,13 +215,13 @@ In a similar way that in the previous section, you may want to use a different v
 Go to <https://spark.apache.org/downloads.html> and copy the download url bundling the Hadoop version you want and matching the Apache Spark version of the container. Extend the Bitnami container image as below:
 
 ```Dockerfile
-FROM bitnami/spark:3.0.0
+FROM bitnami/spark:3.5.0
 USER root
 RUN install_packages curl
 USER 1001
 RUN rm -r /opt/bitnami/spark/jars && \
-    curl --location http://mirror.cc.columbia.edu/pub/software/apache/spark/spark-3.0.0/spark-3.0.0-bin-hadoop2.7.tgz | \
-    tar --extract --gzip --strip=1 --directory /opt/bitnami/spark/ spark-3.0.0-bin-hadoop2.7/jars/
+    curl --location https://dlcdn.apache.org/spark/spark-3.5.0/spark-3.5.0-bin-hadoop3.tgz | \
+    tar --extract --gzip --strip=1 --directory /opt/bitnami/spark/ spark-3.5.0-bin-hadoop3/jars/
 ```
 
 You can check the Hadoop version by running the following commands in the new container image:

--- a/bitnami/spark/README.md
+++ b/bitnami/spark/README.md
@@ -198,7 +198,7 @@ After that, your changes will be taken into account in the server's behaviour.
 
 ### Installing additional jars
 
-By default, this container bundles a generic set of jar files but the default image can be extended to add as many jars as needed for your specific use case. For instance, the following Dockerfile adds [`aws-java-sdk-bundle-1.11.704.jar`](https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-bundle/1.11.704) using a multi-stage Docker build:
+By default, this container bundles a generic set of jar files but the default image can be extended to add as many jars as needed for your specific use case. For instance, the following Dockerfile adds [`aws-java-sdk-bundle-1.11.704.jar`](https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-bundle/1.11.704):
 
 ```Dockerfile
 FROM curlimages/curl-base:latest as curl

--- a/bitnami/spark/README.md
+++ b/bitnami/spark/README.md
@@ -198,12 +198,15 @@ After that, your changes will be taken into account in the server's behaviour.
 
 ### Installing additional jars
 
-By default, this container bundles a generic set of jar files but the default image can be extended to add as many jars as needed for your specific use case. For instance, the following Dockerfile adds [`aws-java-sdk-bundle-1.11.704.jar`](https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-bundle/1.11.704):
+By default, this container bundles a generic set of jar files but the default image can be extended to add as many jars as needed for your specific use case. For instance, the following Dockerfile adds [`aws-java-sdk-bundle-1.11.704.jar`](https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-bundle/1.11.704) using a multi-stage Docker build:
 
 ```Dockerfile
+FROM curlimages/curl-base:latest as curl
+RUN curl https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.11.704/aws-java-sdk-bundle-1.11.704.jar --output /tmp/aws-java-sdk-bundle-1.11.704.jar
+
 FROM bitnami/spark
 USER 1001
-RUN curl https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.11.704/aws-java-sdk-bundle-1.11.704.jar --output /opt/bitnami/spark/jars/aws-java-sdk-bundle-1.11.704.jar
+COPY --from=curl /tmp/aws-java-sdk-bundle-1.11.704.jar /opt/bitnami/spark/jars/aws-java-sdk-bundle-1.11.704.jar
 ```
 
 #### Using a different version of Hadoop jars

--- a/bitnami/spark/README.md
+++ b/bitnami/spark/README.md
@@ -201,12 +201,11 @@ After that, your changes will be taken into account in the server's behaviour.
 By default, this container bundles a generic set of jar files but the default image can be extended to add as many jars as needed for your specific use case. For instance, the following Dockerfile adds [`aws-java-sdk-bundle-1.11.704.jar`](https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-bundle/1.11.704):
 
 ```Dockerfile
-FROM curlimages/curl-base:latest as curl
-RUN curl https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.11.704/aws-java-sdk-bundle-1.11.704.jar --output /tmp/aws-java-sdk-bundle-1.11.704.jar
-
 FROM bitnami/spark
+USER root
+RUN install_packages curl
 USER 1001
-COPY --from=curl /tmp/aws-java-sdk-bundle-1.11.704.jar /opt/bitnami/spark/jars/aws-java-sdk-bundle-1.11.704.jar
+RUN curl https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.11.704/aws-java-sdk-bundle-1.11.704.jar --output /opt/bitnami/spark/jars/aws-java-sdk-bundle-1.11.704.jar
 ```
 
 #### Using a different version of Hadoop jars

--- a/bitnami/spark/README.md
+++ b/bitnami/spark/README.md
@@ -216,7 +216,8 @@ Go to <https://spark.apache.org/downloads.html> and copy the download url bundli
 
 ```Dockerfile
 FROM bitnami/spark:3.0.0
-
+USER root
+RUN install_packages curl
 USER 1001
 RUN rm -r /opt/bitnami/spark/jars && \
     curl --location http://mirror.cc.columbia.edu/pub/software/apache/spark/spark-3.0.0/spark-3.0.0-bin-hadoop2.7.tgz | \


### PR DESCRIPTION
Updating the /bitnami/spark/README.md "Installing additional jars" example to work correctly.

### Description of the change

Curl is not included in the existing Bitnami Spark image, this updates the example to use a multi-stage Docker build to accomplish adding the additonal Jar file. 

### Benefits

The example in the documentation will now build and run correctly.

### Applicable issues
#54826 
