### PR TITLE
[bitnami/*] Update GOSS check-ca-certs destination

### DIFF
--- a/.vib/common/goss/templates/check-ca-certs.yaml
+++ b/.vib/common/goss/templates/check-ca-certs.yaml
@@ -7,5 +7,5 @@
 # - None
 ########################
 http:
-  https://www.bitnami.com:
+  https://bitnami.com:
     status: 200


### PR DESCRIPTION
### Description of the change

Updates check-ca-certs destination from https://www.bitnami.com to https://bitnami.com

### Benefits

It saves one redirection:

```console
$ curl -LI https://www.bitnami.com
HTTP/1.1 301 Moved Permanently
Location: https://bitnami.com/
HTTP/1.1 200 OK
```

```console
$ curl -LI https://bitnami.com
HTTP/1.1 200 OK
```

### Possible drawbacks

n/a

### Applicable issues

n/a

### Additional information

n/a