### PR TITLE
[bitnami/redis] Install libssl1 package required for redis-stack (loadmodule /opt/bitnami/redis/lib/redistimeseries.so)

### DIFF
--- a/bitnami/redis/7.4/debian-12/Dockerfile
+++ b/bitnami/redis/7.4/debian-12/Dockerfile
@@ -40,7 +40,10 @@ RUN mkdir -p /tmp/bitnami/pkg/cache/ ; cd /tmp/bitnami/pkg/cache/ ; \
       sha256sum -c "${COMPONENT}.tar.gz.sha256" ; \
       tar -zxf "${COMPONENT}.tar.gz" -C /opt/bitnami --strip-components=2 --no-same-owner --wildcards '*/files' ; \
       rm -rf "${COMPONENT}".tar.gz{,.sha256} ; \
-    done
+    done ; \
+    # Install libssl1 package required for redis-stack (redis time-series  module)
+    curl -O http://ftp.debian.org/debian/pool/main/o/openssl/libssl1.1_1.1.1w-0+deb11u1_amd64.deb ; \
+    dpkg -i libssl1.1_1.1.1w-0+deb11u1_amd64.deb
 RUN apt-get autoremove --purge -y curl && \
     apt-get update && apt-get upgrade -y && \
     apt-get clean && rm -rf /var/lib/apt/lists /var/cache/apt/archives


### PR DESCRIPTION
Install libssl1 package required for redis-stack (redis time-series  module)

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

The suggestion is to either add libssl package to the image or allow options which load modules much like redis-stack

### Benefits

Whenever the new redis-stack is spun up from bitnami helm chart it will work, right now it's failing when the time-series module is loaded in the redis cluster.

### Possible drawbacks

Image size will be increased by couple of MBs.

### Applicable issues

When using bitnami helm charts to create a Redis cluster or instance with the time-series module, the cluster cannot load modules due to missing libssl.

### Additional information

https://github.com/bitnami/charts/issues/27854
