### PR TITLE
[bitnami/flink] Increase timeout for 'jobmanager.sh start-foreground' goss test

### DIFF
--- a/.vib/flink/goss/flink.yaml
+++ b/.vib/flink/goss/flink.yaml
@@ -3,8 +3,8 @@
 
 command:
   check-flink-jobmanager-run:
-    exec: timeout --preserve-status 5 jobmanager.sh start-foreground
-    timeout: 8000
+    exec: timeout --preserve-status 20 jobmanager.sh start-foreground
+    timeout: 30000
     exit-status: 143
     stdout:
       - "Rest endpoint listening"


### PR DESCRIPTION
### Description of the change

Increase timeout for 'jobmanager.sh start-foreground' goss test.

### Benefits

The test works for Photon 5.0

### Possible drawbacks

N/A
