### PR TITLE
[bitnami/jmx-exporter] fix docker entrypoint

### DIFF
--- a/bitnami/jmx-exporter/1/debian-12/Dockerfile
+++ b/bitnami/jmx-exporter/1/debian-12/Dockerfile
@@ -56,5 +56,5 @@ EXPOSE 5556
 
 WORKDIR /opt/bitnami/jmx-exporter
 USER 1001
-ENTRYPOINT [ "java", "-jar", "jmx_prometheus_httpserver.jar" ]
+ENTRYPOINT [ "java", "-jar", "jmx_prometheus_standalone.jar" ]
 CMD [ "5556", "example_configs/httpserver_sample_config.yml" ]


### PR DESCRIPTION
In the latest release, the entrypoint command was incorrect, leading to execution errors. 

```bash
docker run -it bitnami/jmx-exporter:latest
```

**Error:**

```
Error: Unable to access jarfile jmx_prometheus_httpserver.jar
```

### Fix

I resolved this by updating the command to use the correct JAR file:


### Impact

This fix allows the JMX Exporter to run without errors. Tested locally and verified.

- Fixes https://github.com/bitnami/containers/issues/75684