### PR TITLE
[bitnami/keycloak] Add management port to EXPOSE

### DIFF
--- a/bitnami/keycloak/25/debian-12/Dockerfile
+++ b/bitnami/keycloak/25/debian-12/Dockerfile
@@ -55,7 +55,7 @@ ENV APP_VERSION="25.0.2" \
     JAVA_HOME="/opt/bitnami/java" \
     PATH="/opt/bitnami/common/bin:/opt/bitnami/java/bin:/opt/bitnami/keycloak/bin:$PATH"
 
-EXPOSE 8080 8443
+EXPOSE 8080 8443 9000
 
 USER 1001
 ENTRYPOINT [ "/opt/bitnami/scripts/keycloak/entrypoint.sh" ]


### PR DESCRIPTION
### Description of the change

Add port `9000` to expose of keycloak dockerfile

### Benefits

Document port `9000` is available

### Possible drawbacks

### Applicable issues

- fixes #70612

### Additional information
* [Management port for metrics and health endpoints](https://www.keycloak.org/2024/06/keycloak-2500-released#_management_port_for_metrics_and_health_endpoints)