### PR TITLE
[Wordpress] Deflate mime-type text/javascript

### DIFF
--- a/bitnami/wordpress/6/debian-12/rootfs/opt/bitnami/apache/conf/deflate.conf
+++ b/bitnami/wordpress/6/debian-12/rootfs/opt/bitnami/apache/conf/deflate.conf
@@ -1,5 +1,5 @@
 <IfModule mod_deflate.c>
-  AddOutputFilterByType DEFLATE text/html text/plain text/xml text/css
+  AddOutputFilterByType DEFLATE text/html text/plain text/xml text/css text/javascript
   AddOutputFilterByType DEFLATE application/x-javascript application/javascript application/ecmascript
   AddOutputFilterByType DEFLATE application/rss+xml
 </IfModule>


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Configuration of the Apache webserver to include the mime-type `text/javascript` for compression the response.

### Benefits

<!-- What benefits will be realized by the code change? -->
Javascript will be smaller and therefore loaded more quickly.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
Servers should use text/javascript for JavaScript resources, in accordance with Updates to ECMAScript Media Types. Servers should not use other JavaScript MIME types for JavaScript resources, and must not use non-JavaScript MIME types. [RFC9239](https://www.rfc-editor.org/rfc/rfc9239)