### PR TITLE
Fix REDIS_RDB_POLICY being appended repeatedly when the container is restarted

### DIFF
--- a/bitnami/redis/6.2/debian-12/rootfs/opt/bitnami/scripts/libredis.sh
+++ b/bitnami/redis/6.2/debian-12/rootfs/opt/bitnami/scripts/libredis.sh
@@ -419,6 +419,7 @@ redis_configure_default() {
                 redis_conf_set save ""
             fi
         else
+            redis_conf_set save ""
             for i in ${REDIS_RDB_POLICY}; do
                 redis_conf_set save "${i//#/ }"
             done

--- a/bitnami/redis/7.4/debian-12/rootfs/opt/bitnami/scripts/libredis.sh
+++ b/bitnami/redis/7.4/debian-12/rootfs/opt/bitnami/scripts/libredis.sh
@@ -419,6 +419,7 @@ redis_configure_default() {
                 redis_conf_set save ""
             fi
         else
+            redis_conf_set save ""
             for i in ${REDIS_RDB_POLICY}; do
                 redis_conf_set save "${i//#/ }"
             done


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

bitnami/redis/6.2/debian-12/rootfs/opt/bitnami/scripts/libredis.sh
bitnami/redis/7.4/debian-12/rootfs/opt/bitnami/scripts/libredis.sh
copy the script from line 419 to just before line 422.

### Benefits

Setting REDIS_RDB_POLICY does not cause the settings to increment cyclically due to restarting the redis container.

### Possible drawbacks

none

### Applicable issues

- fixes #72323 

### Additional information

none
