### PR TITLE
[bitnami/openldap] feat: pldap and pldaps support

### DIFF
--- a/bitnami/openldap/2.5/debian-12/rootfs/opt/bitnami/scripts/libopenldap.sh
+++ b/bitnami/openldap/2.5/debian-12/rootfs/opt/bitnami/scripts/libopenldap.sh
@@ -52,6 +52,9 @@ export LDAP_DAEMON_GROUP="slapd"
 # Settings
 export LDAP_PORT_NUMBER="${LDAP_PORT_NUMBER:-1389}"
 export LDAP_LDAPS_PORT_NUMBER="${LDAP_LDAPS_PORT_NUMBER:-1636}"
+export LDAP_ENABLE_PROXYPROTO="${LDAP_ENABLE_PROXYPROTO:-no}"
+export LDAP_PROXYPROTO_PORT_NUMBER="${LDAP_PROXYPROTO_PORT_NUMBER:-"${LDAP_PORT_NUMBER}"}"
+export LDAP_PROXYPROTO_LDAPS_PORT_NUMBER="${LDAP_PROXYPROTO_LDAPS_PORT_NUMBER:-"${LDAP_LDAPS_PORT_NUMBER}"}"
 export LDAP_ROOT="${LDAP_ROOT:-dc=example,dc=org}"
 export LDAP_SUFFIX="$(if [ -z "${LDAP_SUFFIX+x}" ]; then echo "${LDAP_ROOT}"; else echo "${LDAP_SUFFIX}"; fi)"
 export LDAP_ADMIN_USERNAME="${LDAP_ADMIN_USERNAME:-admin}"
@@ -136,7 +139,7 @@ ldap_validate() {
         error "$1"
         error_code=1
     }
-    for var in LDAP_SKIP_DEFAULT_TREE LDAP_ENABLE_TLS; do
+    for var in LDAP_SKIP_DEFAULT_TREE LDAP_ENABLE_TLS LDAP_ENABLE_PROXYPROTO; do
         if ! is_yes_no_value "${!var}"; then
             print_validation_error "The allowed values for $var are: yes or no"
         fi
@@ -169,6 +172,12 @@ ldap_validate() {
     if [[ -n "$LDAP_PORT_NUMBER" ]] && [[ -n "$LDAP_LDAPS_PORT_NUMBER" ]]; then
         if [[ "$LDAP_PORT_NUMBER" -eq "$LDAP_LDAPS_PORT_NUMBER" ]]; then
             print_validation_error "LDAP_PORT_NUMBER and LDAP_LDAPS_PORT_NUMBER are bound to the same port!"
+        fi
+    fi
+
+    if [[ -n "$LDAP_PROXYPROTO_PORT_NUMBER" ]] && [[ -n "$LDAP_PROXYPROTO_LDAPS_PORT_NUMBER" ]]; then
+        if [[ "$LDAP_PROXYPROTO_PORT_NUMBER" -eq "$LDAP_PROXYPROTO_LDAPS_PORT_NUMBER" ]]; then
+            print_validation_error "LDAP_PROXYPROTO_PORT_NUMBER and LDAP_PROXYPROTO_LDAPS_PORT_NUMBER are bound to the same port!"
         fi
     fi
 

--- a/bitnami/openldap/2.5/debian-12/rootfs/opt/bitnami/scripts/libopenldap.sh
+++ b/bitnami/openldap/2.5/debian-12/rootfs/opt/bitnami/scripts/libopenldap.sh
@@ -169,6 +169,12 @@ ldap_validate() {
         print_validation_error "Specify the same number of passwords on LDAP_PASSWORDS as the number of users on LDAP_USERS!"
     fi
 
+    for var in LDAP_PORT_NUMBER LDAP_LDAPS_PORT_NUMBER LDAP_PROXYPROTO_PORT_NUMBER LDAP_PROXYPROTO_LDAPS_PORT_NUMBER; do
+        if ! is_positive_int "${!var}"; then
+            print_validation_error "The value for $var must be positive integer!"
+        fi
+    done
+
     if [[ -n "$LDAP_PORT_NUMBER" ]] && [[ -n "$LDAP_LDAPS_PORT_NUMBER" ]]; then
         if [[ "$LDAP_PORT_NUMBER" -eq "$LDAP_LDAPS_PORT_NUMBER" ]]; then
             print_validation_error "LDAP_PORT_NUMBER and LDAP_LDAPS_PORT_NUMBER are bound to the same port!"

--- a/bitnami/openldap/2.5/debian-12/rootfs/opt/bitnami/scripts/openldap/run.sh
+++ b/bitnami/openldap/2.5/debian-12/rootfs/opt/bitnami/scripts/openldap/run.sh
@@ -76,4 +76,5 @@ done
 flags+=("$@")
 
 info "** Starting slapd **"
+debug "Startup cmd: ${command}" "${flags[*]}"
 exec "${command}" "${flags[@]}"

--- a/bitnami/openldap/2.6/debian-12/rootfs/opt/bitnami/scripts/libopenldap.sh
+++ b/bitnami/openldap/2.6/debian-12/rootfs/opt/bitnami/scripts/libopenldap.sh
@@ -52,6 +52,9 @@ export LDAP_DAEMON_GROUP="slapd"
 # Settings
 export LDAP_PORT_NUMBER="${LDAP_PORT_NUMBER:-1389}"
 export LDAP_LDAPS_PORT_NUMBER="${LDAP_LDAPS_PORT_NUMBER:-1636}"
+export LDAP_ENABLE_PROXYPROTO="${LDAP_ENABLE_PROXYPROTO:-no}"
+export LDAP_PROXYPROTO_PORT_NUMBER="${LDAP_PROXYPROTO_PORT_NUMBER:-"${LDAP_PORT_NUMBER}"}"
+export LDAP_PROXYPROTO_LDAPS_PORT_NUMBER="${LDAP_PROXYPROTO_LDAPS_PORT_NUMBER:-"${LDAP_LDAPS_PORT_NUMBER}"}"
 export LDAP_ROOT="${LDAP_ROOT:-dc=example,dc=org}"
 export LDAP_SUFFIX="$(if [ -z "${LDAP_SUFFIX+x}" ]; then echo "${LDAP_ROOT}"; else echo "${LDAP_SUFFIX}"; fi)"
 export LDAP_ADMIN_USERNAME="${LDAP_ADMIN_USERNAME:-admin}"
@@ -136,7 +139,7 @@ ldap_validate() {
         error "$1"
         error_code=1
     }
-    for var in LDAP_SKIP_DEFAULT_TREE LDAP_ENABLE_TLS; do
+    for var in LDAP_SKIP_DEFAULT_TREE LDAP_ENABLE_TLS LDAP_ENABLE_PROXYPROTO; do
         if ! is_yes_no_value "${!var}"; then
             print_validation_error "The allowed values for $var are: yes or no"
         fi
@@ -169,6 +172,12 @@ ldap_validate() {
     if [[ -n "$LDAP_PORT_NUMBER" ]] && [[ -n "$LDAP_LDAPS_PORT_NUMBER" ]]; then
         if [[ "$LDAP_PORT_NUMBER" -eq "$LDAP_LDAPS_PORT_NUMBER" ]]; then
             print_validation_error "LDAP_PORT_NUMBER and LDAP_LDAPS_PORT_NUMBER are bound to the same port!"
+        fi
+    fi
+
+    if [[ -n "$LDAP_PROXYPROTO_PORT_NUMBER" ]] && [[ -n "$LDAP_PROXYPROTO_LDAPS_PORT_NUMBER" ]]; then
+        if [[ "$LDAP_PROXYPROTO_PORT_NUMBER" -eq "$LDAP_PROXYPROTO_LDAPS_PORT_NUMBER" ]]; then
+            print_validation_error "LDAP_PROXYPROTO_PORT_NUMBER and LDAP_PROXYPROTO_LDAPS_PORT_NUMBER are bound to the same port!"
         fi
     fi
 

--- a/bitnami/openldap/2.6/debian-12/rootfs/opt/bitnami/scripts/libopenldap.sh
+++ b/bitnami/openldap/2.6/debian-12/rootfs/opt/bitnami/scripts/libopenldap.sh
@@ -169,6 +169,12 @@ ldap_validate() {
         print_validation_error "Specify the same number of passwords on LDAP_PASSWORDS as the number of users on LDAP_USERS!"
     fi
 
+    for var in LDAP_PORT_NUMBER LDAP_LDAPS_PORT_NUMBER LDAP_PROXYPROTO_PORT_NUMBER LDAP_PROXYPROTO_LDAPS_PORT_NUMBER; do
+        if ! is_positive_int "${!var}"; then
+            print_validation_error "The value for $var must be positive integer!"
+        fi
+    done
+
     if [[ -n "$LDAP_PORT_NUMBER" ]] && [[ -n "$LDAP_LDAPS_PORT_NUMBER" ]]; then
         if [[ "$LDAP_PORT_NUMBER" -eq "$LDAP_LDAPS_PORT_NUMBER" ]]; then
             print_validation_error "LDAP_PORT_NUMBER and LDAP_LDAPS_PORT_NUMBER are bound to the same port!"

--- a/bitnami/openldap/2.6/debian-12/rootfs/opt/bitnami/scripts/openldap/run.sh
+++ b/bitnami/openldap/2.6/debian-12/rootfs/opt/bitnami/scripts/openldap/run.sh
@@ -76,4 +76,5 @@ done
 flags+=("$@")
 
 info "** Starting slapd **"
+debug "Startup cmd: ${command}" "${flags[*]}"
 exec "${command}" "${flags[@]}"

--- a/bitnami/openldap/README.md
+++ b/bitnami/openldap/README.md
@@ -274,6 +274,20 @@ This new feature is not mutually exclusive, which means it is possible to listen
       ...
     ```
 
+### Run behind load balancer
+
+OpenLDAP supports the HAProxy proxy protocol version 2 to detect real client IP that is masked when server runs behind load balancer. You can enable and configure this feature with the following environment variables:
+
+* `LDAP_ENABLE_PROXYPROTO`: Whether to enable proxy protocol support for traffic or not. Defaults to `no`.
+* `LDAP_PROXYPROTO_PORT_NUMBER`: The port OpenLDAP is listening for requests that is wrapped in proxy protocol. Default: the **LDAP_PORT_NUMBER** value.
+* `LDAP_PROXYPROTO_LDAPS_PORT_NUMBER`: Port used for TLS secure traffic that is wrapped in proxy protocol. Default: the **LDAP_LDAPS_PORT_NUMBER** value.
+
+Enabling this feature will replace regular and TLS ports with proxy protocol capable analogs. To use both port types, set **LDAP_PROXYPROTO_PORT_NUMBER** to some different value than **LDAP_PORT_NUMBER**. The same statement applied to **LDAP_PROXYPROTO_LDAPS_PORT_NUMBER** and **LDAP_LDAPS_PORT_NUMBER** pair.
+
+**Security warning**: To prevent client IP spoofing, it is highly advised to secure the proxy protocol capable ports by firewall that allow traffic only from load balancer hosts.
+
+Check the official page [OpenLDAP, Running slapd, Command-Line Options](https://www.openldap.org/doc/admin26/runningslapd.html#Command-Line%20Options) for additional information.
+
 ### Initializing a new instance
 
 The [Bitnami OpenLDAP](https://github.com/bitnami/containers/blob/main/bitnami/openldap) image allows you to use your custom scripts to initialize a fresh instance.


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change
Ability to enable pldap(s) protocols.

### Benefits
The pldap(s) is required when LDAP servers is run behind LB proxy. The proxy protocol v2 allow reveal the real client IP on LDAP server side in such setup.

### Possible drawbacks

Previous deployments not affected, this feature is disabled by default.
In new deployments that want use pldap(s) and replication, user must provide additional config to move proxy protocol enabled ports to non-default values, since replication can't run on pldap(s).

### Applicable issues

None.

### Additional information

The /opt/bitnami/scripts/openldap/run.sh are refactored to allow independent configuration and advanced logic for each startup flag. This changes are BASH specific and require additional patch if container moves to other shell.
Additional check for LDAP_PORT_NUMBER and LDAP_LDAPS_PORT_NUMBER is set, which should not affect valid deployments.
