### PR TITLE
[bitnami/elasticsearch] Enclose IPv6 addresses in square brackets in the healthcheck URL.

### DIFF
--- a/bitnami/elasticsearch/7/debian-12/rootfs/opt/bitnami/scripts/libelasticsearch.sh
+++ b/bitnami/elasticsearch/7/debian-12/rootfs/opt/bitnami/scripts/libelasticsearch.sh
@@ -909,6 +909,9 @@ elasticsearch_healthcheck() {
     local host
 
     host=$(get_elasticsearch_hostname)
+    if validate_ipv6 "$host"; then
+        host="[$host]"
+    fi
 
     if is_boolean_yes "$DB_ENABLE_SECURITY"; then
         command_args+=("-k" "--user" "${DB_USERNAME}:${DB_PASSWORD}")

--- a/bitnami/elasticsearch/7/debian-12/rootfs/opt/bitnami/scripts/libelasticsearch.sh
+++ b/bitnami/elasticsearch/7/debian-12/rootfs/opt/bitnami/scripts/libelasticsearch.sh
@@ -909,8 +909,8 @@ elasticsearch_healthcheck() {
     local host
 
     host=$(get_elasticsearch_hostname)
-    if validate_ipv6 "$host"; then
-        host="[$host]"
+    if validate_ipv6 "${host}"; then
+        host="[${host}]"
     fi
 
     if is_boolean_yes "$DB_ENABLE_SECURITY"; then

--- a/bitnami/elasticsearch/8/debian-12/rootfs/opt/bitnami/scripts/libelasticsearch.sh
+++ b/bitnami/elasticsearch/8/debian-12/rootfs/opt/bitnami/scripts/libelasticsearch.sh
@@ -909,6 +909,9 @@ elasticsearch_healthcheck() {
     local host
 
     host=$(get_elasticsearch_hostname)
+    if validate_ipv6 "$host"; then
+        host="[$host]"
+    fi
 
     if is_boolean_yes "$DB_ENABLE_SECURITY"; then
         command_args+=("-k" "--user" "${DB_USERNAME}:${DB_PASSWORD}")

--- a/bitnami/elasticsearch/8/debian-12/rootfs/opt/bitnami/scripts/libelasticsearch.sh
+++ b/bitnami/elasticsearch/8/debian-12/rootfs/opt/bitnami/scripts/libelasticsearch.sh
@@ -909,8 +909,8 @@ elasticsearch_healthcheck() {
     local host
 
     host=$(get_elasticsearch_hostname)
-    if validate_ipv6 "$host"; then
-        host="[$host]"
+    if validate_ipv6 "${host}"; then
+        host="[${host}]"
     fi
 
     if is_boolean_yes "$DB_ENABLE_SECURITY"; then


### PR DESCRIPTION
### Description of the change

The change adds a pair of square brackets around IPv6 addresses in the
URL used in the elasticsearch_healthcheck() function. The generated URL
is invalid otherwise, and the heath check will fail on IPv6-only hosts.

### Benefits

Ability to use the chart for an IPv6-only installation of elasticsearch.

### Possible drawbacks

This is a bug fix.

### Applicable issues

Didn't create an issue for this.

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
