### PR TITLE
[bitnami/openldap] Allow to optionally set olcSuffix via LDAP_SUFFIX env var

### DIFF
--- a/bitnami/openldap/2.5/debian-12/rootfs/opt/bitnami/scripts/libopenldap.sh
+++ b/bitnami/openldap/2.5/debian-12/rootfs/opt/bitnami/scripts/libopenldap.sh
@@ -53,6 +53,7 @@ export LDAP_DAEMON_GROUP="slapd"
 export LDAP_PORT_NUMBER="${LDAP_PORT_NUMBER:-1389}"
 export LDAP_LDAPS_PORT_NUMBER="${LDAP_LDAPS_PORT_NUMBER:-1636}"
 export LDAP_ROOT="${LDAP_ROOT:-dc=example,dc=org}"
+export LDAP_SUFFIX="$(if [ -z "${LDAP_SUFFIX+x}" ]; then echo "${LDAP_ROOT}"; else echo "${LDAP_SUFFIX}"; fi)"
 export LDAP_ADMIN_USERNAME="${LDAP_ADMIN_USERNAME:-admin}"
 export LDAP_ADMIN_DN="${LDAP_ADMIN_USERNAME/#/cn=},${LDAP_ROOT}"
 export LDAP_ADMIN_PASSWORD="${LDAP_ADMIN_PASSWORD:-adminpassword}"
@@ -382,7 +383,7 @@ ldap_admin_credentials() {
 dn: olcDatabase={2}mdb,cn=config
 changetype: modify
 replace: olcSuffix
-olcSuffix: $LDAP_ROOT
+olcSuffix: $LDAP_SUFFIX
 
 dn: olcDatabase={2}mdb,cn=config
 changetype: modify

--- a/bitnami/openldap/2.6/debian-12/rootfs/opt/bitnami/scripts/libopenldap.sh
+++ b/bitnami/openldap/2.6/debian-12/rootfs/opt/bitnami/scripts/libopenldap.sh
@@ -53,6 +53,7 @@ export LDAP_DAEMON_GROUP="slapd"
 export LDAP_PORT_NUMBER="${LDAP_PORT_NUMBER:-1389}"
 export LDAP_LDAPS_PORT_NUMBER="${LDAP_LDAPS_PORT_NUMBER:-1636}"
 export LDAP_ROOT="${LDAP_ROOT:-dc=example,dc=org}"
+export LDAP_SUFFIX="$(if [ -z "${LDAP_SUFFIX+x}" ]; then echo "${LDAP_ROOT}"; else echo "${LDAP_SUFFIX}"; fi)"
 export LDAP_ADMIN_USERNAME="${LDAP_ADMIN_USERNAME:-admin}"
 export LDAP_ADMIN_DN="${LDAP_ADMIN_USERNAME/#/cn=},${LDAP_ROOT}"
 export LDAP_ADMIN_PASSWORD="${LDAP_ADMIN_PASSWORD:-adminpassword}"
@@ -382,7 +383,7 @@ ldap_admin_credentials() {
 dn: olcDatabase={2}mdb,cn=config
 changetype: modify
 replace: olcSuffix
-olcSuffix: $LDAP_ROOT
+olcSuffix: $LDAP_SUFFIX
 
 dn: olcDatabase={2}mdb,cn=config
 changetype: modify

--- a/bitnami/openldap/README.md
+++ b/bitnami/openldap/README.md
@@ -194,6 +194,7 @@ The Bitnami Docker OpenLDAP can be easily setup with the following environment v
 * `LDAP_CONFIGURE_PPOLICY`: Enables the ppolicy module and creates an empty configuration. Default: **no**.
 * `LDAP_PPOLICY_USE_LOCKOUT`: Whether bind attempts to locked accounts will always return an error. Will only be applied with `LDAP_CONFIGURE_PPOLICY` active. Default: **no**.
 * `LDAP_PPOLICY_HASH_CLEARTEXT`: Whether plaintext passwords should be hashed automatically. Will only be applied with `LDAP_CONFIGURE_PPOLICY` active. Default: **no**.
+* `LDAP_SUFFIX`: The DN suffix of queries that will be handled by the default database. Default: `LDAP_ROOT` value.
 
 You can bootstrap the contents of your database by putting LDIF files in the directory `/ldifs` (or the one you define in `LDAP_CUSTOM_LDIF_DIR`). Those may only contain content underneath your base DN (set by `LDAP_ROOT`). You can **not** set configuration for e.g. `cn=config` in those files.
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Right now the olcSuffix config is fixed to the `LDAP_ROOT` value. While this is most of the times reasonable, those values are not strictly related, being olcSuffix the prefix of the queries handled by the internal mdb backend.
This change allows to optionally set the LDAP olcSuffix to a different value from `LDAP_ROOT`. The change does not break existing behaviour.

### Benefits

In multi tenant scenarios you end to have multiple trees, right now you either have to use a container for each tree (which is not easy if you create those trees dynamically), or provide a script on container init that does this change. Or, worse, prefix all those trees with a common one.
By allowing to set the olcSuffix on the container, simplifies a lot usage in those scenarios.

### Possible drawbacks

None
