### PR TITLE
[hubble-ui]: fix vib tests

### DIFF
--- a/.vib/hubble-ui-backend/goss/hubble-ui-backend.yaml
+++ b/.vib/hubble-ui-backend/goss/hubble-ui-backend.yaml
@@ -5,7 +5,7 @@ command:
   # This binary doesn't support any 'help' nor 'version' command or flags
   # so we just check that it runs
   check-hubble-ui-backend:
-    exec: backend
-    exit-status: 1
+    exec: timeout --preserve-status 5 backend
+    exit-status: 0
     stderr:
-      - "TLS to hubble-relay is not enabled"
+      - "running ListenAndServe"

--- a/.vib/hubble-ui/goss/goss.yaml
+++ b/.vib/hubble-ui/goss/goss.yaml
@@ -9,7 +9,6 @@ gossfile:
   ../../common/goss/templates/check-broken-symlinks.yaml: {}
   ../../common/goss/templates/check-ca-certs.yaml: {}
   ../../common/goss/templates/check-directories.yaml: {}
-  ../../common/goss/templates/check-files.yaml: {}
   ../../common/goss/templates/check-linked-libraries.yaml: {}
   ../../common/goss/templates/check-sed-in-place.yaml: {}
   ../../common/goss/templates/check-spdx.yaml: {}


### PR DESCRIPTION
### Description of the change

Fixes `hubble-ui-backend` goss test. Also removes test `check-files.yaml` which  is not needed for `hubble-ui` since there are no files to check in the `vars.yaml`.