### PR TITLE
[bitnami/nginx] shutting down gracefully

### DIFF
--- a/bitnami/nginx/1.27/debian-12/Dockerfile
+++ b/bitnami/nginx/1.27/debian-12/Dockerfile
@@ -23,6 +23,8 @@ ENV HOME="/" \
     OS_FLAVOUR="debian-12" \
     OS_NAME="linux"
 
+STOPSIGNAL SIGQUIT
+
 COPY prebuildfs /
 SHELL ["/bin/bash", "-o", "errexit", "-o", "nounset", "-o", "pipefail", "-c"]
 # Install required system packages and dependencies


### PR DESCRIPTION
### Description of the Change

This pull request adds `STOPSIGNAL SIGQUIT` to the Dockerfile for Nginx. This change allows Nginx to handle shutdown signals more gracefully.

### Benefits

By implementing this change, when `docker stop` is called, Nginx will be able to shut down gracefully, improving service reliability and user experience during container shutdowns.

### Possible Drawbacks

If immediate termination of Nginx is required, users must specify `--stop-signal SIGTERM` when running or creating containers. This retains flexibility for users who prefer the default behavior.

### Applicable Issues

- Fixes #65691 

### Additional Information

For more details on signal handling in Nginx, please refer to the official documentation: [Nginx Runtime Control](https://docs.nginx.com/nginx/admin-guide/basic-functionality/runtime-control/).