### PR TITLE
[bitnami/mediawiki] Add env var to control skipping config validation during startup

### DIFF
--- a/bitnami/mediawiki/1/debian-12/rootfs/opt/bitnami/scripts/libmediawiki.sh
+++ b/bitnami/mediawiki/1/debian-12/rootfs/opt/bitnami/scripts/libmediawiki.sh
@@ -152,11 +152,11 @@ mediawiki_initialize() {
         mediawiki_wait_for_db_connection "$db_host" "$db_port" "$db_name" "$db_user" "$db_pass"
         # Perform MediaWiki database schema upgrade
         info "Performing database schema upgrade if needed"
-        update_args=""
+        local -a update_args=()
         if is_boolean_yes "$MEDIAWIKI_SKIP_CONFIG_VALIDATION"; then
-            update_args+=" --skip-config-validation"
+            update_args+=( "--skip-config-validation" )
         fi
-        debug_execute php "${MEDIAWIKI_BASE_DIR}/maintenance/update.php" $update_args
+        debug_execute php "${MEDIAWIKI_BASE_DIR}/maintenance/update.php" "${update_args[@]}"
     fi
 
     # Avoid exit code of previous commands to affect the result of this function

--- a/bitnami/mediawiki/1/debian-12/rootfs/opt/bitnami/scripts/libmediawiki.sh
+++ b/bitnami/mediawiki/1/debian-12/rootfs/opt/bitnami/scripts/libmediawiki.sh
@@ -151,7 +151,12 @@ mediawiki_initialize() {
         db_port="$MEDIAWIKI_DATABASE_PORT_NUMBER"
         mediawiki_wait_for_db_connection "$db_host" "$db_port" "$db_name" "$db_user" "$db_pass"
         # Perform MediaWiki database schema upgrade
-        debug_execute php "${MEDIAWIKI_BASE_DIR}/maintenance/update.php"
+        info "Performing database schema upgrade if needed"
+        update_args=""
+        if is_boolean_yes "$MEDIAWIKI_SKIP_CONFIG_VALIDATION"; then
+            update_args+=" --skip-config-validation"
+        fi
+        debug_execute php "${MEDIAWIKI_BASE_DIR}/maintenance/update.php" $update_args
     fi
 
     # Avoid exit code of previous commands to affect the result of this function

--- a/bitnami/mediawiki/1/debian-12/rootfs/opt/bitnami/scripts/libmediawiki.sh
+++ b/bitnami/mediawiki/1/debian-12/rootfs/opt/bitnami/scripts/libmediawiki.sh
@@ -124,7 +124,11 @@ mediawiki_initialize() {
         else
             info "An already initialized MediaWiki database was provided, configuration will be skipped"
             # Perform MediaWiki database schema upgrade
-            debug_execute php "${MEDIAWIKI_BASE_DIR}/maintenance/update.php"
+            local -a update_args=()
+            if is_boolean_yes "$MEDIAWIKI_SKIP_CONFIG_VALIDATION"; then
+                update_args+=( "--skip-config-validation" )
+            fi
+            debug_execute php "${MEDIAWIKI_BASE_DIR}/maintenance/update.php" "${update_args[@]}"
         fi
 
         # Configure MediaWiki based on environment variables

--- a/bitnami/mediawiki/1/debian-12/rootfs/opt/bitnami/scripts/mediawiki-env.sh
+++ b/bitnami/mediawiki/1/debian-12/rootfs/opt/bitnami/scripts/mediawiki-env.sh
@@ -46,6 +46,7 @@ mediawiki_env_vars=(
     MEDIAWIKI_DATABASE_NAME
     MEDIAWIKI_DATABASE_USER
     MEDIAWIKI_DATABASE_PASSWORD
+    MEDIAWIKI_SKIP_CONFIG_VALIDATION
     SMTP_HOST
     SMTP_HOST_ID
     SMTP_PORT
@@ -76,6 +77,7 @@ export MEDIAWIKI_CONF_FILE="${MEDIAWIKI_BASE_DIR}/LocalSettings.php"
 # MediaWiki persistence configuration
 export MEDIAWIKI_VOLUME_DIR="${BITNAMI_VOLUME_DIR}/mediawiki"
 export MEDIAWIKI_DATA_TO_PERSIST="${MEDIAWIKI_DATA_TO_PERSIST:-images extensions skins LocalSettings.php}"
+export MEDIAWIKI_SKIP_CONFIG_VALIDATION="${MEDIAWIKI_SKIP_CONFIG_VALIDATION:-no}"
 
 # MediaWiki site configuration
 export MEDIAWIKI_SKIP_BOOTSTRAP="${MEDIAWIKI_SKIP_BOOTSTRAP:-}" # only used during the first initialization

--- a/bitnami/mediawiki/README.md
+++ b/bitnami/mediawiki/README.md
@@ -222,6 +222,7 @@ docker run -d --name mediawiki \
 | `MEDIAWIKI_DATABASE_NAME`              | Database name.                                                                                                                                                                     | `bitnami_mediawiki`                         |
 | `MEDIAWIKI_DATABASE_USER`              | Database user name.                                                                                                                                                                | `bn_mediawiki`                              |
 | `MEDIAWIKI_DATABASE_PASSWORD`          | Database user password.                                                                                                                                                            | `nil`                                       |
+| `MEDIAWIKI_SKIP_CONFIG_VALIDATION`     | Skip config validation during startup. Allows the use of deprecated values in MediaWiki configuration file. Valid values: `yes`, `no`.                                                                                                                                                           | `no`                                       |
 
 #### Read-only environment variables
 


### PR DESCRIPTION
As suggested/requested in https://github.com/bitnami/containers/issues/65721#issuecomment-2078888820 here's a PR introducing a new environment variable that controls whether or not validation is performed of configuration file during database upgrade at container start-up.

This allows the use deprecated values (such as `$wgAllowImageTag`) in LocalSettings.php

This PR also adds a log message after connecting to the database to better indicate which part of the start-up process is running.