### PR TITLE
[bitnami/redis] test: :white_check_mark: Add sleep to avoid race condition

### DIFF
--- a/.vib/redis/goss/redis.yaml
+++ b/.vib/redis/goss/redis.yaml
@@ -12,7 +12,7 @@ file:
       - "daemonize yes"
 command:
   check-redis-server:
-    exec: redis-server /opt/bitnami/redis/etc/redis.conf && ps aux
+    exec: redis-server /opt/bitnami/redis/etc/redis.conf && sleep 5 && ps aux
     exit-status: 0
     timeout: 20000
     stdout:


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits
Currently, the redis tests are randomly failing because of a race condition between launching `redis-server` and checking `ps`. This PR adds a sleep to ensure that the process is running.

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
