### PR TITLE
Add support for overlay - Reverse Group Membership Maintenance

### DIFF
--- a/bitnami/openldap/README.md
+++ b/bitnami/openldap/README.md
@@ -219,6 +219,19 @@ This overlay can record accesses to a given backend database on another database
 
 Check the official page [OpenLDAP, Overlays, Access Logging](https://www.openldap.org/doc/admin26/overlays.html#Access%20Logging) for detailed configuration information.
 
+#### Reverse Group Membership Maintenance
+
+* `LDAP_ENABLE_MEMBEROF`: Enables the memberof module with the following configuration defaults unless specified otherwise. Default: **no**.
+* `LDAP_MEMBEROF_DN` : The DN that is used as modifiersName for internal modifications performed to update the reverse group membership. Will only be applied with `LDAP_ENABLE_MEMBEROF` active. Default: **rootdn of the underlying database**.
+* `LDAP_MEMBEROF_DANGLING` : Specifies the behavior when a member is deleted or modified in a way that would break the group membership. Will only be applied with `LDAP_ENABLE_MEMBEROF` active. Default: **ignore**.
+* `LDAP_MEMBEROF_DANGLINGERROR` : Can be used to modify the response code returned in case of violation. Will only be applied with `LDAP_ENABLE_MEMBEROF` active. Default: {constraint violation} **80**.
+* `LDAP_MEMBEROF_REFINT` : Determines whether the overlay will try to preserve referential integrity or not. Will only be applied with `LDAP_ENABLE_MEMBEROF` active. Must be {true|false}. Default: **FALSE**.
+* `LDAP_MEMBEROF_GROUPOC` : The name of the objectClass that triggers the reverse group membership update. Will only be applied with `LDAP_ENABLE_MEMBEROF` active. Default: **groupOfNames**.
+* `LDAP_MEMBEROF_MEMBERAD` : The name of the attribute that contains the names of the members in the group objects; it must be DN-valued. Will only be applied with `LDAP_ENABLE_MEMBEROF` active. Default: **member**.
+* `LDAP_MEMBEROF_MEMBEROFAD` : The name of  the attribute that contains the names of the groups an entry is member of; it must be DN-valued. Will only be applied with `LDAP_ENABLE_MEMBEROF` active. Default: **memberOf**.
+
+Check the official page [OpenLDAP, Overlays, Reverse Group Membership Maintenance](https://www.openldap.org/doc/admin26/overlays.html#Reverse%20Group%20Membership%20Maintenance) for detailed configuration information.
+
 #### Sync Provider
 
 * `LDAP_ENABLE_SYNCPROV`: Enables the syncrepl module with the following configuration defaults unless specified otherwise. Default: **no**.

--- a/bitnami/tensorflow-serving/2/debian-12/Dockerfile
+++ b/bitnami/tensorflow-serving/2/debian-12/Dockerfile
@@ -8,10 +8,10 @@ ARG TARGETARCH
 
 LABEL com.vmware.cp.artifact.flavor="sha256:c50c90cfd9d12b445b011e6ad529f1ad3daea45c26d20b00732fae3cd71f6a83" \
       org.opencontainers.image.base.name="docker.io/bitnami/minideb:bookworm" \
-      org.opencontainers.image.created="2024-02-22T05:22:53Z" \
+      org.opencontainers.image.created="2024-03-23T05:55:51Z" \
       org.opencontainers.image.description="Application packaged by VMware, Inc" \
       org.opencontainers.image.licenses="Apache-2.0" \
-      org.opencontainers.image.ref.name="2.14.1-debian-12-r9" \
+      org.opencontainers.image.ref.name="2.14.1-debian-12-r10" \
       org.opencontainers.image.title="tensorflow-serving" \
       org.opencontainers.image.vendor="VMware, Inc." \
       org.opencontainers.image.version="2.14.1"
@@ -28,7 +28,7 @@ SHELL ["/bin/bash", "-o", "errexit", "-o", "nounset", "-o", "pipefail", "-c"]
 RUN install_packages ca-certificates curl gcc-11 libgcc-s1 libstdc++6 procps
 RUN mkdir -p /tmp/bitnami/pkg/cache/ ; cd /tmp/bitnami/pkg/cache/ ; \
     COMPONENTS=( \
-      "render-template-1.0.6-9-linux-${OS_ARCH}-debian-12" \
+      "render-template-1.0.6-10-linux-${OS_ARCH}-debian-12" \
       "tensorflow-serving-2.14.1-3-linux-${OS_ARCH}-debian-12" \
     ) ; \
     for COMPONENT in "${COMPONENTS[@]}"; do \

--- a/bitnami/tensorflow-serving/2/debian-12/prebuildfs/opt/bitnami/.bitnami_components.json
+++ b/bitnami/tensorflow-serving/2/debian-12/prebuildfs/opt/bitnami/.bitnami_components.json
@@ -3,7 +3,7 @@
         "arch": "amd64",
         "distro": "debian-12",
         "type": "NAMI",
-        "version": "1.0.6-9"
+        "version": "1.0.6-10"
     },
     "tensorflow-serving": {
         "arch": "amd64",

--- a/bitnami/tensorflow-serving/2/debian-12/prebuildfs/opt/bitnami/scripts/libbitnami.sh
+++ b/bitnami/tensorflow-serving/2/debian-12/prebuildfs/opt/bitnami/scripts/libbitnami.sh
@@ -48,6 +48,7 @@ print_image_welcome_page() {
     info "${BOLD}Welcome to the Bitnami ${BITNAMI_APP_NAME} container${RESET}"
     info "Subscribe to project updates by watching ${BOLD}${github_url}${RESET}"
     info "Submit issues and feature requests at ${BOLD}${github_url}/issues${RESET}"
+    info "Upgrade to Tanzu Application Catalog for production environments to access custom-configured and pre-packaged software components. Gain enhanced features, including Software Bill of Materials (SBOM), CVE scan result reports, and VEX documents. To learn more, visit ${BOLD}https://bitnami.com/enterprise${RESET}"
     info ""
 }
 


### PR DESCRIPTION
### Description of the change

This change extends the existing [bitnami/openldap:2.6] container deployment with configurable support for the existing memberOf module:

- Reverse Group Membership Maintenance `memberOf`

### Benefits

Future users of the [bitnami/openldap] container will be able to access the Reverse Group Membership Maintenance module and functionality with minimal configuration.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

This change originally created to provide the capability required to support the use case described in [this](https://github.com/bitnami/containers/issues/50524) issue

Subsequently Openldap Team changes her mind about memberof overlay : it is no more deprecated [this announce](https://lists.openldap.org/hyperkitty/list/openldap-devel@openldap.org/thread/2GPCBKOPH5KY6X36D74KED7STFW5JMAU/)
