### PR TITLE
[bitnami/cassandra] fix non-existent certs folder

### DIFF
--- a/bitnami/cassandra/4.0/debian-12/rootfs/opt/bitnami/scripts/libcassandra.sh
+++ b/bitnami/cassandra/4.0/debian-12/rootfs/opt/bitnami/scripts/libcassandra.sh
@@ -68,6 +68,8 @@ cassandra_setup_client_ssl() {
         -srcstorepass "${DB_KEYSTORE_PASSWORD}" \
         -deststorepass "${DB_KEYSTORE_PASSWORD}"
 
+    mkdir -p "$(dirname "${DB_SSL_CERT_FILE}")"
+
     openssl pkcs12 -in "${DB_TMP_P12_FILE}" -nokeys \
         -out "${DB_SSL_CERT_FILE}" -passin pass:"${DB_KEYSTORE_PASSWORD}"
     rm "${DB_TMP_P12_FILE}"

--- a/bitnami/cassandra/4.1/debian-12/rootfs/opt/bitnami/scripts/libcassandra.sh
+++ b/bitnami/cassandra/4.1/debian-12/rootfs/opt/bitnami/scripts/libcassandra.sh
@@ -68,6 +68,8 @@ cassandra_setup_client_ssl() {
         -srcstorepass "${DB_KEYSTORE_PASSWORD}" \
         -deststorepass "${DB_KEYSTORE_PASSWORD}"
 
+    mkdir -p "$(dirname "${DB_SSL_CERT_FILE}")"
+
     openssl pkcs12 -in "${DB_TMP_P12_FILE}" -nokeys \
         -out "${DB_SSL_CERT_FILE}" -passin pass:"${DB_KEYSTORE_PASSWORD}"
     rm "${DB_TMP_P12_FILE}"


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

I added code to to make sure the folder in which a client certificate should be created exists if TLS is enabled.
<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Even with default settings the folder does not exist by default, which leads to failed startups
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

None to my knowledge
<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #70738 

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
