### PR TITLE
[bitnami/flink] update scripts how configuration is handled

### DIFF
--- a/bitnami/flink/1/debian-12/rootfs/opt/bitnami/scripts/flink/entrypoint.sh
+++ b/bitnami/flink/1/debian-12/rootfs/opt/bitnami/scripts/flink/entrypoint.sh
@@ -18,11 +18,8 @@ set -o pipefail
 
 print_welcome_page
 
-# We add the copy from default config in the entrypoint to not break users 
-# bypassing the setup.sh logic. If the file already exists do not overwrite (in
-# case someone mounts a configuration file in /opt/bitnami/flink/conf)
 debug "Copying files from $FLINK_DEFAULT_CONF_DIR to $FLINK_CONF_DIR"
-cp -nfr "$FLINK_DEFAULT_CONF_DIR"/. "$FLINK_CONF_DIR"
+cp -fr "$FLINK_DEFAULT_CONF_DIR"/. "$FLINK_CONF_DIR"
 
 if [[ "$1" = "/opt/bitnami/scripts/flink/run.sh" ]]; then
     info "** Starting Apache Flink ${FLINK_MODE} setup **"


### PR DESCRIPTION
Closes https://github.com/bitnami/containers/issues/67010 https://github.com/bitnami/charts/issues/25457

### Description of the change

This will solve issue with configuration consistency and allow to avoid situation where YAML keys are duplicated after second run of entrypoint.

### Benefits

It will start working when entrypoint will be second time.

### Possible drawbacks

It will change bahaviour for users which are mounting /opt/bitnami/flink/conf as config.yaml will be always overwritten.

### Additional information

Configuration scripts are causing that main config should be threated as ephemeral. If they want to have persistent configuration then they should replace default base configs FLINK_DEFAULT_CONF_DIR:
https://github.com/bitnami/containers/blob/fe7ac75eb9e200ed06efeeb6a11bdef77f922cd7/bitnami/flink/1/debian-12/rootfs/opt/bitnami/scripts/flink-env.sh#L51

and then setup script will merge default base and environmental configs correctly.
