### PR TITLE
[bitnami/postgresql-pgpool] use correct node port on healthcheck

### DIFF
--- a/bitnami/pgpool/4/debian-12/rootfs/opt/bitnami/scripts/libpgpool.sh
+++ b/bitnami/pgpool/4/debian-12/rootfs/opt/bitnami/scripts/libpgpool.sh
@@ -315,8 +315,9 @@ pgpool_healthcheck() {
             IFS="|" read -ra node_info <<< "$node"
             local node_id="${node_info[0]}"
             local node_host="${node_info[1]}"
+            local node_port="${node_info[2]}"
             if [[ $(PGCONNECT_TIMEOUT=3 PGPASSWORD="${PGPOOL_POSTGRES_PASSWORD}" psql -U "${PGPOOL_POSTGRES_USERNAME}" \
-                -d postgres -h "${node_host}" -p "${PGPOOL_PORT_NUMBER}" -tA -c "SELECT 1" || true) == 1 ]]; then
+                -d postgres -h "${node_host}" -p "${node_port}" -tA -c "SELECT 1" || true) == 1 ]]; then
                 # attach backend if it has come back online
                 pgpool_attach_node "${node_id}"
             fi


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Based on @AlexShander's finding on #72979, pgpool's healthcheck uses its port rather than postgresql's port when checking connection to them

### Benefits

<!-- What benefits will be realized by the code change? -->
Let user to set different port between pgpool and postgresql

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #72979

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

