### PR TITLE
[bitnami/etcd] fix libetcd.sh handling for host and port

### DIFF
--- a/bitnami/etcd/3.5/debian-12/rootfs/opt/bitnami/scripts/libetcd.sh
+++ b/bitnami/etcd/3.5/debian-12/rootfs/opt/bitnami/scripts/libetcd.sh
@@ -447,7 +447,7 @@ setup_etcd_active_endpoints() {
         ETCD_ACTIVE_ENDPOINTS=$(echo "${active_endpoints_array[*]}" | tr ' ' ',')
         export ETCD_ACTIVE_ENDPOINTS
     fi
-    echo "${active_endpoints} ${cluster_size} ${ETCD_ACTIVE_ENDPOINTS}"
+    echo "${active_endpoints} ${cluster_size} ${ETCD_ACTIVE_ENDPOINTS} ${host} ${port}"
 }
 
 ########################
@@ -462,7 +462,8 @@ setup_etcd_active_endpoints() {
 is_healthy_etcd_cluster() {
     local return_value=0
     local active_endpoints cluster_size
-    read -r active_endpoints cluster_size ETCD_ACTIVE_ENDPOINTS <<<"$(setup_etcd_active_endpoints)"
+    local host port
+    read -r active_endpoints cluster_size ETCD_ACTIVE_ENDPOINTS host port <<<"$(setup_etcd_active_endpoints)"
     export ETCD_ACTIVE_ENDPOINTS
 
     if is_boolean_yes "$ETCD_DISASTER_RECOVERY"; then


### PR DESCRIPTION
Today, the host and port (after a refactor for chart versions 9.2.2 and later) are not being properly passed from `setup_etcd_active_endpoints` to `is_healthy_etcd_cluster`. As a result, the startup will fail complaining about `host` being unset for the line `remove_in_file "/snapshots/.disaster_recovery" "$host:$port"`.

This PR fixes the startup behavior by passing `host` and `port` via the read that already exists.