### PR TITLE
[bitnami/prometheus] Console* paths only available for Prometheus 2.y.z

### DIFF
--- a/.vib/prometheus/goss/prometheus.yaml
+++ b/.vib/prometheus/goss/prometheus.yaml
@@ -12,3 +12,14 @@ command:
     stderr:
       - "Starting Prometheus Server"
       - "Server is ready"
+{{ if regexMatch "^2.+" .Env.APP_VERSION }}
+file:
+  /opt/bitnami/prometheus/conf/consoles:
+    exists: true
+    mode: "0755"
+    filetype: directory
+  /opt/bitnami/prometheus/conf/console_libraries:
+    exists: true
+    mode: "0755"
+    filetype: directory
+{{end}}

--- a/.vib/prometheus/goss/vars.yaml
+++ b/.vib/prometheus/goss/vars.yaml
@@ -5,9 +5,6 @@ directories:
   - mode: "0775"
     paths:
       - /opt/bitnami/prometheus/data
-  - paths:
-      - /opt/bitnami/prometheus/conf/console_libraries
-      - /opt/bitnami/prometheus/conf/consoles
 files:
   - paths:
       - /opt/bitnami/prometheus/conf/prometheus.yml


### PR DESCRIPTION
### Description of the change

Adapt Goss test to validate console* paths only for Prometheus 2.y.z
