### PR TITLE
[bitnami/keycloak] Use Java 21 with Keycloak 25

### DIFF
--- a/bitnami/keycloak/25/debian-12/Dockerfile
+++ b/bitnami/keycloak/25/debian-12/Dockerfile
@@ -30,7 +30,7 @@ RUN install_packages ca-certificates curl krb5-user libaio1 procps zlib1g
 RUN mkdir -p /tmp/bitnami/pkg/cache/ ; cd /tmp/bitnami/pkg/cache/ ; \
     COMPONENTS=( \
       "wait-for-port-1.0.8-2-linux-${OS_ARCH}-debian-12" \
-      "java-17.0.12-10-0-linux-${OS_ARCH}-debian-12" \
+      "java-21.0.4-9-0-linux-${OS_ARCH}-debian-12" \
       "keycloak-25.0.2-1-linux-${OS_ARCH}-debian-12" \
     ) ; \
     for COMPONENT in "${COMPONENTS[@]}"; do \


### PR DESCRIPTION
### Description of the change

Use Java 21 for Keycloak 25.

### Benefits

Java 17 is deprecated by Keycloak. Java 21 should be used. See: https://www.keycloak.org/2024/06/keycloak-2500-released

### Possible drawbacks



### Applicable issues

- fixes #70424

### Additional information


