### PR TITLE
[bitnami/airflow] Ensure Airflow configuration values starting with dashes are set correctly

### DIFF
--- a/bitnami/airflow-scheduler/2/debian-12/rootfs/opt/bitnami/scripts/libairflow.sh
+++ b/bitnami/airflow-scheduler/2/debian-12/rootfs/opt/bitnami/scripts/libairflow.sh
@@ -233,7 +233,7 @@ airflow_conf_set() {
     local -r value="${3:?value is required}"
     local -r file="${4:-${AIRFLOW_CONF_FILE}}"
 
-    ini-file set --section "$section" --key "$key" --value "$value" "$file"
+    ini-file set "--section=$section" "--key=$key" "--value=$value" -- "$file"
 }
 
 ########################

--- a/bitnami/airflow-worker/2/debian-12/rootfs/opt/bitnami/scripts/libairflow.sh
+++ b/bitnami/airflow-worker/2/debian-12/rootfs/opt/bitnami/scripts/libairflow.sh
@@ -233,7 +233,7 @@ airflow_conf_set() {
     local -r value="${3:?value is required}"
     local -r file="${4:-${AIRFLOW_CONF_FILE}}"
 
-    ini-file set --section "$section" --key "$key" --value "$value" "$file"
+    ini-file set "--section=$section" "--key=$key" "--value=$value" -- "$file"
 }
 
 ########################

--- a/bitnami/airflow/2/debian-12/rootfs/opt/bitnami/scripts/libairflow.sh
+++ b/bitnami/airflow/2/debian-12/rootfs/opt/bitnami/scripts/libairflow.sh
@@ -233,7 +233,7 @@ airflow_conf_set() {
     local -r value="${3:?value is required}"
     local -r file="${4:-${AIRFLOW_CONF_FILE}}"
 
-    ini-file set --section "$section" --key "$key" --value "$value" "$file"
+    ini-file set "--section=$section" "--key=$key" "--value=$value" -- "$file"
 }
 
 ########################


### PR DESCRIPTION
### Description of the change

This change fixes https://github.com/bitnami/containers/issues/65197 by passing the `--value` flag and its argument as a single string (i.e. `"--value=$value"`, rather than `--value "$value"`) to the `ini-file` tool.

### Benefits

`AIRFLOW_` configuration values that are added to `airflow.cfg` may now start with dashes, and the Airflow container will handle them correctly instead of erroring out on startup.

### Applicable issues

- fixes #65197