### PR TITLE
[bitnami/postgresql-repmgr] fix init script tries to recreate repmgr

### DIFF
--- a/bitnami/postgresql-repmgr/12/debian-12/rootfs/opt/bitnami/scripts/librepmgr.sh
+++ b/bitnami/postgresql-repmgr/12/debian-12/rootfs/opt/bitnami/scripts/librepmgr.sh
@@ -348,13 +348,8 @@ repmgr_create_repmgr_user() {
 
     [[ "$POSTGRESQL_USERNAME" != "postgres" ]] && [[ -n "$POSTGRESQL_POSTGRES_PASSWORD" ]] && postgres_password="$POSTGRESQL_POSTGRES_PASSWORD"
     # The repmgr user is created as superuser for simplicity (ref: https://repmgr.org/docs/4.3/quickstart-repmgr-user-database.html)
-    # In case REPMGR_USERNAME == POSTGRESQL_REPLICATION_USER, we just need to grant repmgr with CREATEDB
-    if [[ "$REPMGR_USERNAME" == "$POSTGRESQL_REPLICATION_USER" ]]; then
-      echo "ALTER USER ${REPMGR_USERNAME} WITH CREATEDB;" | postgresql_execute "" "postgres" "$postgres_password"
-    else
-      echo "CREATE ROLE \"${REPMGR_USERNAME}\" WITH LOGIN CREATEDB PASSWORD '${escaped_password}';" | postgresql_execute "" "postgres" "$postgres_password"
-    fi
-    echo "ALTER USER ${REPMGR_USERNAME} WITH SUPERUSER;" | postgresql_execute "" "postgres" "$postgres_password"
+    postgresql_ensure_user_exists "$REPMGR_USERNAME" --password "$postgres_password"
+    echo "ALTER USER ${REPMGR_USERNAME} WITH SUPERUSER CREATEDB;" | postgresql_execute "" "postgres" "$postgres_password"
     # set the repmgr user's search path to include the 'repmgr' schema name (ref: https://repmgr.org/docs/4.3/quickstart-repmgr-user-database.html)
     echo "ALTER USER ${REPMGR_USERNAME} SET search_path TO repmgr, \"\$user\", public;" | postgresql_execute "" "postgres" "$postgres_password"
 }

--- a/bitnami/postgresql-repmgr/13/debian-12/rootfs/opt/bitnami/scripts/librepmgr.sh
+++ b/bitnami/postgresql-repmgr/13/debian-12/rootfs/opt/bitnami/scripts/librepmgr.sh
@@ -348,13 +348,8 @@ repmgr_create_repmgr_user() {
 
     [[ "$POSTGRESQL_USERNAME" != "postgres" ]] && [[ -n "$POSTGRESQL_POSTGRES_PASSWORD" ]] && postgres_password="$POSTGRESQL_POSTGRES_PASSWORD"
     # The repmgr user is created as superuser for simplicity (ref: https://repmgr.org/docs/4.3/quickstart-repmgr-user-database.html)
-    # In case REPMGR_USERNAME == POSTGRESQL_REPLICATION_USER, we just need to grant repmgr with CREATEDB
-    if [[ "$REPMGR_USERNAME" == "$POSTGRESQL_REPLICATION_USER" ]]; then
-      echo "ALTER USER ${REPMGR_USERNAME} WITH CREATEDB;" | postgresql_execute "" "postgres" "$postgres_password"
-    else
-      echo "CREATE ROLE \"${REPMGR_USERNAME}\" WITH LOGIN CREATEDB PASSWORD '${escaped_password}';" | postgresql_execute "" "postgres" "$postgres_password"
-    fi
-    echo "ALTER USER ${REPMGR_USERNAME} WITH SUPERUSER;" | postgresql_execute "" "postgres" "$postgres_password"
+    postgresql_ensure_user_exists "$REPMGR_USERNAME" --password "$postgres_password"
+    echo "ALTER USER ${REPMGR_USERNAME} WITH SUPERUSER CREATEDB;" | postgresql_execute "" "postgres" "$postgres_password"
     # set the repmgr user's search path to include the 'repmgr' schema name (ref: https://repmgr.org/docs/4.3/quickstart-repmgr-user-database.html)
     echo "ALTER USER ${REPMGR_USERNAME} SET search_path TO repmgr, \"\$user\", public;" | postgresql_execute "" "postgres" "$postgres_password"
 }

--- a/bitnami/postgresql-repmgr/14/debian-12/rootfs/opt/bitnami/scripts/librepmgr.sh
+++ b/bitnami/postgresql-repmgr/14/debian-12/rootfs/opt/bitnami/scripts/librepmgr.sh
@@ -348,13 +348,8 @@ repmgr_create_repmgr_user() {
 
     [[ "$POSTGRESQL_USERNAME" != "postgres" ]] && [[ -n "$POSTGRESQL_POSTGRES_PASSWORD" ]] && postgres_password="$POSTGRESQL_POSTGRES_PASSWORD"
     # The repmgr user is created as superuser for simplicity (ref: https://repmgr.org/docs/4.3/quickstart-repmgr-user-database.html)
-    # In case REPMGR_USERNAME == POSTGRESQL_REPLICATION_USER, we just need to grant repmgr with CREATEDB
-    if [[ "$REPMGR_USERNAME" == "$POSTGRESQL_REPLICATION_USER" ]]; then
-      echo "ALTER USER ${REPMGR_USERNAME} WITH CREATEDB;" | postgresql_execute "" "postgres" "$postgres_password"
-    else
-      echo "CREATE ROLE \"${REPMGR_USERNAME}\" WITH LOGIN CREATEDB PASSWORD '${escaped_password}';" | postgresql_execute "" "postgres" "$postgres_password"
-    fi
-    echo "ALTER USER ${REPMGR_USERNAME} WITH SUPERUSER;" | postgresql_execute "" "postgres" "$postgres_password"
+    postgresql_ensure_user_exists "$REPMGR_USERNAME" --password "$postgres_password"
+    echo "ALTER USER ${REPMGR_USERNAME} WITH SUPERUSER CREATEDB;" | postgresql_execute "" "postgres" "$postgres_password"
     # set the repmgr user's search path to include the 'repmgr' schema name (ref: https://repmgr.org/docs/4.3/quickstart-repmgr-user-database.html)
     echo "ALTER USER ${REPMGR_USERNAME} SET search_path TO repmgr, \"\$user\", public;" | postgresql_execute "" "postgres" "$postgres_password"
 }

--- a/bitnami/postgresql-repmgr/15/debian-12/rootfs/opt/bitnami/scripts/librepmgr.sh
+++ b/bitnami/postgresql-repmgr/15/debian-12/rootfs/opt/bitnami/scripts/librepmgr.sh
@@ -348,13 +348,8 @@ repmgr_create_repmgr_user() {
 
     [[ "$POSTGRESQL_USERNAME" != "postgres" ]] && [[ -n "$POSTGRESQL_POSTGRES_PASSWORD" ]] && postgres_password="$POSTGRESQL_POSTGRES_PASSWORD"
     # The repmgr user is created as superuser for simplicity (ref: https://repmgr.org/docs/4.3/quickstart-repmgr-user-database.html)
-    # In case REPMGR_USERNAME == POSTGRESQL_REPLICATION_USER, we just need to grant repmgr with CREATEDB
-    if [[ "$REPMGR_USERNAME" == "$POSTGRESQL_REPLICATION_USER" ]]; then
-      echo "ALTER USER ${REPMGR_USERNAME} WITH CREATEDB;" | postgresql_execute "" "postgres" "$postgres_password"
-    else
-      echo "CREATE ROLE \"${REPMGR_USERNAME}\" WITH LOGIN CREATEDB PASSWORD '${escaped_password}';" | postgresql_execute "" "postgres" "$postgres_password"
-    fi
-    echo "ALTER USER ${REPMGR_USERNAME} WITH SUPERUSER;" | postgresql_execute "" "postgres" "$postgres_password"
+    postgresql_ensure_user_exists "$REPMGR_USERNAME" --password "$postgres_password"
+    echo "ALTER USER ${REPMGR_USERNAME} WITH SUPERUSER CREATEDB;" | postgresql_execute "" "postgres" "$postgres_password"
     # set the repmgr user's search path to include the 'repmgr' schema name (ref: https://repmgr.org/docs/4.3/quickstart-repmgr-user-database.html)
     echo "ALTER USER ${REPMGR_USERNAME} SET search_path TO repmgr, \"\$user\", public;" | postgresql_execute "" "postgres" "$postgres_password"
 }

--- a/bitnami/postgresql-repmgr/16/debian-12/rootfs/opt/bitnami/scripts/librepmgr.sh
+++ b/bitnami/postgresql-repmgr/16/debian-12/rootfs/opt/bitnami/scripts/librepmgr.sh
@@ -348,13 +348,8 @@ repmgr_create_repmgr_user() {
 
     [[ "$POSTGRESQL_USERNAME" != "postgres" ]] && [[ -n "$POSTGRESQL_POSTGRES_PASSWORD" ]] && postgres_password="$POSTGRESQL_POSTGRES_PASSWORD"
     # The repmgr user is created as superuser for simplicity (ref: https://repmgr.org/docs/4.3/quickstart-repmgr-user-database.html)
-    # In case REPMGR_USERNAME == POSTGRESQL_REPLICATION_USER, we just need to grant repmgr with CREATEDB
-    if [[ "$REPMGR_USERNAME" == "$POSTGRESQL_REPLICATION_USER" ]]; then
-      echo "ALTER USER ${REPMGR_USERNAME} WITH CREATEDB;" | postgresql_execute "" "postgres" "$postgres_password"
-    else
-      echo "CREATE ROLE \"${REPMGR_USERNAME}\" WITH LOGIN CREATEDB PASSWORD '${escaped_password}';" | postgresql_execute "" "postgres" "$postgres_password"
-    fi
-    echo "ALTER USER ${REPMGR_USERNAME} WITH SUPERUSER;" | postgresql_execute "" "postgres" "$postgres_password"
+    postgresql_ensure_user_exists "$REPMGR_USERNAME" --password "$postgres_password"
+    echo "ALTER USER ${REPMGR_USERNAME} WITH SUPERUSER CREATEDB;" | postgresql_execute "" "postgres" "$postgres_password"
     # set the repmgr user's search path to include the 'repmgr' schema name (ref: https://repmgr.org/docs/4.3/quickstart-repmgr-user-database.html)
     echo "ALTER USER ${REPMGR_USERNAME} SET search_path TO repmgr, \"\$user\", public;" | postgresql_execute "" "postgres" "$postgres_password"
 }


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Skip init script from recreating `repmgr` role because it's already been created as `replication user`.

I'm not sure how to explain the bug, this is caused by these 3 lines:
1. `REPMGR_` variables are copied as `POSTGRESQL_REPLICATION_`
https://github.com/bitnami/containers/blob/69b7934deb4535814feb541fcb18f707343263f8/bitnami/postgresql-repmgr/12/debian-12/rootfs/opt/bitnami/scripts/postgresql-env.sh#L450-L457

2. `repmgr` is created as replication user when initializing postgresql
https://github.com/bitnami/containers/blob/69b7934deb4535814feb541fcb18f707343263f8/bitnami/postgresql-repmgr/12/debian-12/rootfs/opt/bitnami/scripts/libpostgresql.sh#L370

3. `repmgr` is recreated as repmgr user when initializing repmgr
https://github.com/bitnami/containers/blob/69b7934deb4535814feb541fcb18f707343263f8/bitnami/postgresql-repmgr/12/debian-12/rootfs/opt/bitnami/scripts/librepmgr.sh#L351

Error message with **leaked password**:
```
2024-10-29 04:16:55.557 GMT [271] ERROR:  role "repmgr" already exists
2024-10-29 04:16:55.557 GMT [271] STATEMENT:  CREATE ROLE "repmgr" WITH LOGIN CREATEDB PASSWORD 'repmgr_password';
ERROR:  role "repmgr" already exists
```

### Benefits

<!-- What benefits will be realized by the code change? -->
- Hides `repmgr`'s password on log
- Propertly grants `CREATEDB` to `repmgr` (previously skipped due to role already exists)

### Possible drawbacks

<!-- Describe any known limitations with your change -->
No drawback

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
