### PR TITLE
[bitnami/kong] Remove validation of non-existent variable

### DIFF
--- a/bitnami/kong/3/debian-12/rootfs/opt/bitnami/scripts/libkong.sh
+++ b/bitnami/kong/3/debian-12/rootfs/opt/bitnami/scripts/libkong.sh
@@ -42,12 +42,6 @@ kong_validate() {
         fi
     }
 
-    check_password_file() {
-        if [[ -n "${!1:-}" ]] && ! [[ -f "${!1:-}" ]]; then
-            print_validation_error "The variable ${1} is defined but the file ${!1} is not accessible or does not exist"
-        fi
-    }
-
     check_resolved_hostname() {
         if ! is_hostname_resolved "$1"; then
             warn "Hostname ${1} could not be resolved, this could lead to connection issues"
@@ -80,7 +74,6 @@ kong_validate() {
     # Database setting validations
     if [[ "${KONG_DATABASE:-postgres}" = "postgres" ]]; then
         # PostgreSQL is the default database type
-        check_password_file KONG_POSTGRESQL_PASSWORD_FILE
         [[ -n "${KONG_PG_HOST:-}" ]] && check_resolved_hostname "${KONG_PG_HOST:-}"
     elif [[ "${KONG_DATABASE:-}" = "off" ]]; then
         warn "KONG_DATABASE is set to 'off', Kong will run but data will not be persisted"


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Remove validation of non-existent variable `KONG_POSTGRESQL_PASSWORD_FILE`. The validation only introduces confusion and doesn't work as intended

### Benefits

<!-- What benefits will be realized by the code change? -->
Reduce confusion when user reads the source code

### Possible drawbacks

<!-- Describe any known limitations with your change -->
No drawback

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #74031

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
If anyone want to store the PASSWORD on file instead of env, use `KONG_PG_PASSWORD_FILE` instead. In fact, you can do this to almost any variable by using `_FILE` suffix
https://github.com/bitnami/containers/blob/e26969165953164cec8a8fb5293375a3af83f29e/bitnami/kong/3/debian-12/rootfs/opt/bitnami/scripts/kong-env.sh#L26-L54