### PR TITLE
[bitnami/kubectl] Add `envsubst` to kubectl Docker image

### DIFF
--- a/bitnami/kubectl/1.26/debian-11/Dockerfile
+++ b/bitnami/kubectl/1.26/debian-11/Dockerfile
@@ -39,6 +39,7 @@ RUN mkdir -p /tmp/bitnami/pkg/cache/ ; cd /tmp/bitnami/pkg/cache/ ; \
     done
 RUN apt-get autoremove --purge -y curl && \
     apt-get update && apt-get upgrade -y && \
+    apt-get -y install gettext-base && \
     apt-get clean && rm -rf /var/lib/apt/lists /var/cache/apt/archives
 RUN chmod g+rwX /opt/bitnami
 RUN mkdir /.kube && chmod g+rwX /.kube

--- a/bitnami/kubectl/1.26/debian-11/Dockerfile
+++ b/bitnami/kubectl/1.26/debian-11/Dockerfile
@@ -23,7 +23,7 @@ ENV HOME="/" \
 COPY prebuildfs /
 SHELL ["/bin/bash", "-o", "errexit", "-o", "nounset", "-o", "pipefail", "-c"]
 # Install required system packages and dependencies
-RUN install_packages ca-certificates curl git jq procps gettext-base
+RUN install_packages ca-certificates curl gettext git jq procps
 RUN mkdir -p /tmp/bitnami/pkg/cache/ ; cd /tmp/bitnami/pkg/cache/ ; \
     COMPONENTS=( \
       "kubectl-1.26.13-0-linux-${OS_ARCH}-debian-11" \

--- a/bitnami/kubectl/1.26/debian-11/Dockerfile
+++ b/bitnami/kubectl/1.26/debian-11/Dockerfile
@@ -23,7 +23,7 @@ ENV HOME="/" \
 COPY prebuildfs /
 SHELL ["/bin/bash", "-o", "errexit", "-o", "nounset", "-o", "pipefail", "-c"]
 # Install required system packages and dependencies
-RUN install_packages ca-certificates curl git jq procps
+RUN install_packages ca-certificates curl git jq procps gettext-base
 RUN mkdir -p /tmp/bitnami/pkg/cache/ ; cd /tmp/bitnami/pkg/cache/ ; \
     COMPONENTS=( \
       "kubectl-1.26.13-0-linux-${OS_ARCH}-debian-11" \
@@ -39,7 +39,6 @@ RUN mkdir -p /tmp/bitnami/pkg/cache/ ; cd /tmp/bitnami/pkg/cache/ ; \
     done
 RUN apt-get autoremove --purge -y curl && \
     apt-get update && apt-get upgrade -y && \
-    apt-get -y install gettext-base && \
     apt-get clean && rm -rf /var/lib/apt/lists /var/cache/apt/archives
 RUN chmod g+rwX /opt/bitnami
 RUN mkdir /.kube && chmod g+rwX /.kube

--- a/bitnami/kubectl/1.27/debian-11/Dockerfile
+++ b/bitnami/kubectl/1.27/debian-11/Dockerfile
@@ -39,6 +39,7 @@ RUN mkdir -p /tmp/bitnami/pkg/cache/ ; cd /tmp/bitnami/pkg/cache/ ; \
     done
 RUN apt-get autoremove --purge -y curl && \
     apt-get update && apt-get upgrade -y && \
+    apt-get -y install gettext-base && \
     apt-get clean && rm -rf /var/lib/apt/lists /var/cache/apt/archives
 RUN chmod g+rwX /opt/bitnami
 RUN mkdir /.kube && chmod g+rwX /.kube

--- a/bitnami/kubectl/1.27/debian-11/Dockerfile
+++ b/bitnami/kubectl/1.27/debian-11/Dockerfile
@@ -23,7 +23,7 @@ ENV HOME="/" \
 COPY prebuildfs /
 SHELL ["/bin/bash", "-o", "errexit", "-o", "nounset", "-o", "pipefail", "-c"]
 # Install required system packages and dependencies
-RUN install_packages ca-certificates curl git jq procps gettext-base
+RUN install_packages ca-certificates curl gettext git jq procps
 RUN mkdir -p /tmp/bitnami/pkg/cache/ ; cd /tmp/bitnami/pkg/cache/ ; \
     COMPONENTS=( \
       "kubectl-1.27.10-0-linux-${OS_ARCH}-debian-11" \

--- a/bitnami/kubectl/1.27/debian-11/Dockerfile
+++ b/bitnami/kubectl/1.27/debian-11/Dockerfile
@@ -23,7 +23,7 @@ ENV HOME="/" \
 COPY prebuildfs /
 SHELL ["/bin/bash", "-o", "errexit", "-o", "nounset", "-o", "pipefail", "-c"]
 # Install required system packages and dependencies
-RUN install_packages ca-certificates curl git jq procps
+RUN install_packages ca-certificates curl git jq procps gettext-base
 RUN mkdir -p /tmp/bitnami/pkg/cache/ ; cd /tmp/bitnami/pkg/cache/ ; \
     COMPONENTS=( \
       "kubectl-1.27.10-0-linux-${OS_ARCH}-debian-11" \
@@ -39,7 +39,6 @@ RUN mkdir -p /tmp/bitnami/pkg/cache/ ; cd /tmp/bitnami/pkg/cache/ ; \
     done
 RUN apt-get autoremove --purge -y curl && \
     apt-get update && apt-get upgrade -y && \
-    apt-get -y install gettext-base && \
     apt-get clean && rm -rf /var/lib/apt/lists /var/cache/apt/archives
 RUN chmod g+rwX /opt/bitnami
 RUN mkdir /.kube && chmod g+rwX /.kube

--- a/bitnami/kubectl/1.28/debian-11/Dockerfile
+++ b/bitnami/kubectl/1.28/debian-11/Dockerfile
@@ -39,6 +39,7 @@ RUN mkdir -p /tmp/bitnami/pkg/cache/ ; cd /tmp/bitnami/pkg/cache/ ; \
     done
 RUN apt-get autoremove --purge -y curl && \
     apt-get update && apt-get upgrade -y && \
+    apt-get -y install gettext-base && \
     apt-get clean && rm -rf /var/lib/apt/lists /var/cache/apt/archives
 RUN chmod g+rwX /opt/bitnami
 RUN mkdir /.kube && chmod g+rwX /.kube

--- a/bitnami/kubectl/1.28/debian-11/Dockerfile
+++ b/bitnami/kubectl/1.28/debian-11/Dockerfile
@@ -23,7 +23,7 @@ ENV HOME="/" \
 COPY prebuildfs /
 SHELL ["/bin/bash", "-o", "errexit", "-o", "nounset", "-o", "pipefail", "-c"]
 # Install required system packages and dependencies
-RUN install_packages ca-certificates curl git jq procps gettext-base
+RUN install_packages ca-certificates curl gettext git jq procps
 RUN mkdir -p /tmp/bitnami/pkg/cache/ ; cd /tmp/bitnami/pkg/cache/ ; \
     COMPONENTS=( \
       "kubectl-1.28.6-0-linux-${OS_ARCH}-debian-11" \

--- a/bitnami/kubectl/1.28/debian-11/Dockerfile
+++ b/bitnami/kubectl/1.28/debian-11/Dockerfile
@@ -23,7 +23,7 @@ ENV HOME="/" \
 COPY prebuildfs /
 SHELL ["/bin/bash", "-o", "errexit", "-o", "nounset", "-o", "pipefail", "-c"]
 # Install required system packages and dependencies
-RUN install_packages ca-certificates curl git jq procps
+RUN install_packages ca-certificates curl git jq procps gettext-base
 RUN mkdir -p /tmp/bitnami/pkg/cache/ ; cd /tmp/bitnami/pkg/cache/ ; \
     COMPONENTS=( \
       "kubectl-1.28.6-0-linux-${OS_ARCH}-debian-11" \
@@ -39,7 +39,6 @@ RUN mkdir -p /tmp/bitnami/pkg/cache/ ; cd /tmp/bitnami/pkg/cache/ ; \
     done
 RUN apt-get autoremove --purge -y curl && \
     apt-get update && apt-get upgrade -y && \
-    apt-get -y install gettext-base && \
     apt-get clean && rm -rf /var/lib/apt/lists /var/cache/apt/archives
 RUN chmod g+rwX /opt/bitnami
 RUN mkdir /.kube && chmod g+rwX /.kube

--- a/bitnami/kubectl/1.29/debian-11/Dockerfile
+++ b/bitnami/kubectl/1.29/debian-11/Dockerfile
@@ -39,6 +39,7 @@ RUN mkdir -p /tmp/bitnami/pkg/cache/ ; cd /tmp/bitnami/pkg/cache/ ; \
     done
 RUN apt-get autoremove --purge -y curl && \
     apt-get update && apt-get upgrade -y && \
+    apt-get -y install gettext-base && \
     apt-get clean && rm -rf /var/lib/apt/lists /var/cache/apt/archives
 RUN chmod g+rwX /opt/bitnami
 RUN mkdir /.kube && chmod g+rwX /.kube

--- a/bitnami/kubectl/1.29/debian-11/Dockerfile
+++ b/bitnami/kubectl/1.29/debian-11/Dockerfile
@@ -23,7 +23,7 @@ ENV HOME="/" \
 COPY prebuildfs /
 SHELL ["/bin/bash", "-o", "errexit", "-o", "nounset", "-o", "pipefail", "-c"]
 # Install required system packages and dependencies
-RUN install_packages ca-certificates curl git jq procps gettext-base
+RUN install_packages ca-certificates curl gettext git jq procps
 RUN mkdir -p /tmp/bitnami/pkg/cache/ ; cd /tmp/bitnami/pkg/cache/ ; \
     COMPONENTS=( \
       "kubectl-1.29.1-0-linux-${OS_ARCH}-debian-11" \

--- a/bitnami/kubectl/1.29/debian-11/Dockerfile
+++ b/bitnami/kubectl/1.29/debian-11/Dockerfile
@@ -23,7 +23,7 @@ ENV HOME="/" \
 COPY prebuildfs /
 SHELL ["/bin/bash", "-o", "errexit", "-o", "nounset", "-o", "pipefail", "-c"]
 # Install required system packages and dependencies
-RUN install_packages ca-certificates curl git jq procps
+RUN install_packages ca-certificates curl git jq procps gettext-base
 RUN mkdir -p /tmp/bitnami/pkg/cache/ ; cd /tmp/bitnami/pkg/cache/ ; \
     COMPONENTS=( \
       "kubectl-1.29.1-0-linux-${OS_ARCH}-debian-11" \
@@ -39,7 +39,6 @@ RUN mkdir -p /tmp/bitnami/pkg/cache/ ; cd /tmp/bitnami/pkg/cache/ ; \
     done
 RUN apt-get autoremove --purge -y curl && \
     apt-get update && apt-get upgrade -y && \
-    apt-get -y install gettext-base && \
     apt-get clean && rm -rf /var/lib/apt/lists /var/cache/apt/archives
 RUN chmod g+rwX /opt/bitnami
 RUN mkdir /.kube && chmod g+rwX /.kube


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This changes adds `envsubst` to the `kubectl` image.

### Benefits

This helps when using using kubernetes manifests that have values that change depending upon the environment situation.
It is fairly common to do something like the following:

```
export SERVER_URL="my-prod-server"
envsubst < my-manifest.yaml | kubectl apply -f -
```

### Possible drawbacks

It increases the image size a bit (I believe about 100K).

### Applicable issues


### Additional information

This was already done/raised for #34957 