### PR TITLE
Skip setting kafka config from empty environment variables

### DIFF
--- a/bitnami/kafka/3.2/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/bitnami/kafka/3.2/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -816,7 +816,8 @@ kafka_configure_from_environment_variables() {
         done
 
         value="${!var}"
-        kafka_server_conf_set "$key" "$value"
+        # Skip empty variables from kafka-env.sh
+        ! is_empty_value "$value" && kafka_server_conf_set "$key" "$value"
     done
 }
 

--- a/bitnami/kafka/3.3/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/bitnami/kafka/3.3/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -816,7 +816,8 @@ kafka_configure_from_environment_variables() {
         done
 
         value="${!var}"
-        kafka_server_conf_set "$key" "$value"
+        # Skip empty variables from kafka-env.sh
+        ! is_empty_value "$value" && kafka_server_conf_set "$key" "$value"
     done
 }
 

--- a/bitnami/kafka/3.4/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/bitnami/kafka/3.4/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -816,7 +816,8 @@ kafka_configure_from_environment_variables() {
         done
 
         value="${!var}"
-        kafka_server_conf_set "$key" "$value"
+        # Skip empty variables from kafka-env.sh
+        ! is_empty_value "$value" && kafka_server_conf_set "$key" "$value"
     done
 }
 

--- a/bitnami/kafka/3.5/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/bitnami/kafka/3.5/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -816,7 +816,8 @@ kafka_configure_from_environment_variables() {
         done
 
         value="${!var}"
-        kafka_server_conf_set "$key" "$value"
+        # Skip empty variables from kafka-env.sh
+        ! is_empty_value "$value" && kafka_server_conf_set "$key" "$value"
     done
 }
 

--- a/bitnami/kafka/3.6/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/bitnami/kafka/3.6/debian-11/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -816,7 +816,8 @@ kafka_configure_from_environment_variables() {
         done
 
         value="${!var}"
-        kafka_server_conf_set "$key" "$value"
+        # Skip empty variables from kafka-env.sh
+        ! is_empty_value "$value" && kafka_server_conf_set "$key" "$value"
     done
 }
 


### PR DESCRIPTION
### Description of the change
When generating the kafka config do not set empty configuration settings.

### Benefits
With the change in https://github.com/bitnami/containers/commit/0b8731370e900f34e525e70311751e10747792da for KAFKA_CFG_MESSAGE_MAX_BYTES the server option `message.max.bytes` would otherwise always be set to empty string which is not accepted as a valid value by the kafka server.

The error message with `bitnami/kafka:3.3.2-debian-11-r244` looks like 
```
Exception in thread "main" org.apache.kafka.common.config.ConfigException: Invalid value  for configuration message.max.bytes: Not a number of type INT
```

### Possible drawbacks
Other variables, for which an empty value wasn't a problem before also won't be set anymore to an empty string value.

### Additional information
I could test this only in a very limited use-case and I'm not very familiar with all of it. This change should be tested by others before merging it.

