### PR TITLE
Fix issue with SONARQUBE_EXTRA_PROPERTIES containing equals

### DIFF
--- a/bitnami/sonarqube/10/debian-12/rootfs/opt/bitnami/scripts/libsonarqube.sh
+++ b/bitnami/sonarqube/10/debian-12/rootfs/opt/bitnami/scripts/libsonarqube.sh
@@ -135,7 +135,7 @@ sonarqube_initialize() {
     if [[ "${#additional_properties[@]}" -gt 0 ]]; then
         info "Adding properties provided via SONARQUBE_EXTRA_PROPERTIES to sonar.properties"
         for property in "${additional_properties[@]}"; do
-            sonarqube_conf_set "${property%=*}" "${property#*=}"
+            sonarqube_conf_set "${property%%=*}" "${property#*=}"
         done
     fi
 

--- a/bitnami/sonarqube/9/debian-12/rootfs/opt/bitnami/scripts/libsonarqube.sh
+++ b/bitnami/sonarqube/9/debian-12/rootfs/opt/bitnami/scripts/libsonarqube.sh
@@ -135,7 +135,7 @@ sonarqube_initialize() {
     if [[ "${#additional_properties[@]}" -gt 0 ]]; then
         info "Adding properties provided via SONARQUBE_EXTRA_PROPERTIES to sonar.properties"
         for property in "${additional_properties[@]}"; do
-            sonarqube_conf_set "${property%=*}" "${property#*=}"
+            sonarqube_conf_set "${property%%=*}" "${property#*=}"
         done
     fi
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Fix an issue with sonarqube script that do not extract extra env var (SONARQUBE_EXTRA_PROPERTIES)

### Benefits

Fix an issue

### Possible drawbacks

None ?

### Applicable issues

N/A

### Additional information

#### Invalid replacement of extra vars (SONARQUBE_EXTRA_PROPERTIES)

Script
```bash
#!/bin/bash

SONARQUBE_EXTRA_PROPERTIES=sonar.core.serverBaseURL=https://example.com,sonar.auth.saml.enabled=true,sonar.auth.saml.applicationId=Example,sonar.auth.saml.providerName=SAML,sonar.auth.saml.providerId=https://example.com/saml2?idpid=IDEXAMPLE,sonar.auth.saml.loginUrl=https://example.com/saml2/idp?idpid=IDEXAMPLE,sonar.auth.saml.user.login=login,sonar.auth.saml.user.name=username,sonar.auth.saml.user.email=email
echo "SONARQUBE_EXTRA_PROPERTIES: $SONARQUBE_EXTRA_PROPERTIES"

IFS=',' read -r -a additional_properties <<< "$SONARQUBE_EXTRA_PROPERTIES"
if [[ "${#additional_properties[@]}" -gt 0 ]]; then
    info "Adding properties provided via SONARQUBE_EXTRA_PROPERTIES to sonar.properties"
    for property in "${additional_properties[@]}"; do
        echo "${property%=*}=${property#*=}"
    done
fi
```

Invalid result
```bash
SONARQUBE_EXTRA_PROPERTIES: sonar.core.serverBaseURL=https://example.com,sonar.auth.saml.enabled=true,sonar.auth.saml.applicationId=Example,sonar.auth.saml.providerName=SAML,sonar.auth.saml.providerId=https://example.com/saml2?idpid=IDEXAMPLE,sonar.auth.saml.loginUrl=https://example.com/saml2/idp?idpid=IDEXAMPLE,sonar.auth.saml.user.login=login,sonar.auth.saml.user.name=username,sonar.auth.saml.user.email=email
info: No menu item 'Adding properties provided via SONARQUBE_EXTRA_PROPERTIES to sonar.properties' in node '(dir)Top'
sonar.core.serverBaseURL=https://example.com
sonar.auth.saml.enabled=true
sonar.auth.saml.applicationId=Example
sonar.auth.saml.providerName=SAML
sonar.auth.saml.providerId=https://example.com/saml2?idpid=https://example.com/saml2?idpid=IDEXAMPLE
sonar.auth.saml.loginUrl=https://example.com/saml2/idp?idpid=https://example.com/saml2/idp?idpid=IDEXAMPLE
sonar.auth.saml.user.login=login
sonar.auth.saml.user.name=username
sonar.auth.saml.user.email=email
```

> sonar.auth.saml.providerId=https://example.com/saml2?idpid=https://example.com/saml2?idpid=IDEXAMPLE

Invalid double replacement

#### Correct replacement of extra vars (SONARQUBE_EXTRA_PROPERTIES)

Script
```bash
#!/bin/bash

SONARQUBE_EXTRA_PROPERTIES=sonar.core.serverBaseURL=https://example.com,sonar.auth.saml.enabled=true,sonar.auth.saml.applicationId=Example,sonar.auth.saml.providerName=SAML,sonar.auth.saml.providerId=https://example.com/saml2?idpid=IDEXAMPLE,sonar.auth.saml.loginUrl=https://example.com/saml2/idp?idpid=IDEXAMPLE,sonar.auth.saml.user.login=login,sonar.auth.saml.user.name=username,sonar.auth.saml.user.email=email
echo "SONARQUBE_EXTRA_PROPERTIES: $SONARQUBE_EXTRA_PROPERTIES"

IFS=',' read -r -a additional_properties <<< "$SONARQUBE_EXTRA_PROPERTIES"
if [[ "${#additional_properties[@]}" -gt 0 ]]; then
    info "Adding properties provided via SONARQUBE_EXTRA_PROPERTIES to sonar.properties"
    for property in "${additional_properties[@]}"; do
        echo "${property%%=*}=${property#*=}"
    done
fi
```

Correct result
```bash
SONARQUBE_EXTRA_PROPERTIES: sonar.core.serverBaseURL=https://example.com,sonar.auth.saml.enabled=true,sonar.auth.saml.applicationId=Example,sonar.auth.saml.providerName=SAML,sonar.auth.saml.providerId=https://example.com/saml2?idpid=IDEXAMPLE,sonar.auth.saml.loginUrl=https://example.com/saml2/idp?idpid=IDEXAMPLE,sonar.auth.saml.user.login=login,sonar.auth.saml.user.name=username,sonar.auth.saml.user.email=email
info: No menu item 'Adding properties provided via SONARQUBE_EXTRA_PROPERTIES to sonar.properties' in node '(dir)Top'
sonar.core.serverBaseURL=https://example.com
sonar.auth.saml.enabled=true
sonar.auth.saml.applicationId=Example
sonar.auth.saml.providerName=SAML
sonar.auth.saml.providerId=https://example.com/saml2?idpid=IDEXAMPLE
sonar.auth.saml.loginUrl=https://example.com/saml2/idp?idpid=IDEXAMPLE
sonar.auth.saml.user.login=login
sonar.auth.saml.user.name=username
sonar.auth.saml.user.email=email
```

> sonar.auth.saml.providerId=https://example.com/saml2?idpid=IDEXAMPLE

Correct replacement