### PR TITLE
[bitnami/percona-mysql] Remove xtrabackup binary from GOSS test

### DIFF
--- a/.vib/percona-mysql/goss/vars.yaml
+++ b/.vib/percona-mysql/goss/vars.yaml
@@ -3,7 +3,6 @@ binaries:
   - mysql
   - mysqld
   - mysqlsh
-  - xtrabackup
 directories:
   - mode: "0775"
     paths:


### PR DESCRIPTION
### Description of the change

Remove xtrabackup binary from GOSS test after percona-xtrabackup deprecation

