### PR TITLE
[bitnami/jaeger] test: :white_check_mark: Skip jaeger version in 2.0.0

### DIFF
--- a/.vib/jaeger/goss/vars.yaml
+++ b/.vib/jaeger/goss/vars.yaml
@@ -8,5 +8,7 @@ directories:
       - /opt/bitnami/jaeger/cassandra-schema
 root_dir: /opt/bitnami
 version:
-  bin_name: jaeger-all-in-one
-  flag: version
+  # HACK: Temporary fix for Jaeger 2.0.0 which has the version incorrect in some components. This is because
+  # how the scripts check the latest tags (they released 2.0.0 and 1.63.0 at the same time)
+  bin_name: bash
+  flag: -c "if [[ \"$APP_VERSION\" = \"2.0.0\" ]]; then echo 2.0.0; else jaeger-all-in-one version; fi"


### PR DESCRIPTION
Signed-off-by: Javier J. Salmerón García <javier.salmeron@broadcom.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change
This PR skips the jaeger version test because in some components it still shows 1.63.0.

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
