### PR TITLE
[bitnami/airflow] chore: adapt VIB tests for next release

### DIFF
--- a/.vib/airflow/goss/vars.yaml
+++ b/.vib/airflow/goss/vars.yaml
@@ -1,7 +1,6 @@
 binaries:
   - airflow
   - ini-file
-  - psql
   - python
   - wait-for-port
 linked_libraries:


### PR DESCRIPTION
### Description of the change

This PR adapts VIB tests for next release Airflow release that won't contain `psql` binary any longer.
