### PR TITLE
[bitnami/postgresql-pgpool] encrypt health check passwords inside pgp…

### DIFF
--- a/bitnami/pgpool/4/debian-12/rootfs/opt/bitnami/scripts/libpgpool.sh
+++ b/bitnami/pgpool/4/debian-12/rootfs/opt/bitnami/scripts/libpgpool.sh
@@ -493,7 +493,7 @@ pgpool_create_config() {
     # Streaming Replication Check settings
     # https://www.pgpool.net/docs/latest/en/html/runtime-streaming-replication-check.html
     pgpool_set_property "sr_check_user" "$PGPOOL_SR_CHECK_USER"
-    pgpool_set_property "sr_check_password" "$PGPOOL_SR_CHECK_PASSWORD"
+    pgpool_set_property "sr_check_password" "$(pgpool_encrypt_password ${PGPOOL_SR_CHECK_PASSWORD})"
     pgpool_set_property "sr_check_period" "$PGPOOL_SR_CHECK_PERIOD"
     pgpool_set_property "sr_check_database" "$PGPOOL_SR_CHECK_DATABASE"
     # Healthcheck per node settings
@@ -501,7 +501,7 @@ pgpool_create_config() {
     pgpool_set_property "health_check_period" "$PGPOOL_HEALTH_CHECK_PERIOD"
     pgpool_set_property "health_check_timeout" "$PGPOOL_HEALTH_CHECK_TIMEOUT"
     pgpool_set_property "health_check_user" "$PGPOOL_HEALTH_CHECK_USER"
-    pgpool_set_property "health_check_password" "$PGPOOL_HEALTH_CHECK_PASSWORD"
+    pgpool_set_property "health_check_password" "$(pgpool_encrypt_password ${PGPOOL_HEALTH_CHECK_PASSWORD})"
     pgpool_set_property "health_check_max_retries" "$PGPOOL_HEALTH_CHECK_MAX_RETRIES"
     pgpool_set_property "health_check_retry_delay" "$PGPOOL_HEALTH_CHECK_RETRY_DELAY"
     pgpool_set_property "connect_timeout" "$PGPOOL_CONNECT_TIMEOUT"
@@ -588,6 +588,35 @@ pgpool_generate_password_file() {
         fi
     else
         info "Skip generating password file due to PGPOOL_ENABLE_POOL_PASSWD = no"
+    fi
+}
+
+########################
+# Encrypts a password
+# Globals:
+#   PGPOOL_*
+# Arguments:
+#   $1 - password
+# Returns:
+#   None
+#########################
+pgpool_encrypt_password() {
+    local -r password="${1:?missing password}"
+
+    local -a password_encryption_cmd=("pg_md5")
+
+    if [[ "$PGPOOL_AUTHENTICATION_METHOD" = "scram-sha-256" ]]; then
+
+        if is_file_writable "$PGPOOLKEYFILE"; then
+            # Creating a PGPOOLKEYFILE as it is writeable
+            echo "$PGPOOL_AES_KEY" > "$PGPOOLKEYFILE"
+            # Fix permissions for PGPOOLKEYFILE
+            chmod 0600 "$PGPOOLKEYFILE"
+        fi
+        password_encryption_cmd=("pg_enc" "--key-file=${PGPOOLKEYFILE}")
+        debug_execute "${password_encryption_cmd[@]}" "$password" | grep -o -E "AES.+" | tr -d '\n'
+    else
+        debug_execute "${password_encryption_cmd[@]}" "$password" | tr -d '\n'
     fi
 }
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Fix password leak `sr_check_password` and `health_check_password` on `pgpool.conf` (by default has `644` permission) using `pg_enc` and `pg_md5`.

### Benefits

<!-- What benefits will be realized by the code change? -->
Hides `sr_check_password` & `health_check_password`

### Possible drawbacks

<!-- Describe any known limitations with your change -->
No drawback

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
