### PR TITLE
[bitnami/scylladb] chore: :construction_worker: :white_check_mark: Add VIB integration

### DIFF
--- a/.vib/scylladb/goss/goss.yaml
+++ b/.vib/scylladb/goss/goss.yaml
@@ -1,0 +1,14 @@
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+gossfile:
+  # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-app-version.yaml: {}
+  ../../common/goss/templates/check-binaries.yaml: {}
+  ../../common/goss/templates/check-broken-symlinks.yaml: {}
+  ../../common/goss/templates/check-ca-certs.yaml: {}
+  ../../common/goss/templates/check-directories.yaml: {}
+  ../../common/goss/templates/check-files.yaml: {}
+  ../../common/goss/templates/check-linked-libraries.yaml: {}
+  ../../common/goss/templates/check-sed-in-place.yaml: {}
+  ../../common/goss/templates/check-spdx.yaml: {}

--- a/.vib/scylladb/goss/vars.yaml
+++ b/.vib/scylladb/goss/vars.yaml
@@ -1,0 +1,39 @@
+binaries:
+  - scylla
+  - supervisorctl
+  - supervisord
+  - cqlsh
+  - python
+  - java
+files:
+  - mode: "0755"
+    paths:
+      - /opt/bitnami/scylladb/python3/bin/cqlsh
+directories:
+  - mode: "0775"
+    paths:
+      - /.cassandra
+      - /bitnami/scylladb
+      - /bitnami/scylladb/conf
+      - /opt/bitnami/scylladb/tmp
+      - /opt/bitnami/scylladb/etc
+      - /opt/bitnami/scylladb/logs
+      - /docker-entrypoint-initdb.d
+  - paths:
+      - /opt/bitnami/scylladb/etc.default
+root_dir: /opt/bitnami
+linked_libraries:
+  exclude_paths:
+    # Ignore those included in the unified installer
+    - /opt/bitnami/scylladb/libexec/.*
+    - /opt/bitnami/scylladb/libreloc/.*
+sed_in_place:
+  exclude_paths:
+    # Ignore upstream scripts (non Bitnami-related)
+    - /opt/bitnami/scylladb/share/cassandra/pylib/.*
+    - /opt/bitnami/scylladb/scripts/.*
+    - /opt/bitnami/scylladb/docker/.*
+    - /opt/bitnami/scylladb/supervisor/.*
+version:
+  bin_name: scylla
+  flag: --version

--- a/.vib/scylladb/vib-verify.json
+++ b/.vib/scylladb/vib-verify.json
@@ -19,7 +19,8 @@
               }
             },
             "architectures": [
-              "linux/amd64"
+              "linux/amd64",
+              "linux/arm64"
             ]
           }
         },

--- a/.vib/scylladb/vib-verify.json
+++ b/.vib/scylladb/vib-verify.json
@@ -1,0 +1,72 @@
+{
+  "context": {
+    "resources": {
+      "url": "{SHA_ARCHIVE}",
+      "path": "{VIB_ENV_PATH}"
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyJ0YWlsIiwgIi1mIiwgIi9kZXYvbnVsbCJd"
+  },
+  "phases": {
+    "package": {
+      "actions": [
+        {
+          "action_id": "container-image-package",
+          "params": {
+            "application": {
+              "details": {
+                "name": "{VIB_ENV_CONTAINER}",
+                "tag": "{VIB_ENV_TAG}"
+              }
+            },
+            "architectures": [
+              "linux/amd64"
+            ]
+          }
+        },
+        {
+          "action_id": "container-image-lint",
+          "params": {
+            "threshold": "error"
+          }
+        }
+      ]
+    },
+    "verify": {
+      "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "scylladb/goss/goss.yaml",
+            "vars_file": "scylladb/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-scylladb"
+              }
+            }
+          }
+        },
+        {
+          "action_id": "trivy",
+          "params": {
+            "threshold": "LOW",
+            "vuln_type": [
+              "OS"
+            ]
+          }
+        },
+        {
+          "action_id": "grype",
+          "params": {
+            "threshold": "CRITICAL",
+            "package_type": [
+              "OS"
+            ]
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR adds the goss testing suite for ScyllaDB. This one copies the existing one for Cassandra. 
<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
