### PR TITLE
[binami/etcd] If container is run as root, only chown etcd.yaml config file if it exists.

### DIFF
--- a/bitnami/etcd/3.4/debian-12/rootfs/opt/bitnami/scripts/libetcd.sh
+++ b/bitnami/etcd/3.4/debian-12/rootfs/opt/bitnami/scripts/libetcd.sh
@@ -100,7 +100,7 @@ etcd_setup_from_environment_variables() {
             fi
         fi
     done
-    if am_i_root; then
+    if am_i_root && [[ -f "$ETCD_CONF_FILE" ]] ; then
         chown "$ETCD_DAEMON_USER" "$ETCD_CONF_FILE"
     fi
 }

--- a/bitnami/etcd/3.5/debian-12/rootfs/opt/bitnami/scripts/libetcd.sh
+++ b/bitnami/etcd/3.5/debian-12/rootfs/opt/bitnami/scripts/libetcd.sh
@@ -100,7 +100,7 @@ etcd_setup_from_environment_variables() {
             fi
         fi
     done
-    if am_i_root; then
+    if am_i_root && [[ -f "$ETCD_CONF_FILE" ]] ; then
         chown "$ETCD_DAEMON_USER" "$ETCD_CONF_FILE"
     fi
 }


### PR DESCRIPTION
### Description of the change

This change allows the etcd container to be run as root.

### Benefits

The container will not fail if run as root.

### Possible drawbacks

None known.

### Applicable issues

- fixes #71945

### Additional information
None

