### PR TITLE
[bitnami/minio] Update minio-env.sh to allow custom path for persist

### DIFF
--- a/bitnami/minio/2024/debian-11/rootfs/opt/bitnami/scripts/minio-env.sh
+++ b/bitnami/minio/2024/debian-11/rootfs/opt/bitnami/scripts/minio-env.sh
@@ -39,6 +39,7 @@ minio_env_vars=(
     MINIO_FORCE_NEW_KEYS
     MINIO_ROOT_USER
     MINIO_ROOT_PASSWORD
+    MINIO_DATA_DIR
 )
 for env_var in "${minio_env_vars[@]}"; do
     file_env_var="${env_var}_FILE"
@@ -60,7 +61,7 @@ export MINIO_CERTS_DIR="/certs"
 export MINIO_LOGS_DIR="${MINIO_BASE_DIR}/log"
 export MINIO_TMP_DIR="${MINIO_BASE_DIR}/tmp"
 export MINIO_SECRETS_DIR="${MINIO_BASE_DIR}/secrets"
-export MINIO_DATA_DIR="/bitnami/minio/data"
+export MINIO_DATA_DIR="${MINIO_DATA_DIR:-/bitnami/minio/data}"
 export MINIO_LOG_FILE="${MINIO_LOGS_DIR}/minio.log"
 export MINIO_PID_FILE="${MINIO_TMP_DIR}/minio.pid"
 export PATH="${MINIO_BIN_DIR}:${PATH}"

--- a/bitnami/minio/README.md
+++ b/bitnami/minio/README.md
@@ -68,7 +68,7 @@ docker build -t bitnami/APP:latest .
 
 If you remove the container all your data will be lost, and the next time you run the image the database will be reinitialized. To avoid this loss of data, you should mount a volume that will persist even after the container is removed.
 
-For persistence you should mount a directory at the `/bitnami/minio/data` path.
+For persistence you can mount a directory at the `/bitnami/minio/data` path by default.
 
 ```console
 docker run --name minio \
@@ -86,6 +86,31 @@ services:
   ...
     volumes:
       - /path/to/minio-persistence:/bitnami/minio/data
+  ...
+```
+
+You can also mount a volume to a custom path inside the container, provided that you run the container using the `MINIO_DATA_DIR` environment variable.
+
+```console
+docker run --name minio \
+    --publish 9000:9000 \
+    --publish 9001:9001 \
+    --volume /path/to/minio-persistence:/custom/path/within/container \
+    --env MINIO_DATA_DIR=/custom/path/within/container \
+    bitnami/minio:latest
+```
+
+or by modifying the [`docker-compose.yml`](https://github.com/bitnami/containers/blob/main/bitnami/minio/docker-compose.yml) file present in this repository:
+
+```yaml
+services:
+  minio:
+  ...
+    volumes:
+      - /path/to/minio-persistence:/custom/path/within/container
+  ...
+    environment:
+      - MINIO_DATA_DIR=/custom/path/within/container
   ...
 ```
 
@@ -199,6 +224,7 @@ docker-compose up -d
 | `MINIO_FORCE_NEW_KEYS`                   | Force recreating MinIO keys.                                               | `no`                                               |
 | `MINIO_ROOT_USER`                        | MinIO root user name.                                                      | `minio`                                            |
 | `MINIO_ROOT_PASSWORD`                    | Password for MinIO root user.                                              | `miniosecret`                                      |
+| `MINIO_DATA_DIR`                         | Directory that stores MinIO object data                                    | `/bitnami/minio/data`                              |
 
 #### Read-only environment variables
 
@@ -210,14 +236,12 @@ docker-compose up -d
 | `MINIO_LOGS_DIR`     | MinIO directory for log files.        | `${MINIO_BASE_DIR}/log`       |
 | `MINIO_TMP_DIR`      | MinIO directory for log files.        | `${MINIO_BASE_DIR}/tmp`       |
 | `MINIO_SECRETS_DIR`  | MinIO directory for credentials.      | `${MINIO_BASE_DIR}/secrets`   |
-| `MINIO_DATA_DIR`     | MinIO directory for data.             | `/bitnami/minio/data`         |
-| `MINIO_DATA_DIR`     | MinIO directory for data.             | `/bitnami/minio/data`         |
 | `MINIO_LOG_FILE`     | MinIO log file.                       | `${MINIO_LOGS_DIR}/minio.log` |
 | `MINIO_PID_FILE`     | MinIO PID file.                       | `${MINIO_TMP_DIR}/minio.pid`  |
 | `MINIO_DAEMON_USER`  | MinIO system user.                    | `minio`                       |
 | `MINIO_DAEMON_GROUP` | MinIO system group.                   | `minio`                       |
 
-Additionally, MiNIO can be configured via environment variables as detailed at [MinIO(R) documentation](https://docs.min.io/docs/minio-server-configuration-guide.html).
+Additionally, MinIO can be configured via environment variables as detailed at [MinIO(R) documentation](https://docs.min.io/docs/minio-server-configuration-guide.html).
 
 A MinIO(R) Client  (`mc`) is also shipped on this image that can be used to perform administrative tasks as described at the [MinIO(R) Client documentation](https://docs.min.io/docs/minio-admin-complete-guide.html). In the example below, the client is used to obtain the server info:
 


### PR DESCRIPTION
…nce directory and updated README.md

### Description of the change

This change allows the `MINIO_DATA_DIR` environment variable to be a configurable value so that the persistence directory can exist at a path inside the container that is not `/bitnami/minio/data`.

### Benefits

This allows users to have a persistence directory that is not the default `bitnami/minio/data` path so that mounting the persistence volume to something like AWS EFS or EBS can be done with naming conventions suited to the user/team.

### Possible drawbacks

This is very small change, I honestly can't think of any apart from something to check while troubleshooting/debugging.

### Applicable issues

My own issue created in `bitnami/charts` > https://github.com/bitnami/charts/issues/21757 (I will be looking at creating a Helm chart PR in the next few days as well, when I get time).

### Additional information

I tested this by running the container image locally, going into the UI and creating a new bucket called `test-bucket` and you can see that when I shell into the container, there is a `test-bucket` directory created at the custom persistence path.

Here is a screenshot of my terminal to prove that the bucket exists in the correct place (inside `custom-data-dir`):

![Screenshot from 2024-01-29 22-36-15](https://github.com/bitnami/containers/assets/88185573/be8556dc-a894-4961-95b6-564176982d12)

![Screenshot from 2024-01-29 22-37-20](https://github.com/bitnami/containers/assets/88185573/a7bf641c-2233-4bd2-8c0a-5764ae17a5f1)

I would not consider this a limitation but this configuration requires that the user deploying the container must have the container path mount and the environment variables as the same value. This is ONLY when configuring the container to use a custom persistence path, the default `/bitnami/minio/data` can still be used. I have updated the relevant section of the `README.md` which explains.