### PR TITLE
[bitnami/deepspeed] Increase goss command timeout

### DIFF
--- a/.vib/deepspeed/goss/deepspeed.yaml
+++ b/.vib/deepspeed/goss/deepspeed.yaml
@@ -9,5 +9,5 @@ user:
 command:
   check-necessary-libraries:
     exec: python -c 'import deepspeed; print(deepspeed.__version__); import torch; print(torch.__version__); import torchvision; print(torchvision.__version__)'
-    timeout: 8000
+    timeout: 20000
     exit-status: 0


### PR DESCRIPTION
### Description of the change

This PR simply increases the timeout of a goss command test to improve the reliability of the test battery.
