### PR TITLE
[bitnami/grafana] Add workaround for version 11.1.3

### DIFF
--- a/.vib/grafana/goss/vars.yaml
+++ b/.vib/grafana/goss/vars.yaml
@@ -2,10 +2,10 @@ binaries:
   - grafana
 root_dir: /opt/bitnami
 version:
-  # HACK: Temporary fix for Grafana 11.1.2 which had an incorrect version set
+  # HACK: Temporary fix for Grafana 11.1.3 which had an incorrect version set
   # https://github.com/grafana/grafana/issues/90947
   bin_name: bash
-  flag: -c "if [[ \"$APP_VERSION\" = \"11.1.2\" ]]; then echo 11.1.2; else grafana --version; fi"
+  flag: -c "if [[ \"$APP_VERSION\" = \"11.1.3\" ]]; then echo 11.1.3; else grafana --version; fi"
 files:
   - mode: "0664"
     paths:


### PR DESCRIPTION
### Description of the change

This PR adds a workaround for version 11.1.3, which has an incorrect version set:

https://github.com/grafana/grafana/issues/90947

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
