### PR TITLE
[bitnami/java] Load entrypoint.sh for tests

### DIFF
--- a/.vib/java/goss/java.yaml
+++ b/.vib/java/goss/java.yaml
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: APACHE-2.0
 
 command:
+  # Load the entrypoint to unset an environment variable not supported by Java 1.8
   # Java 1.8 does not support --version, with -version printing to stderr
   # We need to parse the printed version differently depending on the version:
   # - Major versions are often shown as "x" instead of "x.0.0"
@@ -9,10 +10,10 @@ command:
   # - Versions are usually printed as x.y.z+b, but $APP_VERSION is formated as x.y.z-r
   # - In Java 1.8, the version may also be printed as x.y.z-b0r or x.y.z-br
   check-app-version:
-    exec: java -version 2>&1 | sed -E -e "s/\+/-/g" -e "s/0_//g" -e "s/-b0?/-/g" | grep "$(echo $APP_VERSION | sed -E 's|([0-9]+)\..*|\1|g')"
+    exec: /opt/bitnami/scripts/java/entrypoint.sh java -version 2>&1 | sed -E -e "s/\+/-/g" -e "s/0_//g" -e "s/-b0?/-/g" | grep "$(echo $APP_VERSION | sed -E 's|([0-9]+)\..*|\1|g')"
     exit-status: 0
   check-run-jar:
-    exec: java -jar ./java/goss/testfiles/HelloTest.jar
+    exec: /opt/bitnami/scripts/java/entrypoint.sh java -jar ./java/goss/testfiles/HelloTest.jar
     stdout:
     - "Hello VIB"
     exit-status: 0


### PR DESCRIPTION
### Description of the change

Load entrypoint.sh for Java GOSS tests. This is required to unset `JAVA_TOOL_OPTIONS=--module-path...` for Java 1.8.

### Benefits

Make it work for Java 1.8 on Photon
