### PR TITLE
[bitnami/parse] Fix inability to connect to the database with own correct config.

### DIFF
--- a/bitnami/parse/7/debian-12/rootfs/opt/bitnami/scripts/libparse.sh
+++ b/bitnami/parse/7/debian-12/rootfs/opt/bitnami/scripts/libparse.sh
@@ -135,7 +135,7 @@ parse_initialize() {
         warn "Parse config.json detected in persistence. Persisting configuration files is deprecated"
         cp "$persisted_conf_file" "$PARSE_CONF_FILE"
         info "Trying to connect to the database server"
-        local -r connection_string="$(parse_conf_get "db_host")"
+        local -r connection_string="$(parse_conf_get "databaseURI")"
         parse_wait_for_mongodb_connection "$connection_string"
     fi
 
@@ -190,7 +190,7 @@ parse_conf_set() {
 parse_conf_get() {
     local -r key="${1:?key missing}"
     debug "Getting ${key} from Parse configuration"
-    jq ".${key}" "$PARSE_CONF_FILE"
+    jq -r ".${key}" "$PARSE_CONF_FILE"
 }
 
 ########################


### PR DESCRIPTION
I trying use my own configurations to learn the Parse Platform.

In general, if you use even a previously generated config as the default of your own config, it causes errors.

I'm assuming that the databaseUri was previously named as db_host in the config. After I fixing this, the configuration started getting the correct databaseUri, but with quotes, which caused the error mongoshInvalidInputError: [COMMON-10001] Invalid URI.

I fixed this in the parse_conf_get function.

I didn't test my solution, just rewrote it in my local docker-compose. I think you will find my fix useful in some cases.

### Description of the change

Fixed configuration initialization script.

### Benefits

You can use your own configuration by mounting it at the desired point. It will work and not crash as it does now.

### Possible drawbacks

Unknown to me. I don't write bash scripts, so I can't rule out that I might have done something wrong.

### Applicable issues

I'm not aware of that

### Additional information

I'm sure it's worth testing before pouring in, as I haven't dabbled in this and am very superficially familiar with bash utilities.
