### PR TITLE
[bitnami/wildfly] Fix check-app-version test

### DIFF
--- a/.vib/wildfly/goss/vars.yaml
+++ b/.vib/wildfly/goss/vars.yaml
@@ -15,5 +15,5 @@ files:
       - /opt/bitnami/wildfly/bin/standalone.conf
 root_dir: /opt/bitnami
 version:
-  bin_name: standalone.sh
-  flag: --version
+  bin_name: grep "Final</version>" /opt/bitnami/wildfly/docs/licenses/licenses.xml
+  flag: ""


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Fix `check-app-version` test. Difference between versions are:

* 30.0.1
```
$ standalone.sh -V
...
WildFly Full 30.0.1.Final (WildFly Core 22.0.2.Final)
```

* 31.0.0

```
$ standalone.sh -V
...
WildFly Core 23.0.1.Final
```