### PR TITLE
[bitnami/oauth2-proxy] Fix broken Further Information link

### DIFF
--- a/bitnami/oauth2-proxy/README.md
+++ b/bitnami/oauth2-proxy/README.md
@@ -87,7 +87,7 @@ We can launch another containers using the same flag (`--network NETWORK`) in th
 ## Configuration
 
 Oauth2-proxy can be configured via config file, command line options or environment variables.
-[Further information](https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview)
+[Further information](https://oauth2-proxy.github.io/oauth2-proxy/configuration/overview)
 
 ## Logging
 


### PR DESCRIPTION
Link currently sends viewer to a 404. Appears the organization of the target site has changed and doesn't do a friendly redirect, so I just updated the link target directly.

### Description of the change

Documentation-only change

### Benefits

Users no longer sent to a 404 when clicking link

### Possible drawbacks

None

### Applicable issues

- fixes #63759

### Additional information
N/A
