### PR TITLE
[bitnami/schema-registry] keystore is not mandatory for SASL_SSL protocol

### DIFF
--- a/bitnami/schema-registry/7.6/debian-12/rootfs/opt/bitnami/scripts/libschemaregistry.sh
+++ b/bitnami/schema-registry/7.6/debian-12/rootfs/opt/bitnami/scripts/libschemaregistry.sh
@@ -144,7 +144,8 @@ schema_registry_validate() {
 
     if [[ -n "$SCHEMA_REGISTRY_KAFKA_BROKERS" ]]; then
         if brokers_auth_protocol="$(schema_registry_brokers_auth_protocol)"; then
-            if [[ "$brokers_auth_protocol" =~ SSL ]]; then
+            # Keystore is not mandatory for SASL_SSL
+            if [[ "$brokers_auth_protocol" =~ SSL ]] && [[ ! "$brokers_auth_protocol" =~ SASL_SSL ]]  && [[ -v "$SCHEMA_REGISTRY_CERTS_DIR" ]]; then
                 if [[ ! -f ${SCHEMA_REGISTRY_CERTS_DIR}/schema-registry.keystore.jks ]] || [[ ! -f ${SCHEMA_REGISTRY_CERTS_DIR}/schema-registry.truststore.jks ]]; then
                     print_validation_error "In order to configure the TLS encryption for communication with Kafka brokers, you must mount your schema-registry.keystore.jks and schema-registry.truststore.jks certificates to the ${SCHEMA_REGISTRY_CERTS_DIR} directory."
                 fi
@@ -302,7 +303,7 @@ schema_registry_initialize() {
             schema_registry_conf_set "kafkastore.sasl.jaas.config" "$aux_string"
         fi
 
-        if [[ "$brokers_auth_protocol" =~ SSL ]]; then
+        if [[ "$brokers_auth_protocol" =~ SSL ]] && [[ -v "$SCHEMA_REGISTRY_CERTS_DIR" ]]; then
             schema_registry_conf_set "kafkastore.ssl.keystore.location" "${SCHEMA_REGISTRY_CERTS_DIR}/schema-registry.keystore.jks"
             [[ -n "$SCHEMA_REGISTRY_KAFKA_KEYSTORE_PASSWORD" ]] && schema_registry_conf_set "kafkastore.ssl.keystore.password" "$SCHEMA_REGISTRY_KAFKA_KEYSTORE_PASSWORD"
             schema_registry_conf_set "kafkastore.ssl.truststore.location" "${SCHEMA_REGISTRY_CERTS_DIR}/schema-registry.truststore.jks"


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

There are multiple protocols for security to connect Schema Registry to Kafka. `SASL_SSL` is one of them. Before this change, a keystore is mandatory to use `SASL_SSL` protocol. This change fixes that requirement. So, keystore won't be a requirement for `SASL_SSL` anymore

### Possible drawbacks


### Applicable issues

- fixes #70483

### Additional information

This code has been tested using AWS MSK with `SASL_SSL` protocol, with the following configuration
```
        - name: SCHEMA_REGISTRY_KAFKA_BROKERS
          value: SASL_SSL://b-1:9096,SASL_SSL://b-2:9096,SASL_SSL://b-3:9096
        - name: SCHEMA_REGISTRY_KAFKA_SASL_MECHANISM
          value: SCRAM-SHA-512
        - name: SCHEMA_REGISTRY_KAFKA_SASL_USERS
          value: confluent-registry
        - name: SCHEMA_REGISTRY_KAFKA_SASL_PASSWORDS
          value: password
        - name: SCHEMA_REGISTRY_LISTENERS
          value: http://0.0.0.0:8081
        - name: SCHEMA_REGISTRY_AVRO_COMPATIBILY_LEVEL
          value: NONE
        - name: SCHEMA_REGISTRY_HEAP_OPTS
          value: -XX:InitialRAMPercentage=80.0 -XX:MaxRAMPercentage=80.0
        - name: SCHEMA_REGISTRY_JVM_PERFORMANCE_OPTS
          value: -XX:MetaspaceSize=96m -XX:+UseG1GC -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35
            -XX:G1HeapRegionSize=16M -XX:MinMetaspaceFreeRatio=50 -XX:MaxMetaspaceFreeRatio=80
        - name: SCHEMA_REGISTRY_JMX_OPTS
          value: -javaagent:/opt/jmx_prometheus_javaagent.jar=5556:/etc/jmx-schema-registry/jmx-schema-registry-prometheus.yml
            -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false
            -Dcom.sun.management.jmxremote.ssl=false
        image: XXXXX
```