### PR TITLE
[bitnami/argo-workflow-exec] Skip copy-readme.sh from sed-in-place test

### DIFF
--- a/.vib/argo-workflow-exec/goss/vars.yaml
+++ b/.vib/argo-workflow-exec/goss/vars.yaml
@@ -13,4 +13,6 @@ root_dir: /opt/bitnami
 version:
   bin_name: argoexec
   flag: version
-
+sed_in_place:
+  exclude_paths:
+    - /opt/bitnami/argo-workflow-exec/hack/copy-readme.sh


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Skips the `copy-readme.sh` script from Goss test to check no `sed --in-place` is used.
