### PR TITLE
[bitnami][clickhouse] Fix ClickHouse bug on custom init/start script

### DIFF
--- a/bitnami/clickhouse/24/debian-12/rootfs/opt/bitnami/scripts/libclickhouse.sh
+++ b/bitnami/clickhouse/24/debian-12/rootfs/opt/bitnami/scripts/libclickhouse.sh
@@ -80,16 +80,16 @@ clickhouse_copy_mounted_configuration() {
             info "Copying mounted configuration from $CLICKHOUSE_MOUNTED_CONF_DIR"
             # Copy first the files at the base of the mounted folder to go to ClickHouse
             # base etc folder
-            find "$CLICKHOUSE_MOUNTED_CONF_DIR" -maxdepth 1 \( -type f -o -type l \) -exec cp -L {} "$CLICKHOUSE_CONF_DIR" \;
+            find "$CLICKHOUSE_MOUNTED_CONF_DIR" -maxdepth 1 \( -type f -o -type l \) -exec cp -L -r {} "$CLICKHOUSE_CONF_DIR" \;
 
             # The ClickHouse override directories (etc/conf.d and etc/users.d) do not support subfolders. That means we cannot
             # copy directly with cp -RL because we need all override xml files to have at the root of these subfolders. In the helm
             # chart we want to allow overrides from different ConfigMaps and Secrets so we need to use the find command
             if [[ -d "${CLICKHOUSE_MOUNTED_CONF_DIR}/conf.d" ]]; then
-                find "${CLICKHOUSE_MOUNTED_CONF_DIR}/conf.d" \( -type f -o -type l \) -exec cp -L {} "${CLICKHOUSE_CONF_DIR}/conf.d" \;
+                find "${CLICKHOUSE_MOUNTED_CONF_DIR}/conf.d" \( -type f -o -type l \) -exec cp -L -r {} "${CLICKHOUSE_CONF_DIR}/conf.d" \;
             fi
             if [[ -d "${CLICKHOUSE_MOUNTED_CONF_DIR}/users.d" ]]; then
-                find "${CLICKHOUSE_MOUNTED_CONF_DIR}/users.d" \( -type f -o -type l \) -exec cp -L {} "${CLICKHOUSE_CONF_DIR}/users.d" \;
+                find "${CLICKHOUSE_MOUNTED_CONF_DIR}/users.d" \( -type f -o -type l \) -exec cp -L -r {} "${CLICKHOUSE_CONF_DIR}/users.d" \;
             fi
         fi
     else
@@ -233,7 +233,7 @@ clickhouse_start_bg() {
     is_clickhouse_running && return
     # This function is meant to be called for internal operations like the init scripts
     local -r cmd=("${CLICKHOUSE_BASE_DIR}/bin/clickhouse-server")
-    local -r args=("--config-file=${CLICKHOUSE_CONF_FILE}" "--pid-file=${CLICKHOUSE_PID_FILE}" "--" "--listen_host=127.0.0.1")
+    local -r args=("--config-file=${CLICKHOUSE_CONF_FILE}" "--pid-file=${CLICKHOUSE_PID_FILE}" "--" "--listen_host=0.0.0.0")
     if am_i_root; then
         run_as_user "$CLICKHOUSE_DAEMON_USER" "${cmd[@]}" "${args[@]}" >"$log_file" 2>&1 &
     else


### PR DESCRIPTION
## [bitnami][clickhouse] Correct ClickHouse behavior when user adds custom init/start script

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

In bitnami/clickhouse 24.8.4-debian-12-r0, when user tries to run custom init/start script (in my case - create a new Database). ClickHouse cannot execute that scripts and cause the container to crash.

```
clickhouse 04:03:51.42 INFO  ==> ** Starting ClickHouse setup **
clickhouse 04:03:51.45 INFO  ==> Copying mounted configuration from /bitnami/clickhouse/etc
cp: -r not specified; omitting directory '/bitnami/clickhouse/etc/conf.d/default/..data'
cp: -r not specified; omitting directory '/bitnami/clickhouse/etc/conf.d/extra-configmap/..data'
clickhouse 04:03:51.46 INFO  ==> Starting ClickHouse in background
clickhouse 04:03:56.47 INFO  ==> ClickHouse started successfully
clickhouse 04:03:56.47 INFO  ==> Loading user's custom files from /docker-entrypoint-initdb.d
clickhouse 04:03:56.47 WARN  ==> Sourcing /docker-entrypoint-initdb.d/platform_init_script.sh as it is not executable by the current user, any error may cause initialization to fail
Received exception from server (version 24.8.4):
Code: 999. DB::Exception: Received from localhost:9000. Coordination::Exception. Coordination::Exception: All connection tries failed while connecting to ZooKeeper. nodes: 10.10.2.133:2181, 10.10.2.45:2181, 10.10.1.159:2181
Poco::Exception. Code: 1000, e.code() = 111, Connection refused (version 24.8.4.13 (official build)), 10.10.2.133:2181
Poco::Exception. Code: 1000, e.code() = 111, Connection refused (version 24.8.4.13 (official build)), 10.10.2.45:2181
Poco::Exception. Code: 1000, e.code() = 111, Connection refused (version 24.8.4.13 (official build)), 10.10.1.159:2181
Poco::Exception. Code: 1000, e.code() = 111, Connection refused (version 24.8.4.13 (official build)), 10.10.2.133:2181
Poco::Exception. Code: 1000, e.code() = 111, Connection refused (version 24.8.4.13 (official build)), 10.10.2.45:2181
Poco::Exception. Code: 1000, e.code() = 111, Connection refused (version 24.8.4.13 (official build)), 10.10.1.159:2181
Poco::Exception. Code: 1000, e.code() = 111, Connection refused (version 24.8.4.13 (official build)), 10.10.2.133:2181
Poco::Exception. Code: 1000, e.code() = 111, Connection refused (version 24.8.4.13 (official build)), 10.10.2.45:2181
Poco::Exception. Code: 1000, e.code() = 111, Connection refused (version 24.8.4.13 (official build)), 10.10.1.159:2181
. (KEEPER_EXCEPTION)
(query: CREATE DATABASE IF NOT EXISTS test ON CLUSTER default;)
```

### Benefits

<!-- What benefits will be realized by the code change? -->

This code change will fix the bug on user's custom script run when ClickHouse cluster start.

This will help me a lots in my current works.


### Possible drawbacks

<!-- Describe any known limitations with your change -->

I don't think there is any issue about this because this bug had appeared for a long time.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- This change will fix my issue: [#29545](https://github.com/bitnami/charts/issues/29545)

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

I've test the code changes, which work as expected
```
clickhouse 02:17:37.92 INFO  ==> ** Starting ClickHouse setup **
clickhouse 02:17:37.95 INFO  ==> Copying mounted configuration from /bitnami/clickhouse/etc
clickhouse 02:17:37.97 INFO  ==> Starting ClickHouse in background
clickhouse 02:17:42.98 INFO  ==> ClickHouse started successfully
clickhouse 02:17:42.98 INFO  ==> Loading user's custom files from /docker-entrypoint-initdb.d
clickhouse 02:17:42.98 WARN  ==> Sourcing /docker-entrypoint-initdb.d/platform_init_script.sh as it is not executable by the current user, any error may cause initialization to fail
chi-shard0-0.chi-headless.chi.svc.cluster.local 9000    0               2       0
chi-shard0-2.chi-headless.chi.svc.cluster.local 9000    0               1       0
chi-shard0-1.chi-headless.chi.svc.cluster.local 9000    0               0       0

clickhouse 02:17:59.74 INFO  ==> ** ClickHouse setup finished! **
clickhouse 02:17:59.75 INFO  ==> ** Starting ClickHouse **
Processing configuration file '/opt/bitnami/clickhouse/etc/config.xml'.
Merging configuration file '/opt/bitnami/clickhouse/etc/conf.d/00_default_overrides.xml'.
Merging configuration file '/opt/bitnami/clickhouse/etc/conf.d/platform_extra_overrides.xml'.
```

