### PR TITLE
Add Grafana Pyroscope v1.6.0 Debian 12 support

### DIFF
--- a/bitnami/grafana-pyroscope/3/debian-12/Dockerfile
+++ b/bitnami/grafana-pyroscope/3/debian-12/Dockerfile
@@ -1,0 +1,59 @@
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+FROM docker.io/bitnami/minideb:bookworm
+
+ARG TARGETARCH
+
+LABEL com.vmware.cp.artifact.flavor="sha256:c50c90cfd9d12b445b011e6ad529f1ad3daea45c26d20b00732fae3cd71f6a83" \
+      org.opencontainers.image.base.name="docker.io/bitnami/minideb:bookworm" \
+      org.opencontainers.image.created="2024-06-15T01:05:00Z" \
+      org.opencontainers.image.description="Application packaged by Broadcom, Inc." \
+      org.opencontainers.image.documentation="https://github.com/bitnami/containers/tree/main/bitnami/grafana-pyroscope/README.md" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.ref.name="3.0.0-debian-12-r6" \
+      org.opencontainers.image.source="https://github.com/bitnami/containers/tree/main/bitnami/grafana-pyroscope" \
+      org.opencontainers.image.title="grafana-pyroscoppe" \
+      org.opencontainers.image.vendor="Broadcom, Inc." \
+      org.opencontainers.image.version="3.0.0"
+
+ENV HOME="/" \
+    OS_ARCH="${TARGETARCH:-amd64}" \
+    OS_FLAVOUR="debian-12" \
+    OS_NAME="linux"
+
+COPY prebuildfs /
+SHELL ["/bin/bash", "-o", "errexit", "-o", "nounset", "-o", "pipefail", "-c"]
+# Install required system packages and dependencies
+RUN install_packages ca-certificates curl procps
+RUN mkdir -p /tmp/bitnami/pkg/cache/ ; cd /tmp/bitnami/pkg/cache/ ; \
+    COMPONENTS=( \
+      "pyroscope_1.6.0_linux_${OS_ARCH}" \
+    ) ; \
+    for COMPONENT in "${COMPONENTS[@]}"; do \
+      if [ ! -f "${COMPONENT}.tar.gz" ]; then \
+        curl -SsLf "https://github.com/grafana/pyroscope/releases/download/v1.6.0/${COMPONENT}.tar.gz" -O ; \
+        curl -SsLf "https://github.com/grafana/pyroscope/releases/download/v1.6.0/checksums.txt" -O ; \
+      fi ; \
+      grep "${COMPONENT}.tar.gz" checksums.txt | sha256sum -c - ; \
+      mkdir -p /opt/bitnami/grafana-pyroscope/bin ; \
+      tar -zxf "${COMPONENT}.tar.gz" -C /opt/bitnami/grafana-pyroscope/bin --no-same-owner pyroscope; \
+      rm -rf "${COMPONENT}".tar.gz{,.sha256} ; \
+    done
+RUN apt-get autoremove --purge -y curl && \
+    apt-get update && apt-get upgrade -y && \
+    apt-get clean && rm -rf /var/lib/apt/lists /var/cache/apt/archives
+RUN chmod g+rwX /opt/bitnami
+RUN mkdir -p /bitnami/grafana-pyroscope/data /bitnami/grafana-pyroscope/pyroscope && chmod -R g+rwX /bitnami/grafana-pyroscope && ln -s  /bitnami/grafana-pyroscope/pyroscope /etc/pyroscope && ln -s /bitnami/grafana-pyroscope/data /data
+RUN find / -perm /6000 -type f -exec chmod a-s {} \; || true
+
+ENV APP_VERSION="3.0.0" \
+    BITNAMI_APP_NAME="grafana-pyroscope" \
+    PATH="/opt/bitnami/grafana-pyroscope/bin:$PATH"
+
+EXPOSE 4040
+
+USER 1001
+ENTRYPOINT [ "pyroscope" ]
+CMD [ "-server.http-listen-port", "4040"]
+

--- a/bitnami/grafana-pyroscope/3/debian-12/prebuildfs/opt/bitnami/.bitnami_components.json
+++ b/bitnami/grafana-pyroscope/3/debian-12/prebuildfs/opt/bitnami/.bitnami_components.json
@@ -1,0 +1,8 @@
+{
+    "grafana-loki": {
+        "arch": "amd64",
+        "distro": "debian-12",
+        "type": "NAMI",
+        "version": "3.0.0-3"
+    }
+}

--- a/bitnami/grafana-pyroscope/3/debian-12/prebuildfs/opt/bitnami/licenses/licenses.txt
+++ b/bitnami/grafana-pyroscope/3/debian-12/prebuildfs/opt/bitnami/licenses/licenses.txt
@@ -1,0 +1,2 @@
+Bitnami containers ship with software bundles. You can find the licenses under:
+/opt/bitnami/[name-of-bundle]/licenses/[bundle-version].txt

--- a/bitnami/grafana-pyroscope/3/debian-12/prebuildfs/usr/sbin/install_packages
+++ b/bitnami/grafana-pyroscope/3/debian-12/prebuildfs/usr/sbin/install_packages
@@ -1,0 +1,27 @@
+#!/bin/sh
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+set -eu
+
+n=0
+max=2
+export DEBIAN_FRONTEND=noninteractive
+
+until [ $n -gt $max ]; do
+    set +e
+    (
+      apt-get update -qq &&
+      apt-get install -y --no-install-recommends "$@"
+    )
+    CODE=$?
+    set -e
+    if [ $CODE -eq 0 ]; then
+        break
+    fi
+    if [ $n -eq $max ]; then
+        exit $CODE
+    fi
+    echo "apt failed, retrying"
+    n=$(($n + 1))
+done
+apt-get clean && rm -rf /var/lib/apt/lists /var/cache/apt/archives

--- a/bitnami/grafana-pyroscope/3/debian-12/prebuildfs/usr/sbin/run-script
+++ b/bitnami/grafana-pyroscope/3/debian-12/prebuildfs/usr/sbin/run-script
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+set -u
+
+if [ $# -eq 0 ]; then
+    >&2 echo "No arguments provided"
+    exit 1
+fi
+
+script=$1
+exit_code="${2:-96}"
+fail_if_not_present="${3:-n}"
+
+if test -f "$script"; then
+  sh $script
+
+  if [ $? -ne 0 ]; then
+    exit $((exit_code))
+  fi
+elif [ "$fail_if_not_present" = "y" ]; then
+  >&2 echo "script not found: $script"
+  exit 127
+fi

--- a/bitnami/grafana-pyroscope/3/debian-12/tags-info.yaml
+++ b/bitnami/grafana-pyroscope/3/debian-12/tags-info.yaml
@@ -1,0 +1,5 @@
+rolling-tags:
+- "3"
+- 3-debian-12
+- 3.0.0
+- latest

--- a/bitnami/grafana-pyroscope/README.md
+++ b/bitnami/grafana-pyroscope/README.md
@@ -1,0 +1,84 @@
+# Bitnami package for Pyroscope
+
+## What is Pyroscope?
+
+> Pyroscope is an open source continuous profiling platform. It allows you to monitor your applications in real time to identify performance bottlenecks and improve resource efficiency.
+
+[Overview of Pyroscope](https://github.com/grafana/pyroscope)
+
+Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
+
+## TL;DR
+
+```console
+docker run --name pyroscope bitnami/grafana-pyroscope:latest
+```
+
+## Why use Bitnami Images?
+
+* Bitnami closely tracks upstream source changes and promptly publishes new versions of this image using our automated systems.
+* With Bitnami images the latest bug fixes and features are available as soon as possible.
+* Bitnami containers, virtual machines and cloud images use the same components and configuration approach - making it easy to switch between formats based on your project needs.
+* All our images are based on [**minideb**](https://github.com/bitnami/minideb) -a minimalist Debian based container image that gives you a small base container image and the familiarity of a leading Linux distribution- or **scratch** -an explicitly empty image-.
+* All Bitnami images available in Docker Hub are signed with [Notation](https://notaryproject.dev/). [Check this post](https://blog.bitnami.com/2024/03/bitnami-packaged-containers-and-helm.html) to know how to verify the integrity of the images.
+* Bitnami container images are released on a regular basis with the latest distribution packages available.
+
+## Get this image
+
+The recommended way to get the Bitnami Pyroscope Docker Image is to pull the prebuilt image from the [Docker Hub Registry](https://hub.docker.com/r/bitnami/pyroscope).
+
+```console
+docker pull bitnami/pyroscope:latest
+```
+
+To use a specific version, you can pull a versioned tag. You can view the [list of available versions](https://hub.docker.com/r/bitnami/pyroscope/tags/) in the Docker Hub Registry.
+
+```console
+docker pull bitnami/pyroscope:[TAG]
+```
+
+If you wish, you can also build the image yourself by cloning the repository, changing to the directory containing the Dockerfile, and executing the `docker build` command. Remember to replace the `APP`, `VERSION`, and `OPERATING-SYSTEM` path placeholders in the example command below with the correct values.
+
+```console
+git clone https://github.com/bitnami/containers.git
+cd bitnami/APP/VERSION/OPERATING-SYSTEM
+docker build -t bitnami/APP:latest .
+```
+
+## Why use a non-root container?
+
+Non-root container images add an extra layer of security and are generally recommended for production environments. However, because they run as a non-root user, privileged tasks are typically off-limits. Learn more about non-root containers [in our docs](https://docs.vmware.com/en/VMware-Tanzu-Application-Catalog/services/tutorials/GUID-work-with-non-root-containers-index.html).
+
+## Configuration
+
+### Running commands
+
+To run commands inside this container you can use `docker run`, for example to execute `pyroscope --version` you can follow the example below:
+
+```console
+docker run --rm --name pyroscope bitnami/pyroscope:latest -- --version
+```
+
+## Contributing
+
+We'd love for you to contribute to this container. You can request new features by creating an [issue](https://github.com/bitnami/containers/issues) or submitting a [pull request](https://github.com/bitnami/containers/pulls) with your contribution.
+
+## Issues
+
+If you encountered a problem running this container, you can file an [issue](https://github.com/bitnami/containers/issues/new/choose). For us to provide better support, be sure to fill the issue template.
+
+## License
+
+Copyright &copy; 2024 Broadcom. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+<http://www.apache.org/licenses/LICENSE-2.0>
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
This commit adds support for Grafana Pyroscope version 1.6.0 on Debian 12. It includes the creation of README, Dockerfile.

### Description of the change

A new Docker image for Grafana Pyroscope version 3.0.0, optimized for Debian 12. This new image aims to provide users with the latest version of Grafana Pyroscope, leveraging the enhancements and features introduced in the newest release.

### Benefits

- Offers the latest features and fixes from Grafana Pyroscope 1.6.0.

### Possible drawbacks

This implementation introduces a change in the source of the Docker image files for Pyroscope. Traditionally, Bitnami packages source their images from `https://downloads.bitnami.com/files/stacksmith`, which is a trusted and standardized source for Bitnami's container images. However, as there was no existing image for Pyroscope in this repository, this update utilizes the official releases available at `https://github.com/grafana/pyroscope/releases`.

### Applicable issues

[bitnami/pyroscope] Request to create official Docker image and add new Helm chart for Pyroscope [#27185](https://github.com/bitnami/charts/issues/27185)

Signed-off-by: Carlos Peliciari <cpeliciari@outlook.com>