### PR TITLE
[bitnami/postgresql] Updated libpostgresql.sh to specify a host to Postgres Commands

### DIFF
--- a/bitnami/postgresql/16/debian-12/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/bitnami/postgresql/16/debian-12/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -792,7 +792,7 @@ postgresql_start_bg() {
     else
         "${pg_ctl_cmd[@]}" "start" "${pg_ctl_flags[@]}" >/dev/null 2>&1
     fi
-    local pg_isready_args=("-U" "postgres" "-p" "$POSTGRESQL_PORT_NUMBER")
+    local pg_isready_args=("-U" "postgres" "-p" "$POSTGRESQL_PORT_NUMBER" "-h" "127.0.0.1")
     local counter=$POSTGRESQL_INIT_MAX_TIMEOUT
     while ! "$POSTGRESQL_BIN_DIR"/pg_isready "${pg_isready_args[@]}" >/dev/null 2>&1; do
         sleep 1
@@ -1078,7 +1078,7 @@ postgresql_execute_print_output() {
     local opts
     read -r -a opts <<<"${@:4}"
 
-    local args=("-U" "$user" "-p" "${POSTGRESQL_PORT_NUMBER:-5432}")
+    local args=("-U" "$user" "-p" "${POSTGRESQL_PORT_NUMBER:-5432}" "-h" "127.0.0.1")
     [[ -n "$db" ]] && args+=("-d" "$db")
     [[ "${#opts[@]}" -gt 0 ]] && args+=("${opts[@]}")
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Updates the `postgresql_start_bg` and `postgresql_execute_print_output` functions in libpostgresql.sh to specify the loopback address as the host for `psql` and `pg_isready` commands.

### Benefits

If a custom unix socket directory is specified in the Primary configuration, startup will fail as the `psql` and `pg_isready` commands do not look at the correct location for the Unix socket directory. This updates them to use the loopback host which should work regardless of where the unix socket file is stored, and it is also consistent with the behavior of the probes used by the Helm chart.

Being able to specify a custom Unix socket directory is useful, as the [Bitnami Postgresql image provided by Iron Bank](https://repo1.dso.mil/dsop/bitnami/postgres/postgresql16/-/blob/development/Dockerfile?ref_type=heads) is built on top of the RHEL Universal Base Image and uses the RHEL Postgresql port. The RHEL Postgresql port defaults to storing Postgresql's unix socket under /run, which poses an issue as it is a common security measure to deploy containers with read-only root filesystems.

### Possible drawbacks

None that I'm aware of. I've tested this in standalone and replication mode, and both appeared to work as expected.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #68027 

### Additional information

There appears to be a separate bug here mentioned in #68027 where if the startup setup fails the first time, it will never be completed. When this happens, the Postgresql container will act as if it is healthy even though the authentication and databases have not been properly setup. This PR does not fix that issue.
