### PR TITLE
[redis-sentinel] Add support for ipv6

### DIFF
--- a/bitnami/redis-sentinel/6.2/debian-12/rootfs/opt/bitnami/scripts/redis-sentinel/postunpack.sh
+++ b/bitnami/redis-sentinel/6.2/debian-12/rootfs/opt/bitnami/scripts/redis-sentinel/postunpack.sh
@@ -25,7 +25,7 @@ done
 
 # Redis Sentinel defaults
 redis_conf_set "port" "$REDIS_SENTINEL_DEFAULT_PORT_NUMBER"
-redis_conf_set "bind" "0.0.0.0"
+redis_conf_set "bind" "0.0.0.0 ::"
 redis_conf_set "pidfile" "$REDIS_SENTINEL_PID_FILE"
 # Send logs to stdout
 redis_conf_set "daemonize" "no"

--- a/bitnami/redis-sentinel/7.4/debian-12/rootfs/opt/bitnami/scripts/redis-sentinel/postunpack.sh
+++ b/bitnami/redis-sentinel/7.4/debian-12/rootfs/opt/bitnami/scripts/redis-sentinel/postunpack.sh
@@ -25,7 +25,7 @@ done
 
 # Redis Sentinel defaults
 redis_conf_set "port" "$REDIS_SENTINEL_DEFAULT_PORT_NUMBER"
-redis_conf_set "bind" "0.0.0.0"
+redis_conf_set "bind" "0.0.0.0 ::"
 redis_conf_set "pidfile" "$REDIS_SENTINEL_PID_FILE"
 # Send logs to stdout
 redis_conf_set "daemonize" "no"


### PR DESCRIPTION
### Description of the change

Small change to add support for ipv6 in `redis-sentinel` by updating the `bind` configuration to `0.0.0.0 ::`

### Benefits

Enables support for both ipv4 and ipv6

### Possible drawbacks

None that I can imagine

### Applicable issues

n/A

### Additional information

Tested and confirmed on a Redis replica set running in Railway
