### PR TITLE
[bitnami/airflow] Escape special characters in Airflow LDAP configuration values

### DIFF
--- a/bitnami/airflow-scheduler/2/debian-12/rootfs/opt/bitnami/scripts/libairflow.sh
+++ b/bitnami/airflow-scheduler/2/debian-12/rootfs/opt/bitnami/scripts/libairflow.sh
@@ -323,13 +323,14 @@ airflow_webserver_conf_set() {
     # Check if the value was set before
     if grep -q "^#*\\s*${key} =.*$" "$file"; then
         local entry
-        is_boolean_yes "$is_literal" && entry="${key} = '${value}'" || entry="${key} = ${value}"
+        local new_value="$value"
+        is_boolean_yes "$is_literal" && new_value="${new_value//\\/\\\\}" && entry="${key} = '${new_value//"'"/\\\'}'" || entry="${key} = ${value}"
         # Update the existing key
         replace_in_file "$file" "^#*\\s*${key} =.*$" "$entry" false
     else
         # Add a new key
         local new_value="$value"
-        is_boolean_yes "$is_literal" && new_value="'${value}'"
+        is_boolean_yes "$is_literal" && new_value="${new_value//\\/\\\\}" && new_value="'${new_value//"'"/\\\'}'"
         printf '\n%s = %s' "$key" "$new_value" >>"$file"
     fi
 }

--- a/bitnami/airflow-worker/2/debian-12/rootfs/opt/bitnami/scripts/libairflow.sh
+++ b/bitnami/airflow-worker/2/debian-12/rootfs/opt/bitnami/scripts/libairflow.sh
@@ -323,13 +323,14 @@ airflow_webserver_conf_set() {
     # Check if the value was set before
     if grep -q "^#*\\s*${key} =.*$" "$file"; then
         local entry
-        is_boolean_yes "$is_literal" && entry="${key} = '${value}'" || entry="${key} = ${value}"
+        local new_value="$value"
+        is_boolean_yes "$is_literal" && new_value="${new_value//\\/\\\\}" && entry="${key} = '${new_value//"'"/\\\'}'" || entry="${key} = ${value}"
         # Update the existing key
         replace_in_file "$file" "^#*\\s*${key} =.*$" "$entry" false
     else
         # Add a new key
         local new_value="$value"
-        is_boolean_yes "$is_literal" && new_value="'${value}'"
+        is_boolean_yes "$is_literal" && new_value="${new_value//\\/\\\\}" && new_value="'${new_value//"'"/\\\'}'"
         printf '\n%s = %s' "$key" "$new_value" >>"$file"
     fi
 }

--- a/bitnami/airflow/2/debian-12/rootfs/opt/bitnami/scripts/libairflow.sh
+++ b/bitnami/airflow/2/debian-12/rootfs/opt/bitnami/scripts/libairflow.sh
@@ -323,13 +323,14 @@ airflow_webserver_conf_set() {
     # Check if the value was set before
     if grep -q "^#*\\s*${key} =.*$" "$file"; then
         local entry
-        is_boolean_yes "$is_literal" && entry="${key} = '${value}'" || entry="${key} = ${value}"
+        local new_value="$value"
+        is_boolean_yes "$is_literal" && new_value="${new_value//\\/\\\\}" && entry="${key} = '${new_value//"'"/\\\'}'" || entry="${key} = ${value}"
         # Update the existing key
         replace_in_file "$file" "^#*\\s*${key} =.*$" "$entry" false
     else
         # Add a new key
         local new_value="$value"
-        is_boolean_yes "$is_literal" && new_value="'${value}'"
+        is_boolean_yes "$is_literal" && new_value="${new_value//\\/\\\\}" && new_value="'${new_value//"'"/\\\'}'"
         printf '\n%s = %s' "$key" "$new_value" >>"$file"
     fi
 }


### PR DESCRIPTION
### Description of the change

This change fixes https://github.com/bitnami/containers/issues/65217 by escaping single quotes and backslashes in `AIRFLOW_LDAP_` configuration values that are interpolated into `webserver_config.py` as Python strings.

However, values that are not interpolated as strings such as `AIRFLOW_LDAP_ROLES_MAPPING`, `AIRFLOW_LDAP_ROLES_SYNC_AT_LOGIN`, and `AIRFLOW_LDAP_ALLOW_SELF_SIGNED` are still susceptible to arbitrary Python injection.

### Benefits

`AIRFLOW_LDAP_` configuration values that are interpolated as Python strings (e.g. `AIRFLOW_LDAP_BIND_PASSWORD`) may now contain single quotes and backslashes, and the Airflow container will handle them correctly instead of erroring out on startup.

### Possible drawbacks

If for some reason this behavior was being abused by users to inject arbitrary Python into `webserver_config.py`, that will no longer work; they should instead mount their own `webserver_config.py` into the container.

### Applicable issues

- fixes #65217