### PR TITLE
[bitnami/clickhouse] Fix CLICKHOUSE_MOUNTED_DIR: unbound variable

### DIFF
--- a/bitnami/clickhouse/24/debian-12/rootfs/opt/bitnami/scripts/libclickhouse.sh
+++ b/bitnami/clickhouse/24/debian-12/rootfs/opt/bitnami/scripts/libclickhouse.sh
@@ -93,7 +93,7 @@ clickhouse_copy_mounted_configuration() {
             fi
         fi
     else
-        warn "The folder $CLICKHOUSE_CONF_DIR is not writable. This is likely because a read-only filesystem was mounted in that folder. Using $CLICKHOUSE_MOUNTED_DIR is recommended"
+        warn "The folder $CLICKHOUSE_CONF_DIR is not writable. This is likely because a read-only filesystem was mounted in that folder. Using $CLICKHOUSE_MOUNTED_CONF_DIR is recommended"
     fi
 }
 


### PR DESCRIPTION

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

should be `CLICKHOUSE_MOUNTED_CONF_DIR`

### Benefits

proper warning message



