### PR TITLE
[bitnami/kong]: fix libkong.sh kong_stop function

### DIFF
--- a/bitnami/kong/3/debian-12/rootfs/opt/bitnami/scripts/libkong.sh
+++ b/bitnami/kong/3/debian-12/rootfs/opt/bitnami/scripts/libkong.sh
@@ -265,7 +265,7 @@ is_kong_not_running() {
 kong_stop() {
     local -r retries=5
     local -r sleep_time=5
-    kong stop -c "$KONG_CONF_FILE" -p "$KONG_PREFIX"
+    kong stop
     if ! retry_while is_kong_not_running "$retries" "$sleep_time"; then
         error "Kong failed to shut down"
         exit 1

--- a/bitnami/kong/3/debian-12/rootfs/opt/bitnami/scripts/libkong.sh
+++ b/bitnami/kong/3/debian-12/rootfs/opt/bitnami/scripts/libkong.sh
@@ -265,7 +265,7 @@ is_kong_not_running() {
 kong_stop() {
     local -r retries=5
     local -r sleep_time=5
-    kong stop
+    kong stop -p "$KONG_PREFIX"
     if ! retry_while is_kong_not_running "$retries" "$sleep_time"; then
         error "Kong failed to shut down"
         exit 1


### PR DESCRIPTION
### Description of the change

kong_stop function while testing additional script use `kong stop -c ...` and there is not `-c` argumentn or `-p` arguments.
If you set `metrics: true` at bitnami/kong helm chart, pods will fail with following error

```
kong: unrecognized parameter: c
```

### Benefits

kong will not fail while loading user's custom files (like the one used for the metrics)

### Possible drawbacks

N/A

### Applicable issues

[#69390](https://github.com/bitnami/containers/issues/69390)

### Additional information

N/A
