### PR TITLE
ci: avoid running ldd against static binaries

### DIFF
--- a/.vib/common/goss/scripts/check-linked-libraries.sh
+++ b/.vib/common/goss/scripts/check-linked-libraries.sh
@@ -12,5 +12,11 @@ for file in "${files[@]}"; do
   if [[ -n $EXCLUDE_PATHS ]] && [[ "$file" =~ $EXCLUDE_PATHS ]]; then
     continue
   fi
-  [[ $(ldd "$file" | grep -c "not found") -eq 0 ]] || exit 1
+  if ldd "$file" 2>&1 | grep -q "not a dynamic executable"; then
+    continue
+  fi
+  if ldd "$file" | grep -c "not found"; then
+    echo "missing linked libraries at $file"
+    exit 1
+  fi
 done


### PR DESCRIPTION
### Description of the change

This PR ensures we ensure the target executables we're inspecting looking for missing libraries aren't statically compiled.

### Benefits

Avoiding errors like the one below:

```console
[INFO][goss-cli] Command: check-linked-libraries: stderr:  	not a dynamic executable
[INFO][goss-cli] Command: check-linked-libraries: stderr:  	not a dynamic executable
[INFO][goss-cli] Command: check-linked-libraries: stderr:  	not a dynamic executable
```

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A
