### PR TITLE
[bitnami/*] Set Trivy threshold to LOW

### DIFF
--- a/.vib/acmesolver/vib-verify.json
+++ b/.vib/acmesolver/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/airflow-exporter/vib-verify.json
+++ b/.vib/airflow-exporter/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/airflow-scheduler/vib-verify.json
+++ b/.vib/airflow-scheduler/vib-verify.json
@@ -53,7 +53,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/airflow-worker/vib-verify.json
+++ b/.vib/airflow-worker/vib-verify.json
@@ -53,7 +53,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/airflow/vib-verify.json
+++ b/.vib/airflow/vib-verify.json
@@ -53,7 +53,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/alertmanager/vib-verify.json
+++ b/.vib/alertmanager/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/apache-exporter/vib-verify.json
+++ b/.vib/apache-exporter/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/apache/vib-verify.json
+++ b/.vib/apache/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/apisix-dashboard/vib-verify.json
+++ b/.vib/apisix-dashboard/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/apisix-ingress-controller/vib-verify.json
+++ b/.vib/apisix-ingress-controller/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/apisix/vib-verify.json
+++ b/.vib/apisix/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/appsmith/vib-verify.json
+++ b/.vib/appsmith/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/argo-cd/vib-verify.json
+++ b/.vib/argo-cd/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/argo-workflow-cli/vib-verify.json
+++ b/.vib/argo-workflow-cli/vib-verify.json
@@ -36,7 +36,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/argo-workflow-controller/vib-verify.json
+++ b/.vib/argo-workflow-controller/vib-verify.json
@@ -36,7 +36,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/argo-workflow-exec/vib-verify.json
+++ b/.vib/argo-workflow-exec/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/aspnet-core/vib-verify.json
+++ b/.vib/aspnet-core/vib-verify.json
@@ -51,7 +51,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/attu/vib-verify.json
+++ b/.vib/attu/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/aws-cli/vib-verify.json
+++ b/.vib/aws-cli/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/azure-cli/vib-verify.json
+++ b/.vib/azure-cli/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/blackbox-exporter/vib-verify.json
+++ b/.vib/blackbox-exporter/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/cainjector/vib-verify.json
+++ b/.vib/cainjector/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/cassandra-exporter/vib-verify.json
+++ b/.vib/cassandra-exporter/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/cassandra/vib-verify.json
+++ b/.vib/cassandra/vib-verify.json
@@ -51,7 +51,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/cert-manager-webhook/vib-verify.json
+++ b/.vib/cert-manager-webhook/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/cert-manager/vib-verify.json
+++ b/.vib/cert-manager/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/clickhouse/vib-verify.json
+++ b/.vib/clickhouse/vib-verify.json
@@ -36,7 +36,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/cluster-autoscaler/vib-verify.json
+++ b/.vib/cluster-autoscaler/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/concourse/vib-verify.json
+++ b/.vib/concourse/vib-verify.json
@@ -51,7 +51,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/configmap-reload/vib-verify.json
+++ b/.vib/configmap-reload/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/configurable-http-proxy/vib-verify.json
+++ b/.vib/configurable-http-proxy/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/consul-exporter/vib-verify.json
+++ b/.vib/consul-exporter/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/consul/vib-verify.json
+++ b/.vib/consul/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/contour/vib-verify.json
+++ b/.vib/contour/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/cosign/vib-verify.json
+++ b/.vib/cosign/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/couchdb/vib-verify.json
+++ b/.vib/couchdb/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/deepspeed/vib-verify.json
+++ b/.vib/deepspeed/vib-verify.json
@@ -49,7 +49,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": ["OS"]
           }
         },

--- a/.vib/dex/vib-verify.json
+++ b/.vib/dex/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/discourse/vib-verify.json
+++ b/.vib/discourse/vib-verify.json
@@ -51,7 +51,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/dokuwiki/vib-verify.json
+++ b/.vib/dokuwiki/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/dotnet-sdk/vib-verify.json
+++ b/.vib/dotnet-sdk/vib-verify.json
@@ -51,7 +51,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/dotnet/vib-verify.json
+++ b/.vib/dotnet/vib-verify.json
@@ -51,7 +51,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/drupal/vib-verify.json
+++ b/.vib/drupal/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/ejbca/vib-verify.json
+++ b/.vib/ejbca/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/elasticsearch-exporter/vib-verify.json
+++ b/.vib/elasticsearch-exporter/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/elasticsearch/vib-verify.json
+++ b/.vib/elasticsearch/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/envoy/vib-verify.json
+++ b/.vib/envoy/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/etcd/3.4/vib-verify.json
+++ b/.vib/etcd/3.4/vib-verify.json
@@ -51,7 +51,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/etcd/vib-verify.json
+++ b/.vib/etcd/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/express/vib-verify.json
+++ b/.vib/express/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/external-dns/vib-verify.json
+++ b/.vib/external-dns/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/flink/vib-verify.json
+++ b/.vib/flink/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/fluent-bit/vib-verify.json
+++ b/.vib/fluent-bit/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/fluentd/vib-verify.json
+++ b/.vib/fluentd/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/fluxcd-helm-controller/vib-verify.json
+++ b/.vib/fluxcd-helm-controller/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/fluxcd-image-automation-controller/vib-verify.json
+++ b/.vib/fluxcd-image-automation-controller/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/fluxcd-image-reflector-controller/vib-verify.json
+++ b/.vib/fluxcd-image-reflector-controller/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/fluxcd-kustomize-controller/vib-verify.json
+++ b/.vib/fluxcd-kustomize-controller/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/fluxcd-notification-controller/vib-verify.json
+++ b/.vib/fluxcd-notification-controller/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/fluxcd-source-controller/vib-verify.json
+++ b/.vib/fluxcd-source-controller/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/ghost/vib-verify.json
+++ b/.vib/ghost/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/git/vib-verify.json
+++ b/.vib/git/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/gitea/vib-verify.json
+++ b/.vib/gitea/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/gitlab-runner-helper/vib-verify.json
+++ b/.vib/gitlab-runner-helper/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/gitlab-runner/vib-verify.json
+++ b/.vib/gitlab-runner/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/golang/vib-verify.json
+++ b/.vib/golang/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/google-cloud-sdk/vib-verify.json
+++ b/.vib/google-cloud-sdk/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/gotrue/vib-verify.json
+++ b/.vib/gotrue/vib-verify.json
@@ -36,7 +36,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/gradle/vib-verify.json
+++ b/.vib/gradle/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/grafana-image-renderer/vib-verify.json
+++ b/.vib/grafana-image-renderer/vib-verify.json
@@ -51,7 +51,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/grafana-loki/vib-verify.json
+++ b/.vib/grafana-loki/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/grafana-mimir/vib-verify.json
+++ b/.vib/grafana-mimir/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/grafana-operator/vib-verify.json
+++ b/.vib/grafana-operator/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/grafana-tempo-query/vib-verify.json
+++ b/.vib/grafana-tempo-query/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/grafana-tempo-vulture/vib-verify.json
+++ b/.vib/grafana-tempo-vulture/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/grafana-tempo/vib-verify.json
+++ b/.vib/grafana-tempo/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/grafana/vib-verify.json
+++ b/.vib/grafana/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/haproxy/vib-verify.json
+++ b/.vib/haproxy/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/harbor-adapter-trivy/vib-verify.json
+++ b/.vib/harbor-adapter-trivy/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/harbor-core/vib-verify.json
+++ b/.vib/harbor-core/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/harbor-exporter/vib-verify.json
+++ b/.vib/harbor-exporter/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/harbor-jobservice/vib-verify.json
+++ b/.vib/harbor-jobservice/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/harbor-portal/vib-verify.json
+++ b/.vib/harbor-portal/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/harbor-registry/vib-verify.json
+++ b/.vib/harbor-registry/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/harbor-registryctl/vib-verify.json
+++ b/.vib/harbor-registryctl/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/influxdb/vib-verify.json
+++ b/.vib/influxdb/vib-verify.json
@@ -51,7 +51,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/jaeger/vib-verify.json
+++ b/.vib/jaeger/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/java/vib-verify.json
+++ b/.vib/java/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/jax/vib-verify.json
+++ b/.vib/jax/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/jenkins-agent/vib-verify.json
+++ b/.vib/jenkins-agent/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/jenkins/vib-verify.json
+++ b/.vib/jenkins/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/jmx-exporter/vib-verify.json
+++ b/.vib/jmx-exporter/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/joomla/vib-verify.json
+++ b/.vib/joomla/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/jruby/vib-verify.json
+++ b/.vib/jruby/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/jsonnet/vib-verify.json
+++ b/.vib/jsonnet/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/jupyter-base-notebook/vib-verify.json
+++ b/.vib/jupyter-base-notebook/vib-verify.json
@@ -51,7 +51,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/jupyterhub/vib-verify.json
+++ b/.vib/jupyterhub/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/jwt-cli/vib-verify.json
+++ b/.vib/jwt-cli/vib-verify.json
@@ -51,7 +51,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/kafka-exporter/vib-verify.json
+++ b/.vib/kafka-exporter/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/kafka/vib-verify.json
+++ b/.vib/kafka/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/kaniko/vib-verify.json
+++ b/.vib/kaniko/vib-verify.json
@@ -36,7 +36,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/kapacitor/vib-verify.json
+++ b/.vib/kapacitor/vib-verify.json
@@ -36,7 +36,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/keycloak-config-cli/vib-verify.json
+++ b/.vib/keycloak-config-cli/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/keycloak/vib-verify.json
+++ b/.vib/keycloak/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/kiam/vib-verify.json
+++ b/.vib/kiam/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/kibana/vib-verify.json
+++ b/.vib/kibana/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/kong-ingress-controller/vib-verify.json
+++ b/.vib/kong-ingress-controller/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/kong/vib-verify.json
+++ b/.vib/kong/vib-verify.json
@@ -51,7 +51,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/ksql/vib-verify.json
+++ b/.vib/ksql/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/kube-rbac-proxy/vib-verify.json
+++ b/.vib/kube-rbac-proxy/vib-verify.json
@@ -36,7 +36,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/kube-state-metrics/vib-verify.json
+++ b/.vib/kube-state-metrics/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/kubeapps-apis/vib-verify.json
+++ b/.vib/kubeapps-apis/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/kubeapps-apprepository-controller/vib-verify.json
+++ b/.vib/kubeapps-apprepository-controller/vib-verify.json
@@ -36,7 +36,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/kubeapps-asset-syncer/vib-verify.json
+++ b/.vib/kubeapps-asset-syncer/vib-verify.json
@@ -36,7 +36,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/kubeapps-dashboard/vib-verify.json
+++ b/.vib/kubeapps-dashboard/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/kubeapps-oci-catalog/vib-verify.json
+++ b/.vib/kubeapps-oci-catalog/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": ["OS"]
           }
         },

--- a/.vib/kubeapps-pinniped-proxy/vib-verify.json
+++ b/.vib/kubeapps-pinniped-proxy/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/kubectl/vib-verify.json
+++ b/.vib/kubectl/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/kuberay-apiserver/vib-verify.json
+++ b/.vib/kuberay-apiserver/vib-verify.json
@@ -34,7 +34,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": ["OS"]
           }
         },

--- a/.vib/kuberay-operator/vib-verify.json
+++ b/.vib/kuberay-operator/vib-verify.json
@@ -34,7 +34,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": ["OS"]
           }
         },

--- a/.vib/kubernetes-event-exporter/vib-verify.json
+++ b/.vib/kubernetes-event-exporter/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/laravel/vib-verify.json
+++ b/.vib/laravel/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/logstash/vib-verify.json
+++ b/.vib/logstash/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/magento/vib-verify.json
+++ b/.vib/magento/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/mariadb-galera/10.4/vib-verify.json
+++ b/.vib/mariadb-galera/10.4/vib-verify.json
@@ -51,7 +51,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/mariadb-galera/vib-verify.json
+++ b/.vib/mariadb-galera/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/mariadb/10.4/vib-verify.json
+++ b/.vib/mariadb/10.4/vib-verify.json
@@ -51,7 +51,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/mariadb/vib-verify.json
+++ b/.vib/mariadb/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/mastodon/vib-verify.json
+++ b/.vib/mastodon/vib-verify.json
@@ -48,7 +48,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/matomo/vib-verify.json
+++ b/.vib/matomo/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/mediawiki/vib-verify.json
+++ b/.vib/mediawiki/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/memcached-exporter/vib-verify.json
+++ b/.vib/memcached-exporter/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/memcached/vib-verify.json
+++ b/.vib/memcached/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/metallb-controller/vib-verify.json
+++ b/.vib/metallb-controller/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/metallb-speaker/vib-verify.json
+++ b/.vib/metallb-speaker/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/metrics-server/vib-verify.json
+++ b/.vib/metrics-server/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/milvus/vib-verify.json
+++ b/.vib/milvus/vib-verify.json
@@ -48,7 +48,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/minio-client/vib-verify.json
+++ b/.vib/minio-client/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/minio/vib-verify.json
+++ b/.vib/minio/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/mlflow/vib-verify.json
+++ b/.vib/mlflow/vib-verify.json
@@ -49,7 +49,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": ["OS"]
           }
         },

--- a/.vib/mongodb-exporter/vib-verify.json
+++ b/.vib/mongodb-exporter/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/mongodb-sharded/vib-verify.json
+++ b/.vib/mongodb-sharded/vib-verify.json
@@ -51,7 +51,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/mongodb/vib-verify.json
+++ b/.vib/mongodb/vib-verify.json
@@ -51,7 +51,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/moodle/vib-verify.json
+++ b/.vib/moodle/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/multus-cni/vib-verify.json
+++ b/.vib/multus-cni/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/mysql/vib-verify.json
+++ b/.vib/mysql/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/mysqld-exporter/vib-verify.json
+++ b/.vib/mysqld-exporter/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/nats-exporter/vib-verify.json
+++ b/.vib/nats-exporter/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/nats/vib-verify.json
+++ b/.vib/nats/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/natscli/vib-verify.json
+++ b/.vib/natscli/vib-verify.json
@@ -49,7 +49,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": ["OS"]
           }
         },

--- a/.vib/neo4j/vib-verify.json
+++ b/.vib/neo4j/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/nginx-exporter/vib-verify.json
+++ b/.vib/nginx-exporter/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/nginx-ingress-controller/vib-verify.json
+++ b/.vib/nginx-ingress-controller/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/nginx/vib-verify.json
+++ b/.vib/nginx/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/node-exporter/vib-verify.json
+++ b/.vib/node-exporter/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/node/vib-verify.json
+++ b/.vib/node/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/notation/vib-verify.json
+++ b/.vib/notation/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/oauth2-proxy/vib-verify.json
+++ b/.vib/oauth2-proxy/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/odoo/14/vib-verify.json
+++ b/.vib/odoo/14/vib-verify.json
@@ -51,7 +51,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/odoo/vib-verify.json
+++ b/.vib/odoo/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/opencart/vib-verify.json
+++ b/.vib/opencart/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/openldap/vib-verify.json
+++ b/.vib/openldap/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/openresty/vib-verify.json
+++ b/.vib/openresty/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/opensearch-dashboards/vib-verify.json
+++ b/.vib/opensearch-dashboards/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/opensearch/vib-verify.json
+++ b/.vib/opensearch/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/oras/vib-verify.json
+++ b/.vib/oras/vib-verify.json
@@ -36,7 +36,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/os-shell/vib-verify.json
+++ b/.vib/os-shell/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/osclass/vib-verify.json
+++ b/.vib/osclass/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/parse-dashboard/vib-verify.json
+++ b/.vib/parse-dashboard/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/parse/vib-verify.json
+++ b/.vib/parse/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/percona-mysql/vib-verify.json
+++ b/.vib/percona-mysql/vib-verify.json
@@ -36,7 +36,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/percona-xtrabackup/vib-verify.json
+++ b/.vib/percona-xtrabackup/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/pgbouncer/vib-verify.json
+++ b/.vib/pgbouncer/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/pgpool/vib-verify.json
+++ b/.vib/pgpool/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/php-fpm/vib-verify.json
+++ b/.vib/php-fpm/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/phpbb/vib-verify.json
+++ b/.vib/phpbb/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/phpmyadmin/vib-verify.json
+++ b/.vib/phpmyadmin/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/pinniped-cli/vib-verify.json
+++ b/.vib/pinniped-cli/vib-verify.json
@@ -49,7 +49,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": ["OS"]
           }
         },

--- a/.vib/pinniped/vib-verify.json
+++ b/.vib/pinniped/vib-verify.json
@@ -36,7 +36,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/postgres-exporter/vib-verify.json
+++ b/.vib/postgres-exporter/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/postgresql-repmgr/vib-verify.json
+++ b/.vib/postgresql-repmgr/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/postgresql/vib-verify.json
+++ b/.vib/postgresql/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/postgrest/vib-verify.json
+++ b/.vib/postgrest/vib-verify.json
@@ -51,7 +51,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/prestashop/vib-verify.json
+++ b/.vib/prestashop/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/prometheus-operator/vib-verify.json
+++ b/.vib/prometheus-operator/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/prometheus-rsocket-proxy/vib-verify.json
+++ b/.vib/prometheus-rsocket-proxy/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/prometheus/vib-verify.json
+++ b/.vib/prometheus/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/promtail/vib-verify.json
+++ b/.vib/promtail/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/pushgateway/vib-verify.json
+++ b/.vib/pushgateway/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/pymilvus/vib-verify.json
+++ b/.vib/pymilvus/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/python/vib-verify.json
+++ b/.vib/python/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/pytorch/vib-verify.json
+++ b/.vib/pytorch/vib-verify.json
@@ -51,7 +51,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/rabbitmq-cluster-operator/vib-verify.json
+++ b/.vib/rabbitmq-cluster-operator/vib-verify.json
@@ -36,7 +36,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/rabbitmq/vib-verify.json
+++ b/.vib/rabbitmq/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/rails/vib-verify.json
+++ b/.vib/rails/vib-verify.json
@@ -51,7 +51,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/ray/vib-verify.json
+++ b/.vib/ray/vib-verify.json
@@ -49,7 +49,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": ["OS"]
           }
         },

--- a/.vib/rclone/vib-verify.json
+++ b/.vib/rclone/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/redis-cluster/vib-verify.json
+++ b/.vib/redis-cluster/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/redis-exporter/vib-verify.json
+++ b/.vib/redis-exporter/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/redis-sentinel/vib-verify.json
+++ b/.vib/redis-sentinel/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/redis/vib-verify.json
+++ b/.vib/redis/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/redmine/vib-verify.json
+++ b/.vib/redmine/vib-verify.json
@@ -36,7 +36,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/rmq-default-credential-updater/vib-verify.json
+++ b/.vib/rmq-default-credential-updater/vib-verify.json
@@ -36,7 +36,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/rmq-messaging-topology-operator/vib-verify.json
+++ b/.vib/rmq-messaging-topology-operator/vib-verify.json
@@ -36,7 +36,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/ruby/vib-verify.json
+++ b/.vib/ruby/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/schema-registry/vib-verify.json
+++ b/.vib/schema-registry/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/sealed-secrets-controller/vib-verify.json
+++ b/.vib/sealed-secrets-controller/vib-verify.json
@@ -36,7 +36,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/sealed-secrets-kubeseal/vib-verify.json
+++ b/.vib/sealed-secrets-kubeseal/vib-verify.json
@@ -36,7 +36,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/solr/vib-verify.json
+++ b/.vib/solr/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/sonarqube/vib-verify.json
+++ b/.vib/sonarqube/vib-verify.json
@@ -36,7 +36,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/spark/vib-verify.json
+++ b/.vib/spark/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/spring-cloud-dataflow-composed-task-runner/vib-verify.json
+++ b/.vib/spring-cloud-dataflow-composed-task-runner/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/spring-cloud-dataflow-shell/vib-verify.json
+++ b/.vib/spring-cloud-dataflow-shell/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/spring-cloud-dataflow/vib-verify.json
+++ b/.vib/spring-cloud-dataflow/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/spring-cloud-skipper-shell/vib-verify.json
+++ b/.vib/spring-cloud-skipper-shell/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/spring-cloud-skipper/vib-verify.json
+++ b/.vib/spring-cloud-skipper/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/suitecrm/vib-verify.json
+++ b/.vib/suitecrm/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/supabase-postgres-meta/vib-verify.json
+++ b/.vib/supabase-postgres-meta/vib-verify.json
@@ -36,7 +36,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/supabase-postgres/vib-verify.json
+++ b/.vib/supabase-postgres/vib-verify.json
@@ -36,7 +36,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/supabase-realtime/vib-verify.json
+++ b/.vib/supabase-realtime/vib-verify.json
@@ -36,7 +36,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/supabase-storage/vib-verify.json
+++ b/.vib/supabase-storage/vib-verify.json
@@ -36,7 +36,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/supabase-studio/vib-verify.json
+++ b/.vib/supabase-studio/vib-verify.json
@@ -36,7 +36,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/telegraf/vib-verify.json
+++ b/.vib/telegraf/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/tensorflow-resnet/vib-verify.json
+++ b/.vib/tensorflow-resnet/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/tensorflow-serving/vib-verify.json
+++ b/.vib/tensorflow-serving/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/tensorflow/vib-verify.json
+++ b/.vib/tensorflow/vib-verify.json
@@ -49,7 +49,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": ["OS"]
           }
         },

--- a/.vib/thanos/vib-verify.json
+++ b/.vib/thanos/vib-verify.json
@@ -36,7 +36,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/tomcat-jdk-11/vib-verify.json
+++ b/.vib/tomcat-jdk-11/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/tomcat-jdk-17/vib-verify.json
+++ b/.vib/tomcat-jdk-17/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/tomcat/vib-verify.json
+++ b/.vib/tomcat/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/trivy/vib-verify.json
+++ b/.vib/trivy/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/vault-csi-provider/vib-verify.json
+++ b/.vib/vault-csi-provider/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/vault-k8s/vib-verify.json
+++ b/.vib/vault-k8s/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/vault/vib-verify.json
+++ b/.vib/vault/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/whereabouts/vib-verify.json
+++ b/.vib/whereabouts/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/wildfly/vib-verify.json
+++ b/.vib/wildfly/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/wordpress-nginx/vib-verify.json
+++ b/.vib/wordpress-nginx/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/wordpress/vib-verify.json
+++ b/.vib/wordpress/vib-verify.json
@@ -52,7 +52,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/.vib/zookeeper/vib-verify.json
+++ b/.vib/zookeeper/vib-verify.json
@@ -37,7 +37,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]

--- a/TESTING.md
+++ b/TESTING.md
@@ -64,7 +64,7 @@ Let's take a look at an example and try to understand it!
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "LOW",
             "vuln_type": [
               "OS"
             ]


### PR DESCRIPTION
### Description of the change

Set the threshold for the Trivy action to `LOW`.

### Benefits

As it seems that Trivy is checking the source package instead of the binary package, there are some false positives (e.g., receiving some alerts when the package is not even available for Debian 11). 

When this situation happens, this would block container images at the packaging step. Setting the threshold to `LOW` will help reduce the noise when a false positive happens.

### Possible drawbacks

We might have some unnecessary releases for users.