### PR TITLE
feat:  mysql_upgrade is not needed when the version greater than 8.0.16

### DIFF
--- a/bitnami/mysql/8.0/debian-12/rootfs/opt/bitnami/scripts/libmysql.sh
+++ b/bitnami/mysql/8.0/debian-12/rootfs/opt/bitnami/scripts/libmysql.sh
@@ -825,7 +825,7 @@ mysql_upgrade() {
     if [[ "$DB_FLAVOR" = *"mysql"* ]] && [[
         "$major_version" -gt "8"
         || ( "$major_version" -eq "8" && "$minor_version" -gt "0" )
-        || ( "$major_version" -eq "8" && "$minor_version" -eq "0" && "$patch_version" -ge "16" )
+        || ( "$major_version" -eq "8" && "$minor_version" -eq "0" && "$patch_version" -le "16" )
     ]]; then
         mysql_stop
         mysql_start_bg "--upgrade=FORCE"


### PR DESCRIPTION
https://dev.mysql.com/doc/refman/8.0/en/replication-upgrade.html#:~:text=If%20you%20have%20upgraded%20to%20MySQL%208.0.16%20or%20later%2C%20do%20not%20invoke%20mysql_upgrade.%20From%20that%20release%2C%20MySQL%20Server%20performs%20the%20entire%20MySQL%20upgrade%20procedure%2C%20disabling%20binary%20logging%20during%20the%20upgrade.

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
