### PR TITLE
[bitnami/opensearch] S3 Repository plugin isn't included by default

### DIFF
--- a/bitnami/opensearch/README.md
+++ b/bitnami/opensearch/README.md
@@ -395,8 +395,6 @@ If you would rather extend than replace the default configuration with your sett
 
 ### Plugins
 
-The Bitnami OpenSearch Docker image comes with the [S3 Repository plugin](https://www.elastic.co/guide/en/opensearch/plugins/current/repository-s3.html) installed by default.
-
 You can add extra plugins by setting the `OPENSEARCH_PLUGINS` environment variable. To specify multiple plugins, separate them by spaces, commas or semicolons. When the container is initialized it will install all of the specified plugins before starting OpenSearch.
 
 ```console


### PR DESCRIPTION
### Description of the change

This PR updates OpenSearch's README removing inaccurate info about default included plugins. 

### Benefits

This plugin isn't included by default in the image, hence the README is confusing users.

### Possible drawbacks

None

### Applicable issues

Reported at https://github.com/bitnami/charts/issues/29498

### Additional information

N/A
