### PR TITLE
[bitnami/grafana-image-renderer] Fix goss tests: sed-in-place and linked-libraries

### DIFF
--- a/.vib/common/goss/scripts/check-sed-in-place.sh
+++ b/.vib/common/goss/scripts/check-sed-in-place.sh
@@ -12,6 +12,5 @@ for file in "${files[@]}"; do
   if [[ -n $EXCLUDE_PATHS ]] && [[ "$file" =~ $EXCLUDE_PATHS ]]; then
     continue
   fi
-  echo $file
   [[ $(grep -cE "sed -i|sed --in-place" "$file") -eq 0 ]] || exit 1
 done

--- a/.vib/common/goss/scripts/check-sed-in-place.sh
+++ b/.vib/common/goss/scripts/check-sed-in-place.sh
@@ -12,5 +12,6 @@ for file in "${files[@]}"; do
   if [[ -n $EXCLUDE_PATHS ]] && [[ "$file" =~ $EXCLUDE_PATHS ]]; then
     continue
   fi
+  echo $file
   [[ $(grep -cE "sed -i|sed --in-place" "$file") -eq 0 ]] || exit 1
 done

--- a/.vib/grafana-image-renderer/goss/vars.yaml
+++ b/.vib/grafana-image-renderer/goss/vars.yaml
@@ -10,4 +10,9 @@ files:
   - paths:
       - /opt/bitnami/grafana-image-renderer/conf/config.json
       - /opt/bitnami/grafana-image-renderer/plugin.json
+linked_libraries:
+  timeout: 45000
 root_dir: /opt/bitnami
+sed_in_place:
+  exclude_paths:
+    - /opt/bitnami/grafana-image-renderer/node_modules

--- a/.vib/grafana-image-renderer/goss/vars.yaml
+++ b/.vib/grafana-image-renderer/goss/vars.yaml
@@ -15,4 +15,4 @@ linked_libraries:
 root_dir: /opt/bitnami
 sed_in_place:
   exclude_paths:
-    - /opt/bitnami/grafana-image-renderer/node_modules
+    - /opt/bitnami/grafana-image-renderer/node_modules/babel-preset-current-node-syntax/scripts/check-yarn-bug.sh


### PR DESCRIPTION
### Description of the change

Fixes goss tests for `grafana-image-renderer` new release.

Increase check-linked-libraries timeout and exclude file `/opt/bitnami/grafana-image-renderer/node_modules/babel-preset-current-node-syntax/scripts/check-yarn-bug.sh` from check-sed-in-place.

Its content:
```
I have no name!@e7f95ad4c85d:/vib$ cat /opt/bitnami/grafana-image-renderer/node_modules/babel-preset-current-node-syntax/scripts/check-yarn-bug.sh
if grep 3155328e5 .yarn/releases/yarn-*.cjs -c; then
        echo "Your version of yarn is affected by https://github.com/yarnpkg/berry/issues/1882"
        echo "Please run \`sed -i -e \"s/3155328e5/4567890e5/g\" .yarn/releases/yarn-*.cjs\`"
        exit 1
fi
```