### PR TITLE
[bitnami/phpmyadmin] fix wrong variables CONFIGURATION_ALLOWDENY_

### DIFF
--- a/bitnami/phpmyadmin/5/debian-12/rootfs/opt/bitnami/scripts/libphpmyadmin.sh
+++ b/bitnami/phpmyadmin/5/debian-12/rootfs/opt/bitnami/scripts/libphpmyadmin.sh
@@ -116,8 +116,8 @@ phpmyadmin_initialize() {
     fi
 
     # Configure allow deny order/rules settings
-    ! is_empty_value "$CONFIGURATION_ALLOWDENY_ORDER" && phpmyadmin_conf_set "\$cfg['Servers'][\$i]['AllowDeny']['order']" "$ALLOWDENY_ORDER"
-    ! is_empty_value "$CONFIGURATION_ALLOWDENY_RULES" && phpmyadmin_conf_set "\$cfg['Servers'][\$i]['AllowDeny']['rules']" "array($ALLOWDENY_RULES)" yes
+    ! is_empty_value "$CONFIGURATION_ALLOWDENY_ORDER" && phpmyadmin_conf_set "\$cfg['Servers'][\$i]['AllowDeny']['order']" "$CONFIGURATION_ALLOWDENY_ORDER"
+    ! is_empty_value "$CONFIGURATION_ALLOWDENY_RULES" && phpmyadmin_conf_set "\$cfg['Servers'][\$i]['AllowDeny']['rules']" "array($CONFIGURATION_ALLOWDENY_RULES)" yes
 
     # Configure automatic login with account
     if ! is_empty_value "$DATABASE_USER"; then


### PR DESCRIPTION
### Description of the change

Rename 2 variables `ALLOWDENY_ORDER` and `ALLOWDENY_RULES` (I couldn’t find any previous declaration; it seems to be a variable name error) to `CONFIGURATION_ALLOWDENY_ORDER` and `CONFIGURATION_ALLOWDENY_RULES`.

### Benefits

The container can start with these variables, and it functions properly. The configuration was applied to the file `/opt/bitnami/phpmyadmin/config.inc.php` and works fine.

### Possible drawbacks

Not found yet.

### Applicable issues

- fixes #68067
