### PR TITLE
[bitnami/matomo] Fix tests for Matomo 5.1.0

### DIFF
--- a/.vib/matomo/goss/goss.yaml
+++ b/.vib/matomo/goss/goss.yaml
@@ -5,6 +5,7 @@ gossfile:
   # Goss tests exclusive to the current container
   ../../matomo/goss/matomo.yaml: {}
   # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-app-version.yaml: {}
   ../../common/goss/templates/check-apache-libphp.yaml: {}
   ../../common/goss/templates/check-binaries.yaml: {}
   ../../common/goss/templates/check-broken-symlinks.yaml: {}

--- a/.vib/matomo/goss/matomo.yaml
+++ b/.vib/matomo/goss/matomo.yaml
@@ -33,15 +33,8 @@ file:
   /opt/bitnami/matomo/.buildcomplete:
     exists: false
 command:
-  # Since it is not done with sudo, the exit code is 1
-  check-app-version:
-    exec: php /opt/bitnami/matomo/console --version
-    exit-status: 1
-    stdout:
-      - "{{ .Env.APP_VERSION }}"
-  # Since it is not done with sudo, the exit code is 1
   check-app-run:
     exec: php /opt/bitnami/matomo/console config:get --section=database
-    exit-status: 1
+    exit-status: 0
     stdout:
       - "Mysql"

--- a/.vib/matomo/goss/vars.yaml
+++ b/.vib/matomo/goss/vars.yaml
@@ -19,4 +19,7 @@ files:
   - paths:
       - /opt/bitnami/matomo/piwik.js
       - /opt/bitnami/matomo/piwik.php
+version:
+  bin_name: php /opt/bitnami/matomo/console
+  flag: --version
 root_dir: /opt/bitnami


### PR DESCRIPTION
### Description of the change

Starting Matomo 5.1.0, the following commands no longer return exit-code 1:

- `php /opt/bitnami/matomo/console --version`
- `php /opt/bitnami/matomo/console config:get --section=database`

Test `check-app-version` has been replaced with the shared file `common/goss/templates/check-app-version.yaml`
