### PR TITLE
Update docker-compose.yml

### DIFF
--- a/bitnami/moodle/docker-compose.yml
+++ b/bitnami/moodle/docker-compose.yml
@@ -26,8 +26,8 @@ services:
       # ALLOW_EMPTY_PASSWORD is recommended only for development.
       - ALLOW_EMPTY_PASSWORD=yes
     volumes:
-      - 'moodle_data:/bitnami/moodle'
-      - 'moodledata_data:/bitnami/moodledata'
+      - 'moodle_data:/moodle'
+      - 'moodledata_data:/moodledata'
     depends_on:
       - mariadb
 volumes:


### PR DESCRIPTION
Correct internal container paths from `/bitnami/moodle` and `/bitnami/moodledata` to just `/moodle` and `/moodledata`

See discussion at #74719

Other issues raised there:
1. The need to set a `MOODLE_SKIP_BOOTSTRAP=yes` environmental variable after first run (I think this needs to go into the guide at https://hub.docker.com/r/bitnami/moodle)
2. The error in the docker compose changes that mix up `moodle` and `moodledata` (also referenced in the Issue above)

### Description of the change
Correct internal container paths from `/bitnami/moodle` and `/bitnami/moodledata` to just `/moodle` and `/moodledata`

### Benefits
Container now runs OK

### Possible drawbacks
I'm unclear why this change was needed if others have used it OK before

### Applicable issues
Still need to set environmental variable to skip bootstrap after first-run (see above)

### Additional information
Covered in the GitHub issue above.