### PR TITLE
[bitnami/kafka] Updated cluster id argument for formatting storage in Kraft mode

### DIFF
--- a/bitnami/kafka/3.7/debian-12/rootfs/opt/bitnami/scripts/libkafka.sh
+++ b/bitnami/kafka/3.7/debian-12/rootfs/opt/bitnami/scripts/libkafka.sh
@@ -843,7 +843,7 @@ kafka_kraft_storage_initialize() {
         KAFKA_KRAFT_CLUSTER_ID="$("${KAFKA_HOME}/bin/kafka-storage.sh" random-uuid)"
         info "Generated Kafka cluster ID '${KAFKA_KRAFT_CLUSTER_ID}'"
     fi
-    args+=("--cluster-id" "$KAFKA_KRAFT_CLUSTER_ID")
+    args+=("--cluster-id=$KAFKA_KRAFT_CLUSTER_ID")
 
     # SCRAM users are configured during the cluster bootstrapping process and can later be manually updated using kafka-config.sh
     if is_boolean_yes "${KAFKA_KRAFT_BOOTSTRAP_SCRAM_USERS:-}"; then


### PR DESCRIPTION
### Issue Description
The `kafka-storage` CLI command fails when the `--cluster-id` parameter contains a dash ("-") eg `-tSMcAWISqCMa6HzGNyimw`. Although the command `--cluster-id $KAFKA_KRAFT_CLUSTER_ID` is generally correct, it does not handle cases where the cluster ID starts with a dash, causing a parsing error. The proper way to handle this case is to use the format `--cluster-id=$KAFKA_KRAFT_CLUSTER_ID`. 
This issue prevents the Kraft controller from starting and results in the following error:
```
2024-07-16 11:50:16 kafka 16:50:16.14 INFO  ==> Formatting storage directories to add metadata...
2024-07-16 11:50:21 usage: kafka-storage format [-h] --config CONFIG --cluster-id CLUSTER_ID
2024-07-16 11:50:21                      [--add-scram ADD_SCRAM] [--ignore-formatted]
2024-07-16 11:50:21                      [--release-version RELEASE_VERSION]
2024-07-16 11:50:21 kafka-storage: error: argument --cluster-id/-t: expected one argument
```

### Context
In this scenario, we are migrating an existing Kafka cluster from Zookeeper mode to Kraft mode. Therefore, this cluster ID is valid and pre-existing.

### Solution
Update the command to handle cluster IDs starting with a dash by using the format `--cluster-id=$KAFKA_KRAFT_CLUSTER_ID`