### PR TITLE
[bitnami/etcd] Stop logging root password

### DIFF
--- a/bitnami/etcd/3.4/debian-12/rootfs/opt/bitnami/scripts/etcd/run.sh
+++ b/bitnami/etcd/3.4/debian-12/rootfs/opt/bitnami/scripts/etcd/run.sh
@@ -18,7 +18,8 @@ set -o pipefail
 # Load etcd environment variables
 . /opt/bitnami/scripts/etcd-env.sh
 
-is_empty_value "$ETCD_ROOT_PASSWORD" && unset ETCD_ROOT_PASSWORD
+# We need to unset ETCD_ROOT_PASSWORD otherwise it will be logged by etcd process
+unset ETCD_ROOT_PASSWORD
 if [[ -f "$ETCD_NEW_MEMBERS_ENV_FILE" ]]; then
     debug "Loading env vars of existing cluster"
     . "$ETCD_NEW_MEMBERS_ENV_FILE"

--- a/bitnami/etcd/3.5/debian-12/rootfs/opt/bitnami/scripts/etcd/run.sh
+++ b/bitnami/etcd/3.5/debian-12/rootfs/opt/bitnami/scripts/etcd/run.sh
@@ -18,7 +18,9 @@ set -o pipefail
 # Load etcd environment variables
 . /opt/bitnami/scripts/etcd-env.sh
 
-is_empty_value "$ETCD_ROOT_PASSWORD" && unset ETCD_ROOT_PASSWORD
+# We need to unset ETCD_ROOT_PASSWORD otherwise it will be logged by etcd process
+unset ETCD_ROOT_PASSWORD
+
 if [[ -f "$ETCD_NEW_MEMBERS_ENV_FILE" ]]; then
     debug "Loading env vars of existing cluster"
     . "$ETCD_NEW_MEMBERS_ENV_FILE"


### PR DESCRIPTION

### Description of the change

Stop logging root password for etcd

### Benefits

This will avoid logging sensitive information in the stdout of the pod

### Possible drawbacks

N/A

### Applicable issues

https://github.com/bitnami/charts/issues/23910

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
