### PR TITLE
[bitnami/etcd] fix: healthcheck will failed when startup etcd with on…

### DIFF
--- a/bitnami/etcd/3.4/debian-12/rootfs/opt/bitnami/scripts/etcd/healthcheck.sh
+++ b/bitnami/etcd/3.4/debian-12/rootfs/opt/bitnami/scripts/etcd/healthcheck.sh
@@ -21,9 +21,12 @@ host="$(parse_uri "${advertised_array[0]}" "host")"
 port="$(parse_uri "${advertised_array[0]}" "port")"
 read -r -a extra_flags <<< "$(etcdctl_auth_flags)"
 extra_flags+=("--endpoints=${host}:${port}")
-if [[ $ETCD_AUTO_TLS = true ]]; then
+
+ # if ETCD_AUTO_TLS true or CA file not exists, just skip server cert verification
+if [[ $ETCD_AUTO_TLS = true ]] || [[ ! -f "$ETCD_TRUSTED_CA_FILE" ]]; then
      extra_flags+=("--insecure-skip-tls-verify")
 fi
+
 if etcdctl endpoint health "${extra_flags[@]}"; then
     exit 0
 else

--- a/bitnami/etcd/3.5/debian-12/rootfs/opt/bitnami/scripts/etcd/healthcheck.sh
+++ b/bitnami/etcd/3.5/debian-12/rootfs/opt/bitnami/scripts/etcd/healthcheck.sh
@@ -21,9 +21,12 @@ host="$(parse_uri "${advertised_array[0]}" "host")"
 port="$(parse_uri "${advertised_array[0]}" "port")"
 read -r -a extra_flags <<< "$(etcdctl_auth_flags)"
 extra_flags+=("--endpoints=${host}:${port}")
-if [[ $ETCD_AUTO_TLS = true ]]; then
+
+ # if ETCD_AUTO_TLS true or CA file not exists, just skip server cert verification
+if [[ $ETCD_AUTO_TLS = true ]] || [[ ! -f "$ETCD_TRUSTED_CA_FILE" ]]; then
      extra_flags+=("--insecure-skip-tls-verify")
 fi
+
 if etcdctl endpoint health "${extra_flags[@]}"; then
     exit 0
 else


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

modified the script healthcheck.sh to skip tls verification to allow startup etcd with one-way tls authentication

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #70554

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
