### PR TITLE
[bitnami/mariadb-galera] Fix healthcheck if MARIADB_ROOT_USER != root

### DIFF
--- a/bitnami/mariadb-galera/10.11/debian-12/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
+++ b/bitnami/mariadb-galera/10.11/debian-12/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
@@ -2134,14 +2134,14 @@ find_jemalloc_lib() {
 ########################
 # Execute a reliable health check against the current mysql instance
 # Globals:
-#   DB_ROOT_PASSWORD, DB_MASTER_ROOT_PASSWORD
+#   DB_ROOT_USER, DB_ROOT_PASSWORD, DB_MASTER_ROOT_PASSWORD
 # Arguments:
 #   None
 # Returns:
 #   mysqladmin output
 #########################
 mysql_healthcheck() {
-    local args=("-uroot" "-h0.0.0.0")
+    local args=("-u${DB_ROOT_USER}" "-h0.0.0.0")
     local root_password
 
     root_password="$(get_master_env_var_value ROOT_PASSWORD)"

--- a/bitnami/mariadb-galera/10.4/debian-12/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
+++ b/bitnami/mariadb-galera/10.4/debian-12/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
@@ -2134,14 +2134,14 @@ find_jemalloc_lib() {
 ########################
 # Execute a reliable health check against the current mysql instance
 # Globals:
-#   DB_ROOT_PASSWORD, DB_MASTER_ROOT_PASSWORD
+#   DB_ROOT_USER, DB_ROOT_PASSWORD, DB_MASTER_ROOT_PASSWORD
 # Arguments:
 #   None
 # Returns:
 #   mysqladmin output
 #########################
 mysql_healthcheck() {
-    local args=("-uroot" "-h0.0.0.0")
+    local args=("-u${DB_ROOT_USER}" "-h0.0.0.0")
     local root_password
 
     root_password="$(get_master_env_var_value ROOT_PASSWORD)"

--- a/bitnami/mariadb-galera/10.5/debian-12/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
+++ b/bitnami/mariadb-galera/10.5/debian-12/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
@@ -2134,14 +2134,14 @@ find_jemalloc_lib() {
 ########################
 # Execute a reliable health check against the current mysql instance
 # Globals:
-#   DB_ROOT_PASSWORD, DB_MASTER_ROOT_PASSWORD
+#   DB_ROOT_USER, DB_ROOT_PASSWORD, DB_MASTER_ROOT_PASSWORD
 # Arguments:
 #   None
 # Returns:
 #   mysqladmin output
 #########################
 mysql_healthcheck() {
-    local args=("-uroot" "-h0.0.0.0")
+    local args=("-u${DB_ROOT_USER}" "-h0.0.0.0")
     local root_password
 
     root_password="$(get_master_env_var_value ROOT_PASSWORD)"

--- a/bitnami/mariadb-galera/10.6/debian-12/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
+++ b/bitnami/mariadb-galera/10.6/debian-12/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
@@ -2134,14 +2134,14 @@ find_jemalloc_lib() {
 ########################
 # Execute a reliable health check against the current mysql instance
 # Globals:
-#   DB_ROOT_PASSWORD, DB_MASTER_ROOT_PASSWORD
+#   DB_ROOT_USER, DB_ROOT_PASSWORD, DB_MASTER_ROOT_PASSWORD
 # Arguments:
 #   None
 # Returns:
 #   mysqladmin output
 #########################
 mysql_healthcheck() {
-    local args=("-uroot" "-h0.0.0.0")
+    local args=("-u${DB_ROOT_USER}" "-h0.0.0.0")
     local root_password
 
     root_password="$(get_master_env_var_value ROOT_PASSWORD)"

--- a/bitnami/mariadb-galera/11.1/debian-12/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
+++ b/bitnami/mariadb-galera/11.1/debian-12/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
@@ -2134,14 +2134,14 @@ find_jemalloc_lib() {
 ########################
 # Execute a reliable health check against the current mysql instance
 # Globals:
-#   DB_ROOT_PASSWORD, DB_MASTER_ROOT_PASSWORD
+#   DB_ROOT_USER, DB_ROOT_PASSWORD, DB_MASTER_ROOT_PASSWORD
 # Arguments:
 #   None
 # Returns:
 #   mysqladmin output
 #########################
 mysql_healthcheck() {
-    local args=("-uroot" "-h0.0.0.0")
+    local args=("-u${DB_ROOT_USER}" "-h0.0.0.0")
     local root_password
 
     root_password="$(get_master_env_var_value ROOT_PASSWORD)"

--- a/bitnami/mariadb-galera/11.2/debian-12/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
+++ b/bitnami/mariadb-galera/11.2/debian-12/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
@@ -2134,14 +2134,14 @@ find_jemalloc_lib() {
 ########################
 # Execute a reliable health check against the current mysql instance
 # Globals:
-#   DB_ROOT_PASSWORD, DB_MASTER_ROOT_PASSWORD
+#   DB_ROOT_USER, DB_ROOT_PASSWORD, DB_MASTER_ROOT_PASSWORD
 # Arguments:
 #   None
 # Returns:
 #   mysqladmin output
 #########################
 mysql_healthcheck() {
-    local args=("-uroot" "-h0.0.0.0")
+    local args=("-u${DB_ROOT_USER}" "-h0.0.0.0")
     local root_password
 
     root_password="$(get_master_env_var_value ROOT_PASSWORD)"

--- a/bitnami/mariadb-galera/11.4/debian-12/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
+++ b/bitnami/mariadb-galera/11.4/debian-12/rootfs/opt/bitnami/scripts/libmariadbgalera.sh
@@ -2134,14 +2134,14 @@ find_jemalloc_lib() {
 ########################
 # Execute a reliable health check against the current mysql instance
 # Globals:
-#   DB_ROOT_PASSWORD, DB_MASTER_ROOT_PASSWORD
+#   DB_ROOT_USER, DB_ROOT_PASSWORD, DB_MASTER_ROOT_PASSWORD
 # Arguments:
 #   None
 # Returns:
 #   mysqladmin output
 #########################
 mysql_healthcheck() {
-    local args=("-uroot" "-h0.0.0.0")
+    local args=("-u${DB_ROOT_USER}" "-h0.0.0.0")
     local root_password
 
     root_password="$(get_master_env_var_value ROOT_PASSWORD)"


### PR DESCRIPTION
### Description of the change

The `mysql_healthcheck` function now honors the value of  `MARIADB_ROOT_USER`.

### Benefits

The healthcheck works if `MARIADB_ROOT_USER` is specified and not equal to `root`.

---

I'll PR the same changes for `mariadb` if this is approved.
