### PR TITLE
[bitnami/suitecrm] fix cron job for SuiteCRM v8

### DIFF
--- a/bitnami/suitecrm/8/debian-12/rootfs/opt/bitnami/scripts/libsuitecrm.sh
+++ b/bitnami/suitecrm/8/debian-12/rootfs/opt/bitnami/scripts/libsuitecrm.sh
@@ -188,7 +188,7 @@ suitecrm_initialize() {
     # https://docs.suitecrm.com/blog/scheduler-jobs/
     local -a cron_cmd=("${PHP_BIN_DIR}/php" "${SUITECRM_BASE_DIR}/public/legacy/cron.php")
     if am_i_root; then
-        generate_cron_conf "suitecrm" "${cron_cmd[*]} > /dev/null 2>&1" --run-as "$WEB_SERVER_DAEMON_USER" --schedule "*/1 * * * *"
+        generate_cron_conf "suitecrm" "${cron_cmd[*]} > /dev/null 2>&1" --run-as "$WEB_SERVER_DAEMON_USER" --schedule "* * * * *"
     else
         warn "Skipping cron configuration for SuiteCRM because of running as a non-root user"
     fi

--- a/bitnami/suitecrm/8/debian-12/rootfs/opt/bitnami/scripts/libsuitecrm.sh
+++ b/bitnami/suitecrm/8/debian-12/rootfs/opt/bitnami/scripts/libsuitecrm.sh
@@ -186,7 +186,7 @@ suitecrm_initialize() {
 
     # Ensure SuiteCRM cron jobs are created when running setup with a root user
     # https://docs.suitecrm.com/blog/scheduler-jobs/
-    local -a cron_cmd=(cd "${SUITECRM_BASE_DIR};" "${PHP_BIN_DIR}/php" "-f" "cron.php")
+    local -a cron_cmd=("${PHP_BIN_DIR}/php" "${SUITECRM_BASE_DIR}/public/legacy/cron.php")
     if am_i_root; then
         generate_cron_conf "suitecrm" "${cron_cmd[*]} > /dev/null 2>&1" --run-as "$WEB_SERVER_DAEMON_USER" --schedule "*/1 * * * *"
     else


### PR DESCRIPTION
### Description of the change

The path to `cron.php` was not correct. Also simplified the command.

### Benefits

The SuiteCRM Scheduler will work (currently it does not run).

### Possible drawbacks

None.

### Applicable issues

- fixes #73240
- fixes #52365
- fixes #73548

### Additional information

It's unfortunate that such an important and simple fix took so long to get applied.
