### PR TITLE
[bitnami/matomo] Added MATOMO_PROXY_IP_READ_LAST_IN_LIST env variable

### DIFF
--- a/bitnami/matomo/5/debian-12/rootfs/opt/bitnami/scripts/libmatomo.sh
+++ b/bitnami/matomo/5/debian-12/rootfs/opt/bitnami/scripts/libmatomo.sh
@@ -177,6 +177,11 @@ EOF
             ini-file set -s "General" -k "proxy_host_headers[]" -v "$MATOMO_PROXY_HOST_HEADER" "$MATOMO_CONF_FILE"
         fi
 
+        if ! is_empty_value "$MATOMO_PROXY_IP_READ_LAST_IN_LIST"; then
+        info "Configuring Matomo to read the last IP in the list"
+            ini-file set -s "General" -k "proxy_ip_read_last_in_list" -v "$MATOMO_PROXY_IP_READ_LAST_IN_LIST" "$MATOMO_CONF_FILE"
+        fi
+
         # Database SSL
         if is_boolean_yes "$MATOMO_ENABLE_DATABASE_SSL"; then
             info "Enabling database SSL"

--- a/bitnami/matomo/5/debian-12/rootfs/opt/bitnami/scripts/matomo-env.sh
+++ b/bitnami/matomo/5/debian-12/rootfs/opt/bitnami/scripts/matomo-env.sh
@@ -31,6 +31,7 @@ matomo_env_vars=(
     MATOMO_ENABLE_ASSUME_SECURE_PROTOCOL
     MATOMO_ENABLE_FORCE_SSL
     MATOMO_ENABLE_PROXY_URI_HEADER
+    MATOMO_PROXY_IP_READ_LAST_IN_LIST
     MATOMO_USERNAME
     MATOMO_PASSWORD
     MATOMO_EMAIL
@@ -96,6 +97,7 @@ export MATOMO_PROXY_CLIENT_HEADER="${MATOMO_PROXY_CLIENT_HEADER:-}" # only used 
 export MATOMO_ENABLE_ASSUME_SECURE_PROTOCOL="${MATOMO_ENABLE_ASSUME_SECURE_PROTOCOL:-no}" # only used during the first initialization
 export MATOMO_ENABLE_FORCE_SSL="${MATOMO_ENABLE_FORCE_SSL:-no}" # only used during the first initialization
 export MATOMO_ENABLE_PROXY_URI_HEADER="${MATOMO_ENABLE_PROXY_URI_HEADER:-no}" # only used during the first initialization
+export MATOMO_PROXY_IP_READ_LAST_IN_LIST="${MATOMO_PROXY_IP_READ_LAST_IN_LIST:-1}"
 
 # Matomo credentials
 export MATOMO_USERNAME="${MATOMO_USERNAME:-user}" # only used during the first initialization

--- a/bitnami/matomo/README.md
+++ b/bitnami/matomo/README.md
@@ -275,6 +275,7 @@ Bitnami provides up-to-date versions of MariaDB and Matomo, including security p
 | `MATOMO_SKIP_BOOTSTRAP`                | Whether to perform initial bootstrapping for the application.                                                                | `nil`                           |
 | `MATOMO_PROXY_HOST_HEADER`             | Specify the host IP HTTP Header. Usually HTTP_X_FORWARDED_HOST. No defaults.                                                 | `nil`                           |
 | `MATOMO_PROXY_CLIENT_HEADER`           | Specify the client IP HTTP Header. Usually HTTP_X_FORWARDED_FOR.                                                             | `nil`                           |
+| `MATOMO_PROXY_IP_READ_LAST_IN_LIST`    | Specify if the last IP in the `X-FORWARDED-FOR` list should be read.                                                         | `1`                           |
 | `MATOMO_ENABLE_ASSUME_SECURE_PROTOCOL` | Enable assume_secure_protocol in Matomo configuration file.                                                                  | `no`                            |
 | `MATOMO_ENABLE_FORCE_SSL`              | Enable force_ssl in Matomo configuration file.                                                                               | `no`                            |
 | `MATOMO_ENABLE_PROXY_URI_HEADER`       | Enable proxy_uri_header in Matomo configuration file.                                                                        | `no`                            |


### PR DESCRIPTION
### Description of the change

Added the MATOMO_PROXY_IP_READ_LAST_IN_LIST env variable which configures if Matomo should use the first or last IP in the list of IPs in the X-FORWARDED-FOR header. Default is 1 which means that the last IP is used.

### Benefits

In my case, when using an ALB with Traefik, the IP address Matomo used for visitors was the last in the list which was always the internal IP address of the Traefik instance. This change means that users can configure this option to use the first IP in the list.

### Possible drawbacks

No drawbacks, default option is the same as Matomo configures

### Applicable issues

N/A

### Additional information

N/A