### PR TITLE
[bitnami/odoo] Add ODOO_LIST_DB envvar, defaulting to False

### DIFF
--- a/bitnami/odoo/15/debian-12/rootfs/opt/bitnami/scripts/libodoo.sh
+++ b/bitnami/odoo/15/debian-12/rootfs/opt/bitnami/scripts/libodoo.sh
@@ -72,6 +72,7 @@ odoo_validate() {
     check_yes_no_value "ODOO_SKIP_BOOTSTRAP"
     check_yes_no_value "ODOO_SKIP_MODULES_UPDATE"
     check_yes_no_value "ODOO_LOAD_DEMO_DATA"
+    check_yes_no_value "ODOO_LIST_DB"
     check_valid_port "ODOO_PORT_NUMBER"
     check_valid_port "ODOO_LONGPOLLING_PORT_NUMBER"
     ! is_empty_value "$ODOO_DATABASE_HOST" && check_resolved_hostname "$ODOO_DATABASE_HOST"
@@ -136,7 +137,8 @@ odoo_initialize() {
 
         info "Generating configuration file"
         local template_dir="${BITNAMI_ROOT_DIR}/scripts/odoo/bitnami-templates"
-        render-template "${template_dir}/odoo.conf.tpl" > "$ODOO_CONF_FILE"
+        list_db="$(is_boolean_yes "$ODOO_LIST_DB" && echo 'True' || echo 'False')" \
+            render-template "${template_dir}/odoo.conf.tpl" > "$ODOO_CONF_FILE"
 
         if ! is_empty_value "$ODOO_SMTP_HOST"; then
             info "Configuring SMTP"

--- a/bitnami/odoo/15/debian-12/rootfs/opt/bitnami/scripts/odoo-env.sh
+++ b/bitnami/odoo/15/debian-12/rootfs/opt/bitnami/scripts/odoo-env.sh
@@ -30,6 +30,7 @@ odoo_env_vars=(
     ODOO_SKIP_BOOTSTRAP
     ODOO_SKIP_MODULES_UPDATE
     ODOO_LOAD_DEMO_DATA
+    ODOO_LIST_DB
     ODOO_EMAIL
     ODOO_PASSWORD
     ODOO_SMTP_HOST
@@ -95,6 +96,7 @@ export ODOO_LONGPOLLING_PORT_NUMBER="${ODOO_LONGPOLLING_PORT_NUMBER:-8072}" # on
 export ODOO_SKIP_BOOTSTRAP="${ODOO_SKIP_BOOTSTRAP:-no}" # only used during the first initialization
 export ODOO_SKIP_MODULES_UPDATE="${ODOO_SKIP_MODULES_UPDATE:-no}" # only used during the first initialization
 export ODOO_LOAD_DEMO_DATA="${ODOO_LOAD_DEMO_DATA:-no}" # only used during the first initialization
+export ODOO_LIST_DB="${ODOO_LIST_DB:-no}"
 
 # Odoo credentials
 export ODOO_EMAIL="${ODOO_EMAIL:-user@example.com}" # only used during the first initialization

--- a/bitnami/odoo/15/debian-12/rootfs/opt/bitnami/scripts/odoo/bitnami-templates/odoo.conf.tpl
+++ b/bitnami/odoo/15/debian-12/rootfs/opt/bitnami/scripts/odoo/bitnami-templates/odoo.conf.tpl
@@ -22,7 +22,7 @@ http_port = {{ODOO_PORT_NUMBER}}
 ; https://www.odoo.com/forum/help-1/question/cpu-time-limit-exceeded-how-to-solve-it-87922
 limit_time_cpu = 90
 limit_time_real = 150
-; list_db = True
+list_db = {{list_db}}
 ; log_db = False
 ; log_handler = [':INFO']
 ; log_level = info

--- a/bitnami/odoo/16/debian-12/rootfs/opt/bitnami/scripts/libodoo.sh
+++ b/bitnami/odoo/16/debian-12/rootfs/opt/bitnami/scripts/libodoo.sh
@@ -72,6 +72,7 @@ odoo_validate() {
     check_yes_no_value "ODOO_SKIP_BOOTSTRAP"
     check_yes_no_value "ODOO_SKIP_MODULES_UPDATE"
     check_yes_no_value "ODOO_LOAD_DEMO_DATA"
+    check_yes_no_value "ODOO_LIST_DB"
     check_valid_port "ODOO_PORT_NUMBER"
     check_valid_port "ODOO_LONGPOLLING_PORT_NUMBER"
     ! is_empty_value "$ODOO_DATABASE_HOST" && check_resolved_hostname "$ODOO_DATABASE_HOST"
@@ -136,7 +137,8 @@ odoo_initialize() {
 
         info "Generating configuration file"
         local template_dir="${BITNAMI_ROOT_DIR}/scripts/odoo/bitnami-templates"
-        render-template "${template_dir}/odoo.conf.tpl" > "$ODOO_CONF_FILE"
+        list_db="$(is_boolean_yes "$ODOO_LIST_DB" && echo 'True' || echo 'False')" \
+            render-template "${template_dir}/odoo.conf.tpl" > "$ODOO_CONF_FILE"
 
         if ! is_empty_value "$ODOO_SMTP_HOST"; then
             info "Configuring SMTP"

--- a/bitnami/odoo/16/debian-12/rootfs/opt/bitnami/scripts/odoo-env.sh
+++ b/bitnami/odoo/16/debian-12/rootfs/opt/bitnami/scripts/odoo-env.sh
@@ -30,6 +30,7 @@ odoo_env_vars=(
     ODOO_SKIP_BOOTSTRAP
     ODOO_SKIP_MODULES_UPDATE
     ODOO_LOAD_DEMO_DATA
+    ODOO_LIST_DB
     ODOO_EMAIL
     ODOO_PASSWORD
     ODOO_SMTP_HOST
@@ -95,6 +96,7 @@ export ODOO_LONGPOLLING_PORT_NUMBER="${ODOO_LONGPOLLING_PORT_NUMBER:-8072}" # on
 export ODOO_SKIP_BOOTSTRAP="${ODOO_SKIP_BOOTSTRAP:-no}" # only used during the first initialization
 export ODOO_SKIP_MODULES_UPDATE="${ODOO_SKIP_MODULES_UPDATE:-no}" # only used during the first initialization
 export ODOO_LOAD_DEMO_DATA="${ODOO_LOAD_DEMO_DATA:-no}" # only used during the first initialization
+export ODOO_LIST_DB="${ODOO_LIST_DB:-no}"
 
 # Odoo credentials
 export ODOO_EMAIL="${ODOO_EMAIL:-user@example.com}" # only used during the first initialization

--- a/bitnami/odoo/16/debian-12/rootfs/opt/bitnami/scripts/odoo/bitnami-templates/odoo.conf.tpl
+++ b/bitnami/odoo/16/debian-12/rootfs/opt/bitnami/scripts/odoo/bitnami-templates/odoo.conf.tpl
@@ -22,7 +22,7 @@ http_port = {{ODOO_PORT_NUMBER}}
 ; https://www.odoo.com/forum/help-1/question/cpu-time-limit-exceeded-how-to-solve-it-87922
 limit_time_cpu = 90
 limit_time_real = 150
-; list_db = True
+list_db = {{list_db}}
 ; log_db = False
 ; log_handler = [':INFO']
 ; log_level = info

--- a/bitnami/odoo/17/debian-12/rootfs/opt/bitnami/scripts/libodoo.sh
+++ b/bitnami/odoo/17/debian-12/rootfs/opt/bitnami/scripts/libodoo.sh
@@ -72,6 +72,7 @@ odoo_validate() {
     check_yes_no_value "ODOO_SKIP_BOOTSTRAP"
     check_yes_no_value "ODOO_SKIP_MODULES_UPDATE"
     check_yes_no_value "ODOO_LOAD_DEMO_DATA"
+    check_yes_no_value "ODOO_LIST_DB"
     check_valid_port "ODOO_PORT_NUMBER"
     check_valid_port "ODOO_LONGPOLLING_PORT_NUMBER"
     ! is_empty_value "$ODOO_DATABASE_HOST" && check_resolved_hostname "$ODOO_DATABASE_HOST"
@@ -136,7 +137,8 @@ odoo_initialize() {
 
         info "Generating configuration file"
         local template_dir="${BITNAMI_ROOT_DIR}/scripts/odoo/bitnami-templates"
-        render-template "${template_dir}/odoo.conf.tpl" > "$ODOO_CONF_FILE"
+        list_db="$(is_boolean_yes "$ODOO_LIST_DB" && echo 'True' || echo 'False')" \
+            render-template "${template_dir}/odoo.conf.tpl" > "$ODOO_CONF_FILE"
 
         if ! is_empty_value "$ODOO_SMTP_HOST"; then
             info "Configuring SMTP"

--- a/bitnami/odoo/17/debian-12/rootfs/opt/bitnami/scripts/odoo-env.sh
+++ b/bitnami/odoo/17/debian-12/rootfs/opt/bitnami/scripts/odoo-env.sh
@@ -30,6 +30,7 @@ odoo_env_vars=(
     ODOO_SKIP_BOOTSTRAP
     ODOO_SKIP_MODULES_UPDATE
     ODOO_LOAD_DEMO_DATA
+    ODOO_LIST_DB
     ODOO_EMAIL
     ODOO_PASSWORD
     ODOO_SMTP_HOST
@@ -95,6 +96,7 @@ export ODOO_LONGPOLLING_PORT_NUMBER="${ODOO_LONGPOLLING_PORT_NUMBER:-8072}" # on
 export ODOO_SKIP_BOOTSTRAP="${ODOO_SKIP_BOOTSTRAP:-no}" # only used during the first initialization
 export ODOO_SKIP_MODULES_UPDATE="${ODOO_SKIP_MODULES_UPDATE:-no}" # only used during the first initialization
 export ODOO_LOAD_DEMO_DATA="${ODOO_LOAD_DEMO_DATA:-no}" # only used during the first initialization
+export ODOO_LIST_DB="${ODOO_LIST_DB:-no}"
 
 # Odoo credentials
 export ODOO_EMAIL="${ODOO_EMAIL:-user@example.com}" # only used during the first initialization

--- a/bitnami/odoo/17/debian-12/rootfs/opt/bitnami/scripts/odoo/bitnami-templates/odoo.conf.tpl
+++ b/bitnami/odoo/17/debian-12/rootfs/opt/bitnami/scripts/odoo/bitnami-templates/odoo.conf.tpl
@@ -22,7 +22,7 @@ http_port = {{ODOO_PORT_NUMBER}}
 ; https://www.odoo.com/forum/help-1/question/cpu-time-limit-exceeded-how-to-solve-it-87922
 limit_time_cpu = 90
 limit_time_real = 150
-; list_db = True
+list_db = {{list_db}}
 ; log_db = False
 ; log_handler = [':INFO']
 ; log_level = info

--- a/bitnami/odoo/README.md
+++ b/bitnami/odoo/README.md
@@ -195,6 +195,7 @@ docker run -d --name odoo \
 | `ODOO_SKIP_BOOTSTRAP`          | Whether to perform initial bootstrapping for the application.                                                              | `no`                                                   |
 | `ODOO_SKIP_MODULES_UPDATE`     | Whether to perform initial update of the plugins installed.                                                                | `no`                                                   |
 | `ODOO_LOAD_DEMO_DATA`          | Whether to load demo data.                                                                                                 | `no`                                                   |
+| `ODOO_LIST_DB`                 | Whether the database selector is available                                                                                 | `no`                                                   |
 | `ODOO_EMAIL`                   | Odoo user e-mail address.                                                                                                  | `user@example.com`                                     |
 | `ODOO_PASSWORD`                | Odoo user password.                                                                                                        | `bitnami`                                              |
 | `ODOO_SMTP_HOST`               | Odoo SMTP server host.                                                                                                     | `nil`                                                  |


### PR DESCRIPTION
### Description of the change

Add an environment variable to be able to set `list_db = False` in the Odoo configuration file, defaulting to False, as per https://www.odoo.com/documentation/17.0/administration/on_premise/deploy.html?highlight=list_db%20no-database-list#security

### Benefits

More "by-default" security, more configurability

### Possible drawbacks

None

### Applicable issues

- fixes #67349 

### Additional information

Happy to integrate any suggestions!
