### PR TITLE
[bitnami/keycloak] Add KC_RUN_IN_CONTAINER env. var.

### DIFF
--- a/bitnami/keycloak/24/debian-12/rootfs/opt/bitnami/scripts/keycloak-env.sh
+++ b/bitnami/keycloak/24/debian-12/rootfs/opt/bitnami/scripts/keycloak-env.sh
@@ -116,6 +116,9 @@ export KEYCLOAK_INITSCRIPTS_DIR="/docker-entrypoint-initdb.d"
 export KEYCLOAK_CONF_FILE="keycloak.conf"
 export KEYCLOAK_DEFAULT_CONF_FILE="keycloak.conf"
 
+# Keycloak kc.sh context (not used in config file)
+export KC_RUN_IN_CONTAINER="true"
+
 # Keycloak configuration
 KEYCLOAK_ADMIN="${KEYCLOAK_ADMIN:-"${KEYCLOAK_ADMIN_USER:-}"}"
 export KEYCLOAK_ADMIN="${KEYCLOAK_ADMIN:-user}"


### PR DESCRIPTION
### Description of the change

Adds the `KC_RUN_IN_CONTAINER` environment variable to `keycloak-env.sh`. This matches the change in https://github.com/keycloak/keycloak/pull/26661, where `kc.sh` now uses that to automatically set the heap options based on container resources.

### Benefits

Users no longer need to override `JAVA_OPTS`, etc. to set container heap options.

### Possible drawbacks

None known.

### Applicable issues

See also #63545 as Keycloak 24 is where support for this was added.

### Additional information

None.
