### PR TITLE
[bitnami/zipkin] chore: :construction_worker: :white_check_mark: Add VIB tests

### DIFF
--- a/.vib/zipkin/goss/goss.yaml
+++ b/.vib/zipkin/goss/goss.yaml
@@ -1,0 +1,14 @@
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+gossfile:
+  # Load scripts from .vib/common/goss/templates
+  ../../zipkin/goss/zipkin.yaml: {}
+  ../../common/goss/templates/check-app-version.yaml: {}
+  ../../common/goss/templates/check-binaries.yaml: {}
+  ../../common/goss/templates/check-broken-symlinks.yaml: {}
+  ../../common/goss/templates/check-ca-certs.yaml: {}
+  ../../common/goss/templates/check-directories.yaml: {}
+  ../../common/goss/templates/check-linked-libraries.yaml: {}
+  ../../common/goss/templates/check-sed-in-place.yaml: {}
+  ../../common/goss/templates/check-spdx.yaml: {}

--- a/.vib/zipkin/goss/vars.yaml
+++ b/.vib/zipkin/goss/vars.yaml
@@ -1,0 +1,11 @@
+binaries:
+  - java
+  - start-zipkin
+directories:
+  - paths:
+      - /opt/bitnami/zipkin
+root_dir: /opt/bitnami
+# The application does not have a --version flag, but the server logs do show the version
+version:
+  bin_name: timeout
+  flag: --preserve-status 7 bash -c "cd /opt/bitnami/zipkin; start-zipkin" || true

--- a/.vib/zipkin/goss/zipkin.yaml
+++ b/.vib/zipkin/goss/zipkin.yaml
@@ -1,0 +1,16 @@
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+user:
+  zipkin:
+    exists: true
+    uid: 1001
+    gid: 0
+command:
+  run-zipkin:
+    # We need a different port to not collide with the version check
+    exec: export QUERY_PORT=9044; cd /opt/bitnami/zipkin; timeout --preserve-status 12 start-zipkin 2>&1 || true
+    timeout: 15000
+    exit-status: 0
+    stdout:
+      - /Serving HTTP at.*9044/

--- a/.vib/zipkin/vib-verify.json
+++ b/.vib/zipkin/vib-verify.json
@@ -1,0 +1,73 @@
+{
+  "context": {
+    "resources": {
+      "url": "{SHA_ARCHIVE}",
+      "path": "{VIB_ENV_PATH}"
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyJ0YWlsIiwgIi1mIiwgIi9kZXYvbnVsbCJd"
+  },
+  "phases": {
+    "package": {
+      "actions": [
+        {
+          "action_id": "container-image-package",
+          "params": {
+            "application": {
+              "details": {
+                "name": "{VIB_ENV_CONTAINER}",
+                "tag": "{VIB_ENV_TAG}"
+              }
+            },
+            "architectures": [
+              "linux/amd64",
+              "linux/arm64"
+            ]
+          }
+        },
+        {
+          "action_id": "container-image-lint",
+          "params": {
+            "threshold": "error"
+          }
+        }
+      ]
+    },
+    "verify": {
+      "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "dremio/goss/goss.yaml",
+            "vars_file": "dremio/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-dremio"
+              }
+            }
+          }
+        },
+        {
+          "action_id": "trivy",
+          "params": {
+            "threshold": "LOW",
+            "vuln_type": [
+              "OS"
+            ]
+          }
+        },
+        {
+          "action_id": "grype",
+          "params": {
+            "threshold": "CRITICAL",
+            "package_type": [
+              "OS"
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/.vib/zipkin/vib-verify.json
+++ b/.vib/zipkin/vib-verify.json
@@ -40,11 +40,11 @@
             "resources": {
               "path": "/.vib"
             },
-            "tests_file": "dremio/goss/goss.yaml",
-            "vars_file": "dremio/goss/vars.yaml",
+            "tests_file": "zipkin/goss/goss.yaml",
+            "vars_file": "zipkin/goss/vars.yaml",
             "remote": {
               "pod": {
-                "workload": "deploy-dremio"
+                "workload": "deploy-zipkin"
               }
             }
           }


### PR DESCRIPTION
### Description of the change

This PR introduces VIB integration for the new bitnami/zipkin container. It adds goss tests for the container, ensuring the container performs as expected.


### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/zipkin] Add goss tests for VIB integration
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)