### PR TITLE
[bitnami/nginx] latest image: Read-only file system fix #63507

### DIFF
--- a/bitnami/nginx/1.24/debian-12/rootfs/opt/bitnami/scripts/nginx/entrypoint.sh
+++ b/bitnami/nginx/1.24/debian-12/rootfs/opt/bitnami/scripts/nginx/entrypoint.sh
@@ -22,7 +22,7 @@ print_welcome_page
 # bypassing the setup.sh logic. If the file already exists do not overwrite (in
 # case someone mounts a configuration file in /opt/bitnami/nginx/conf)
 debug "Copying files from $NGINX_DEFAULT_CONF_DIR to $NGINX_CONF_DIR"
-cp -nr "$NGINX_DEFAULT_CONF_DIR"/. "$NGINX_CONF_DIR"
+cp -nr "$NGINX_DEFAULT_CONF_DIR"/. "$NGINX_CONF_DIR" || true
 
 
 if [[ "$1" = "/opt/bitnami/scripts/nginx/run.sh" ]]; then

--- a/bitnami/nginx/1.25/debian-12/rootfs/opt/bitnami/scripts/nginx/entrypoint.sh
+++ b/bitnami/nginx/1.25/debian-12/rootfs/opt/bitnami/scripts/nginx/entrypoint.sh
@@ -22,7 +22,7 @@ print_welcome_page
 # bypassing the setup.sh logic. If the file already exists do not overwrite (in
 # case someone mounts a configuration file in /opt/bitnami/nginx/conf)
 debug "Copying files from $NGINX_DEFAULT_CONF_DIR to $NGINX_CONF_DIR"
-cp -nr "$NGINX_DEFAULT_CONF_DIR"/. "$NGINX_CONF_DIR"
+cp -nr "$NGINX_DEFAULT_CONF_DIR"/. "$NGINX_CONF_DIR" || true
 
 
 if [[ "$1" = "/opt/bitnami/scripts/nginx/run.sh" ]]; then


### PR DESCRIPTION
### Description of the change
Fixes issue https://github.com/bitnami/containers/issues/63507 , with least impact for most people.

### Benefits
This fixes a newly introduced issue for people who use read-only file systems.


### Possible drawbacks
Might silently ignore errors during the cp.

### Applicable issues
- fixes #63507
