### PR TITLE
[bitnami/kubectl] Add yq

### DIFF
--- a/bitnami/kubectl/1.27/debian-12/Dockerfile
+++ b/bitnami/kubectl/1.27/debian-12/Dockerfile
@@ -25,7 +25,7 @@ ENV HOME="/" \
 COPY prebuildfs /
 SHELL ["/bin/bash", "-o", "errexit", "-o", "nounset", "-o", "pipefail", "-c"]
 # Install required system packages and dependencies
-RUN install_packages ca-certificates curl gettext git jq procps
+RUN install_packages ca-certificates curl gettext git jq yq procps
 RUN mkdir -p /tmp/bitnami/pkg/cache/ ; cd /tmp/bitnami/pkg/cache/ ; \
     COMPONENTS=( \
       "kubectl-1.27.15-0-linux-${OS_ARCH}-debian-12" \

--- a/bitnami/kubectl/1.28/debian-12/Dockerfile
+++ b/bitnami/kubectl/1.28/debian-12/Dockerfile
@@ -25,7 +25,7 @@ ENV HOME="/" \
 COPY prebuildfs /
 SHELL ["/bin/bash", "-o", "errexit", "-o", "nounset", "-o", "pipefail", "-c"]
 # Install required system packages and dependencies
-RUN install_packages ca-certificates curl gettext git jq procps
+RUN install_packages ca-certificates curl gettext git jq yq procps
 RUN mkdir -p /tmp/bitnami/pkg/cache/ ; cd /tmp/bitnami/pkg/cache/ ; \
     COMPONENTS=( \
       "kubectl-1.28.11-0-linux-${OS_ARCH}-debian-12" \

--- a/bitnami/kubectl/1.29/debian-12/Dockerfile
+++ b/bitnami/kubectl/1.29/debian-12/Dockerfile
@@ -25,7 +25,7 @@ ENV HOME="/" \
 COPY prebuildfs /
 SHELL ["/bin/bash", "-o", "errexit", "-o", "nounset", "-o", "pipefail", "-c"]
 # Install required system packages and dependencies
-RUN install_packages ca-certificates curl gettext git jq procps
+RUN install_packages ca-certificates curl gettext git jq yq procps
 RUN mkdir -p /tmp/bitnami/pkg/cache/ ; cd /tmp/bitnami/pkg/cache/ ; \
     COMPONENTS=( \
       "kubectl-1.29.6-0-linux-${OS_ARCH}-debian-12" \

--- a/bitnami/kubectl/1.30/debian-12/Dockerfile
+++ b/bitnami/kubectl/1.30/debian-12/Dockerfile
@@ -25,7 +25,7 @@ ENV HOME="/" \
 COPY prebuildfs /
 SHELL ["/bin/bash", "-o", "errexit", "-o", "nounset", "-o", "pipefail", "-c"]
 # Install required system packages and dependencies
-RUN install_packages ca-certificates curl gettext git jq procps
+RUN install_packages ca-certificates curl gettext git jq yq procps
 RUN mkdir -p /tmp/bitnami/pkg/cache/ ; cd /tmp/bitnami/pkg/cache/ ; \
     COMPONENTS=( \
       "kubectl-1.30.2-0-linux-${OS_ARCH}-debian-12" \


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change
This PR adds `yq` to the `kubectl` container image. `yq` is a portable command-line YAML processor that enables users to manipulate YAML files, which is particularly useful for working with Kubernetes manifests.

### Benefits
Enhances the functionality of the `kubectl` container image by adding the ability to easily manipulate YAML files.

### Possible drawbacks
Increases the size of the container image (286MB -> 324MB) due to the addition of the `yq` binary and its dependencies.

### Applicable issues
None

### Additional information
There is also a light-weighted version of `yq` (https://github.com/mikefarah/yq) that could also be considered  in order to get rid-off the python3 dependency.
