### PR TITLE
[bitnami/postgresql-repmgr]Add judge primary node ip port is itslef

### DIFF
--- a/bitnami/postgresql-repmgr/15/debian-12/rootfs/opt/bitnami/scripts/librepmgr.sh
+++ b/bitnami/postgresql-repmgr/15/debian-12/rootfs/opt/bitnami/scripts/librepmgr.sh
@@ -237,8 +237,12 @@ repmgr_get_primary_node() {
                 primary_port="$REPMGR_PRIMARY_PORT"
             fi
         else
-            primary_host="$upstream_host"
-            primary_port="$upstream_port"
+           if  [[ "${upstream_host}:${upstream_port}" = "${REPMGR_NODE_NETWORK_NAME}:${REPMGR_PORT_NUMBER}" ]];  then
+                info "Skip Primary Ip self. Starting PostgreSQL normally..."
+           else
+                primary_host="$upstream_host"
+                primary_port="$upstream_port"
+           fi
         fi
     fi
 

--- a/bitnami/postgresql-repmgr/15/debian-12/rootfs/opt/bitnami/scripts/librepmgr.sh
+++ b/bitnami/postgresql-repmgr/15/debian-12/rootfs/opt/bitnami/scripts/librepmgr.sh
@@ -237,12 +237,12 @@ repmgr_get_primary_node() {
                 primary_port="$REPMGR_PRIMARY_PORT"
             fi
         else
-           if  [[ "${upstream_host}:${upstream_port}" = "${REPMGR_NODE_NETWORK_NAME}:${REPMGR_PORT_NUMBER}" ]];  then
-                info "Skip Primary Ip self. Starting PostgreSQL normally..."
-           else
+            if  [[ "${upstream_host}:${upstream_port}" = "${REPMGR_NODE_NETWORK_NAME}:${REPMGR_PORT_NUMBER}" ]];  then
+                info "Avoid setting itself as primary. Starting PostgreSQL normally..."
+            else
                 primary_host="$upstream_host"
                 primary_port="$upstream_port"
-           fi
+            fi
         fi
     fi
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

It seems that the judgment of whether the master node IP is your own is missed here.

Updates the Bitnami postgres-repmgr librepmgr.sh , function `repmgr_get_primary_node`,  add  judgment of whether the master node IP is your own 
### Benefits

Optimize extreme abnormal scenarios, such as: cluster machines lose power at the same time, and the restored cluster self-healing

### Possible drawbacks

Whether the logic of repmgr itself has been tampered with

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fix: https://github.com/bitnami/containers/issues/67372

### Additional information

I'm happy to change approach if directed to how.
