### PR TITLE
[bitnami/keycloak] Add KEYCLOAK_CREATE_ADMIN_USER to list of configs documented in README

### DIFF
--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -73,6 +73,7 @@ docker build -t bitnami/APP:latest .
 | Name                               | Description                                                                                   | Default Value                 |
 |------------------------------------|-----------------------------------------------------------------------------------------------|-------------------------------|
 | `KEYCLOAK_MOUNTED_CONF_DIR`        | Directory for including custom configuration files (that override the default generated ones) | `${KEYCLOAK_VOLUME_DIR}/conf` |
+| `KEYCLOAK_CREATE_ADMIN_USER`       | Create Keycloak administrator user                                                            | `false`                        |
 | `KEYCLOAK_ADMIN`                   | Keycloak administrator user                                                                   | `user`                        |
 | `KEYCLOAK_ADMIN_PASSWORD`          | Keycloak administrator password                                                               | `bitnami`                     |
 | `KEYCLOAK_HTTP_RELATIVE_PATH`      | Set the path relative to "/" for serving resources.                                           | `/`                           |


### PR DESCRIPTION
### Description of the change

I added KEYCLOAK_CREATE_ADMIN_USER to the README. I did not get an ADMIN USER from the container by default, so I guess the default for that is false. This config is part of the original keycloak container.

### Benefits

User is informed how to get an admin user.

### Possible drawbacks

None.
