### PR TITLE
RabbitMQ UI support IPv6

### DIFF
--- a/bitnami/rabbitmq/3.12/debian-12/rootfs/opt/bitnami/scripts/librabbitmq.sh
+++ b/bitnami/rabbitmq/3.12/debian-12/rootfs/opt/bitnami/scripts/librabbitmq.sh
@@ -126,7 +126,7 @@ rabbitmq_validate() {
     fi
 
     if [[ "$RABBITMQ_NODE_TYPE" = "stats" ]]; then
-        if ! validate_ipv4 "$RABBITMQ_MANAGEMENT_BIND_IP"; then
+        if ! validate_ip "$RABBITMQ_MANAGEMENT_BIND_IP"; then
             print_validation_error "An invalid IP was specified in the environment variable RABBITMQ_MANAGEMENT_BIND_IP."
         fi
         check_allowed_port "RABBITMQ_MANAGEMENT_PORT_NUMBER"

--- a/bitnami/rabbitmq/3.13/debian-12/rootfs/opt/bitnami/scripts/librabbitmq.sh
+++ b/bitnami/rabbitmq/3.13/debian-12/rootfs/opt/bitnami/scripts/librabbitmq.sh
@@ -126,7 +126,7 @@ rabbitmq_validate() {
     fi
 
     if [[ "$RABBITMQ_NODE_TYPE" = "stats" ]]; then
-        if ! validate_ipv4 "$RABBITMQ_MANAGEMENT_BIND_IP"; then
+        if ! validate_ip "$RABBITMQ_MANAGEMENT_BIND_IP"; then
             print_validation_error "An invalid IP was specified in the environment variable RABBITMQ_MANAGEMENT_BIND_IP."
         fi
         check_allowed_port "RABBITMQ_MANAGEMENT_PORT_NUMBER"


### PR DESCRIPTION
### Description of the change

Updated IP validation function in RabbitMQ configuration script to support IPv6

### Benefits

RabbitMq UI will work in IPv6 only networks

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #69256 
