### PR TITLE
[bitnami/postgresql-repmgr] Fixing POSTGRESQL_INIT_MAX_TIMEOUT didn't take effect

### DIFF
--- a/bitnami/postgresql-repmgr/12/debian-12/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/bitnami/postgresql-repmgr/12/debian-12/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -777,7 +777,7 @@ postgresql_stop() {
 #########################
 postgresql_start_bg() {
     local -r pg_logs=${1:-false}
-    local -r pg_ctl_flags=("-w" "-D" "$POSTGRESQL_DATA_DIR" "-l" "$POSTGRESQL_LOG_FILE" "-o" "--config-file=$POSTGRESQL_CONF_FILE --external_pid_file=$POSTGRESQL_PID_FILE --hba_file=$POSTGRESQL_PGHBA_FILE")
+    local -r pg_ctl_flags=("-W" "-D" "$POSTGRESQL_DATA_DIR" "-l" "$POSTGRESQL_LOG_FILE" "-o" "--config-file=$POSTGRESQL_CONF_FILE --external_pid_file=$POSTGRESQL_PID_FILE --hba_file=$POSTGRESQL_PGHBA_FILE")
     info "Starting PostgreSQL in background..."
     if is_postgresql_running; then
         return 0

--- a/bitnami/postgresql-repmgr/13/debian-12/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/bitnami/postgresql-repmgr/13/debian-12/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -777,7 +777,7 @@ postgresql_stop() {
 #########################
 postgresql_start_bg() {
     local -r pg_logs=${1:-false}
-    local -r pg_ctl_flags=("-w" "-D" "$POSTGRESQL_DATA_DIR" "-l" "$POSTGRESQL_LOG_FILE" "-o" "--config-file=$POSTGRESQL_CONF_FILE --external_pid_file=$POSTGRESQL_PID_FILE --hba_file=$POSTGRESQL_PGHBA_FILE")
+    local -r pg_ctl_flags=("-W" "-D" "$POSTGRESQL_DATA_DIR" "-l" "$POSTGRESQL_LOG_FILE" "-o" "--config-file=$POSTGRESQL_CONF_FILE --external_pid_file=$POSTGRESQL_PID_FILE --hba_file=$POSTGRESQL_PGHBA_FILE")
     info "Starting PostgreSQL in background..."
     if is_postgresql_running; then
         return 0

--- a/bitnami/postgresql-repmgr/14/debian-12/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/bitnami/postgresql-repmgr/14/debian-12/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -777,7 +777,7 @@ postgresql_stop() {
 #########################
 postgresql_start_bg() {
     local -r pg_logs=${1:-false}
-    local -r pg_ctl_flags=("-w" "-D" "$POSTGRESQL_DATA_DIR" "-l" "$POSTGRESQL_LOG_FILE" "-o" "--config-file=$POSTGRESQL_CONF_FILE --external_pid_file=$POSTGRESQL_PID_FILE --hba_file=$POSTGRESQL_PGHBA_FILE")
+    local -r pg_ctl_flags=("-W" "-D" "$POSTGRESQL_DATA_DIR" "-l" "$POSTGRESQL_LOG_FILE" "-o" "--config-file=$POSTGRESQL_CONF_FILE --external_pid_file=$POSTGRESQL_PID_FILE --hba_file=$POSTGRESQL_PGHBA_FILE")
     info "Starting PostgreSQL in background..."
     if is_postgresql_running; then
         return 0

--- a/bitnami/postgresql-repmgr/15/debian-12/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/bitnami/postgresql-repmgr/15/debian-12/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -777,7 +777,7 @@ postgresql_stop() {
 #########################
 postgresql_start_bg() {
     local -r pg_logs=${1:-false}
-    local -r pg_ctl_flags=("-w" "-D" "$POSTGRESQL_DATA_DIR" "-l" "$POSTGRESQL_LOG_FILE" "-o" "--config-file=$POSTGRESQL_CONF_FILE --external_pid_file=$POSTGRESQL_PID_FILE --hba_file=$POSTGRESQL_PGHBA_FILE")
+    local -r pg_ctl_flags=("-W" "-D" "$POSTGRESQL_DATA_DIR" "-l" "$POSTGRESQL_LOG_FILE" "-o" "--config-file=$POSTGRESQL_CONF_FILE --external_pid_file=$POSTGRESQL_PID_FILE --hba_file=$POSTGRESQL_PGHBA_FILE")
     info "Starting PostgreSQL in background..."
     if is_postgresql_running; then
         return 0

--- a/bitnami/postgresql-repmgr/16/debian-12/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/bitnami/postgresql-repmgr/16/debian-12/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -777,7 +777,7 @@ postgresql_stop() {
 #########################
 postgresql_start_bg() {
     local -r pg_logs=${1:-false}
-    local -r pg_ctl_flags=("-w" "-D" "$POSTGRESQL_DATA_DIR" "-l" "$POSTGRESQL_LOG_FILE" "-o" "--config-file=$POSTGRESQL_CONF_FILE --external_pid_file=$POSTGRESQL_PID_FILE --hba_file=$POSTGRESQL_PGHBA_FILE")
+    local -r pg_ctl_flags=("-W" "-D" "$POSTGRESQL_DATA_DIR" "-l" "$POSTGRESQL_LOG_FILE" "-o" "--config-file=$POSTGRESQL_CONF_FILE --external_pid_file=$POSTGRESQL_PID_FILE --hba_file=$POSTGRESQL_PGHBA_FILE")
     info "Starting PostgreSQL in background..."
     if is_postgresql_running; then
         return 0


### PR DESCRIPTION
### Description of the change

This change adds the -W option to the pg_ctl command used to start PostgreSQL in slow machines, such as virtual machines. The -W option explicitly tells pg_ctl not to wait for the startup to complete.

### Additional information

If the -w option is used, pg_ctl will still be waiting for the startup to complete, which can take more than a minute on slow machines. If pg_ctl times out, the entire container will be terminated, and POSTGRESQL_INIT_MAX_TIMEOUT will not take effect.