### PR TITLE
[bitnami/drupal] Fix problem in getting database port on second run in libdrupal.sh

### DIFF
--- a/bitnami/drupal/10/debian-12/rootfs/opt/bitnami/scripts/libdrupal.sh
+++ b/bitnami/drupal/10/debian-12/rootfs/opt/bitnami/scripts/libdrupal.sh
@@ -203,7 +203,7 @@ drupal_initialize() {
 drupal_database_conf_get() {
     local -r key="${1:?key missing}"
     debug "Getting ${key} from Drupal database configuration"
-    grep -E "^\s*'${key}' =>" "$DRUPAL_CONF_FILE" | grep -E -o "=> '.*'" | cut -f2 -d\'
+    grep -E "^\s*'${key}' =>" "$DRUPAL_CONF_FILE" | awk -F'=>' '{gsub(/[ ,'\''"]/, "", $2); print $2}'
 }
 
 ########################

--- a/bitnami/drupal/11/debian-12/rootfs/opt/bitnami/scripts/libdrupal.sh
+++ b/bitnami/drupal/11/debian-12/rootfs/opt/bitnami/scripts/libdrupal.sh
@@ -203,7 +203,7 @@ drupal_initialize() {
 drupal_database_conf_get() {
     local -r key="${1:?key missing}"
     debug "Getting ${key} from Drupal database configuration"
-    grep -E "^\s*'${key}' =>" "$DRUPAL_CONF_FILE" | grep -E -o "=> '.*'" | cut -f2 -d\'
+    grep -E "^\s*'${key}' =>" "$DRUPAL_CONF_FILE" | awk -F'=>' '{gsub(/[ ,'\''"]/, "", $2); print $2}'
 }
 
 ########################


### PR DESCRIPTION
### Description of the change

This pull request  addresses an issue in the Drupal container where it ends abruptly on the second run due to a problem with retrieving the database port. Specifically, it fixes the issue of the drupal_database_conf_get function failing because the port value does not have single quotes. This fix ensures that both quoted and non-quoted port values are supported, preventing the container from exiting unexpectedly.

I was facing the problem of the Drupal container ending abruptly on the second run:
```
...
drupalday2024-drupal-1   | drupal 11:40:00.14 INFO  ==> ** Starting Drupal setup **
drupalday2024-drupal-1   | realpath: /bitnami/apache/conf: No such file or directory
drupalday2024-drupal-1   | drupal 11:40:00.16 INFO  ==> Configuring Apache ServerTokens directive
drupalday2024-drupal-1   | drupal 11:40:00.18 INFO  ==> Configuring PHP options
drupalday2024-drupal-1   | drupal 11:40:00.18 INFO  ==> Setting PHP expose_php option
drupalday2024-drupal-1   | drupal 11:40:00.19 INFO  ==> Setting PHP output_buffering option
drupalday2024-drupal-1   | drupal 11:40:00.21 INFO  ==> Validating settings in MYSQL_CLIENT_* env vars
drupalday2024-drupal-1   | drupal 11:40:00.24 WARN  ==> You set the environment variable ALLOW_EMPTY_PASSWORD=yes. For safety reasons, do not use this flag in a production environment.
drupalday2024-drupal-1   | drupal 11:40:00.29 INFO  ==> Restoring persisted Drupal installation
drupalday2024-drupal-1   | drupal 11:40:00.32 INFO  ==> Trying to connect to the database server


(exited with no further messages)
```
Therefore, I am contributing this patch which is affecting the second runs, at least in docker composer and Kubernetes helm charts.

### Benefits

 - This change resolves the problem of getting the database port when it has no single quotes (int value). 

People trying to use the Drupal container in docker compose and Kubernetes during the second run will not face the abrupt exit of the container

### Possible drawbacks

It is still done in bash/awk. It could probably be improved by using PHP itself, but that is more involved.

### Applicable issues

Running the container after persistence is built, since `/opt/bitnami/scripts/libdrupal.sh` checks on line 134  `if ! is_app_initialized "$app_name"; then...` and if it goes into the `else` the call  db_port="$(drupal_database_conf_get 'port')", will fail since `drupal_database_conf_get` is expecting single quotes. But port does not have single quotes by default, so both need to be supported:

```
$databases['default']['default'] = array (
  'database' => 'bitnami_drupal',
  'username' => 'bn_drupal',
  'password' => '',
  'prefix' => '',
  'host' => 'mariadb',
  'port' => 3306,
  'isolation_level' => 'READ COMMITTED',
  'driver' => 'mysql',
  'namespace' => 'Drupal\\mysql\\Driver\\Database\\mysql',
  'autoload' => 'core/modules/mysql/src/Driver/Database/mysql/',
);
```

### Additional information

This is a fairly simple fix, but please let me know if you need more information.
