### PR TITLE
[bitnami/elasticsearch] Fix get_machine_ip to handle IPv6 addresses

### DIFF
--- a/bitnami/elasticsearch/8/debian-12/prebuildfs/opt/bitnami/scripts/libnet.sh
+++ b/bitnami/elasticsearch/8/debian-12/prebuildfs/opt/bitnami/scripts/libnet.sh
@@ -68,7 +68,13 @@ get_machine_ip() {
         error "Could not find any IP address associated to hostname ${hostname}"
         exit 1
     fi
-    echo "${ip_addresses[0]}"
+
+    # Check if the first IP address is IPv6 and add brackets
+    if [[ "${ip_addresses[0]}" =~ : ]]; then
+        echo "[${ip_addresses[0]}]"
+    else
+        echo "${ip_addresses[0]}"
+    fi
 }
 
 ########################


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Update `get_machine_ip` and add brackets incase of IPv6 addresses.
Fixes https://github.com/bitnami/containers/issues/67081

### Benefits

<!-- What benefits will be realized by the code change? -->
It will fix the Elasticsearch health/readiness probe failures in IPv6 only cluster deployment with single node.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
