### PR TITLE
[bitnami/openldap] Update README

### DIFF
--- a/bitnami/openldap/README.md
+++ b/bitnami/openldap/README.md
@@ -336,7 +336,7 @@ docker run --name openldap bitnami/openldap:latest
 
 ## Using `docker-compose.yaml`
 
-Please be aware this file has not undergone internal testing. Consequently, we advise its use exclusively for development or testing purposes. For production-ready deployments, we highly recommend utilizing its associated [Bitnami Helm chart](https://github.com/bitnami/charts/tree/main/bitnami/openldap).
+Please be aware this file has not undergone internal testing. Consequently, we advise its use exclusively for development or testing purposes.
 
 If you detect any issue in the `docker-compose.yaml` file, feel free to report it or contribute with a fix by following our [Contributing Guidelines](https://github.com/bitnami/containers/blob/main/CONTRIBUTING.md).
 


### PR DESCRIPTION
### Description of the change

Update bitnami/openldap/README.
Bitnami does not offer a Helm chart for OpenLDAP.
See also https://github.com/bitnami/charts/issues/11003.

### Benefits

Documentation will no longer refer to a non-existent object, avoiding confusion.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

None