### PR TITLE
[bitnami/kubescape] Increase test timeout

### DIFF
--- a/.vib/kubescape/goss/kubescape.yaml
+++ b/.vib/kubescape/goss/kubescape.yaml
@@ -13,6 +13,6 @@ command:
   check-oss-assessment:
     exec: mkdir {{ $target }} && tar -xf ./kubescape/goss/testfiles/sealed-secrets.tar.gz -C {{ $target }}; /opt/bitnami/scripts/kubescape/entrypoint.sh oss-assessment {{ $target }}
     exit-status: 0
-    timeout: 30000
+    timeout: 60000
     stdout:
       - "\"security\":"


### PR DESCRIPTION
Increases 'oss-assessment' test timeout from 30s to 60s