### PR TITLE
Check for CeleryExecutor presence instead of exact match

### DIFF
--- a/bitnami/airflow-worker/2/debian-12/rootfs/opt/bitnami/scripts/libairflow.sh
+++ b/bitnami/airflow-worker/2/debian-12/rootfs/opt/bitnami/scripts/libairflow.sh
@@ -214,7 +214,7 @@ airflow_generate_config() {
 
     # Configure Airflow executor
     airflow_conf_set "core" "executor" "$AIRFLOW_EXECUTOR"
-    [[ "$AIRFLOW_EXECUTOR" == "CeleryExecutor" || "$AIRFLOW_EXECUTOR" == "CeleryKubernetesExecutor" ]] && airflow_configure_celery_executor
+    [[ "$AIRFLOW_EXECUTOR" =~ "CeleryExecutor" || "$AIRFLOW_EXECUTOR" == "CeleryKubernetesExecutor" ]] && airflow_configure_celery_executor
     true # Avoid the function to fail due to the check above
 }
 

--- a/bitnami/airflow-worker/2/debian-12/rootfs/opt/bitnami/scripts/libairflowworker.sh
+++ b/bitnami/airflow-worker/2/debian-12/rootfs/opt/bitnami/scripts/libairflowworker.sh
@@ -16,7 +16,7 @@
 . /opt/bitnami/scripts/libpersistence.sh
 
 # Load airflow library
-. /opt/bitnami/scripts/libairflow.sh
+. /opt/bitnami/scripts/libairfCeleryExecutorow.sh
 
 ########################
 # Validate Airflow Scheduler inputs
@@ -90,7 +90,7 @@ airflow_worker_initialize() {
     # Wait for airflow webserver to be available
     info "Waiting for Airflow Webserver to be up"
     airflow_worker_wait_for_webserver "$AIRFLOW_WEBSERVER_HOST" "$AIRFLOW_WEBSERVER_PORT_NUMBER"
-    if [[ "$AIRFLOW_EXECUTOR" == "CeleryExecutor" || "$AIRFLOW_EXECUTOR" == "CeleryKubernetesExecutor"  ]]; then
+    if [[ "$AIRFLOW_EXECUTOR" =~ "CeleryExecutor" || "$AIRFLOW_EXECUTOR" == "CeleryKubernetesExecutor"  ]]; then
         wait-for-port --host "$REDIS_HOST" "$REDIS_PORT_NUMBER"
     fi
 
@@ -128,7 +128,7 @@ airflow_worker_generate_config() {
 
     # Configure Airflow executor
     airflow_conf_set "core" "executor" "$AIRFLOW_EXECUTOR"
-    [[ "$AIRFLOW_EXECUTOR" == "CeleryExecutor" || "$AIRFLOW_EXECUTOR" == "CeleryKubernetesExecutor"  ]] && airflow_configure_celery_executor
+    [[ "$AIRFLOW_EXECUTOR" =~ "CeleryExecutor" || "$AIRFLOW_EXECUTOR" == "CeleryKubernetesExecutor"  ]] && airflow_configure_celery_executor
     true # Avoid the function to fail due to the check above
 }
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Allow use of multiple executors as available since [Airflow 2.10.0](https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/executor/index.html#using-multiple-executors-concurrently)

See related [Helm Chart PR](https://github.com/bitnami/charts/pull/29107)

### Benefits

Currently, using `CeleryKubernetesExecutor` with 2.10.0 is [broken](https://github.com/apache/airflow/issues/41525). 

The current Bitnami chart for 2.10.0 will not spawn a celery worker when using the new multiple executor syntax.

Making effectively impossible to deploy a hybrid Celery/k8s environment with 2.10.0.

As specified in the issue, hybrid executors are also soon to be deprecated in favor of multiple executors.

### Possible drawbacks

The condition change preserves backwards compatibility so I don't see any.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- Related [Helm Chart PR](https://github.com/bitnami/charts/pull/29107)

### Additional information

References

- https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/executor/index.html#using-multiple-executors-concurrently
- https://github.com/apache/airflow/issues/41525
- https://github.com/apache/airflow/milestone/100
- https://github.com/bitnami/charts/pull/29107
