### PR TITLE
[bitnami/openldap] Update `ldap_start_bg` argument description

### DIFF
--- a/bitnami/openldap/2.5/debian-12/rootfs/opt/bitnami/scripts/libopenldap.sh
+++ b/bitnami/openldap/2.5/debian-12/rootfs/opt/bitnami/scripts/libopenldap.sh
@@ -208,7 +208,8 @@ is_ldap_not_running() {
 ########################
 # Start OpenLDAP server in background
 # Arguments:
-#   None
+#   $1 - max retries. Default: 12
+#   $2 - sleep between retries (in seconds). Default: 1
 # Returns:
 #   None
 #########################

--- a/bitnami/openldap/2.6/debian-12/rootfs/opt/bitnami/scripts/libopenldap.sh
+++ b/bitnami/openldap/2.6/debian-12/rootfs/opt/bitnami/scripts/libopenldap.sh
@@ -208,7 +208,8 @@ is_ldap_not_running() {
 ########################
 # Start OpenLDAP server in background
 # Arguments:
-#   None
+#   $1 - max retries. Default: 12
+#   $2 - sleep between retries (in seconds). Default: 1
 # Returns:
 #   None
 #########################


### PR DESCRIPTION
### Description of the change

Fix `ldap_start_bg` argument description in the OpenLDAP `libopenldap.sh` script to
match its behavior.

No functional changes.

### Benefits

The shell script argument description will actually be correct

### Possible drawbacks

none

### Applicable issues

none

### Additional information

none
