### PR TITLE
[bitnami/clickhouse] fix startup issue when using json logs #75308

### DIFF
--- a/bitnami/clickhouse/24/debian-12/rootfs/opt/bitnami/scripts/libclickhouse.sh
+++ b/bitnami/clickhouse/24/debian-12/rootfs/opt/bitnami/scripts/libclickhouse.sh
@@ -243,7 +243,7 @@ clickhouse_start_bg() {
         error "ClickHouse failed to start"
         exit 1
     fi
-    wait_for_log_entry "Application: Ready for connections" "$log_file"
+    wait_for_log_entry "Ready for connections" "$log_file"
     info "ClickHouse started successfully"
 }
 

--- a/bitnami/clickhouse/README.md
+++ b/bitnami/clickhouse/README.md
@@ -195,6 +195,8 @@ When the container is executed for the first time, it will execute the files wit
 
 In order to have your custom files inside the docker image you can mount them as a volume.
 
+> NOTE: If you use JSON format for clickhouse logs and remove the message field of the logs, the application will fail to start if there are init or start scripts in any of those 2 folders.
+
 ### Environment variables
 
 #### Customizable environment variables


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

I am changing the text we look for in clickhouse startup logs to check that clickhouse started in the background correctly when we are going to run start o init scripts.
 
### Benefits

JSON is the most standard format for logging. With this change, we can use json logs and start scripts at the same time
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

There is an edge case still not covered. If you intentally left the `message` field out of the JSON logs, the application will fail to start even with this fix, but it would be extremely rare for someone to enable json logs and manually omit the message field to produce useless logs.

I added a warning about this possibility in the section of the README that talks about the init/start scripts

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #75308

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
