### PR TITLE
[bitnami/pgpool] Remove deprecated users from pg_hba.conf

### DIFF
--- a/bitnami/pgpool/4/debian-12/rootfs/opt/bitnami/scripts/libpgpool.sh
+++ b/bitnami/pgpool/4/debian-12/rootfs/opt/bitnami/scripts/libpgpool.sh
@@ -366,8 +366,6 @@ EOF
     cat >>"$PGPOOL_PGHBA_FILE" <<EOF
 ${sr_check_auth_line}
 ${postgres_auth_line}
-host     all             wide               all         trust
-host     all             pop_user           all         trust
 host     all             all                all         ${all_authentication}
 EOF
 }


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Remove deprecated users `wide` & `pop_users` from `pg_hba.conf`. Those users should be safe to be removed from `pg_hba.conf` as both are not used anymore.

### Benefits

<!-- What benefits will be realized by the code change? -->
Increase security by removing unwanted access

### Possible drawbacks

<!-- Describe any known limitations with your change -->
Nothing that I can think of

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #73526

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
