### PR TITLE
[bitnami/clickhouse] add support for etc/config.d

### DIFF
--- a/bitnami/clickhouse/24/debian-12/rootfs/opt/bitnami/scripts/clickhouse/postunpack.sh
+++ b/bitnami/clickhouse/24/debian-12/rootfs/opt/bitnami/scripts/clickhouse/postunpack.sh
@@ -20,7 +20,7 @@ set -o pipefail
 ensure_user_exists "$CLICKHOUSE_DAEMON_USER" --group "$CLICKHOUSE_DAEMON_GROUP" --system
 
 # Create directories
-for dir in "$CLICKHOUSE_DATA_DIR" "$CLICKHOUSE_CONF_DIR" "${CLICKHOUSE_CONF_DIR}/conf.d" "${CLICKHOUSE_CONF_DIR}/users.d" "$CLICKHOUSE_DEFAULT_CONF_DIR" "$CLICKHOUSE_LOG_DIR" "$CLICKHOUSE_TMP_DIR" "$CLICKHOUSE_MOUNTED_CONF_DIR" "/docker-entrypoint-startdb.d" "/docker-entrypoint-initdb.d"; do
+for dir in "$CLICKHOUSE_DATA_DIR" "$CLICKHOUSE_CONF_DIR" "${CLICKHOUSE_CONF_DIR}/conf.d" "${CLICKHOUSE_CONF_DIR}/config.d" "${CLICKHOUSE_CONF_DIR}/users.d" "$CLICKHOUSE_DEFAULT_CONF_DIR" "$CLICKHOUSE_LOG_DIR" "$CLICKHOUSE_TMP_DIR" "$CLICKHOUSE_MOUNTED_CONF_DIR" "/docker-entrypoint-startdb.d" "/docker-entrypoint-initdb.d"; do
     ensure_dir_exists "$dir"
     configure_permissions_ownership "$dir" -d "775" -f "664" -u "$CLICKHOUSE_DAEMON_USER" -g "root"
 done

--- a/bitnami/clickhouse/24/debian-12/rootfs/opt/bitnami/scripts/libclickhouse.sh
+++ b/bitnami/clickhouse/24/debian-12/rootfs/opt/bitnami/scripts/libclickhouse.sh
@@ -82,15 +82,15 @@ clickhouse_copy_mounted_configuration() {
             # base etc folder
             find "$CLICKHOUSE_MOUNTED_CONF_DIR" -maxdepth 1 \( -type f -o -type l \) -exec cp -L -r {} "$CLICKHOUSE_CONF_DIR" \;
 
-            # The ClickHouse override directories (etc/conf.d and etc/users.d) do not support subfolders. That means we cannot
+            # The ClickHouse override directories (etc/conf.d, etc/config.d and etc/users.d) do not support subfolders. That means we cannot
             # copy directly with cp -RL because we need all override xml files to have at the root of these subfolders. In the helm
-            # chart we want to allow overrides from different ConfigMaps and Secrets so we need to use the find command
-            if [[ -d "${CLICKHOUSE_MOUNTED_CONF_DIR}/conf.d" ]]; then
-                find "${CLICKHOUSE_MOUNTED_CONF_DIR}/conf.d" \( -type f -o -type l \) -exec cp -L -r {} "${CLICKHOUSE_CONF_DIR}/conf.d" \;
-            fi
-            if [[ -d "${CLICKHOUSE_MOUNTED_CONF_DIR}/users.d" ]]; then
-                find "${CLICKHOUSE_MOUNTED_CONF_DIR}/users.d" \( -type f -o -type l \) -exec cp -L -r {} "${CLICKHOUSE_CONF_DIR}/users.d" \;
-            fi
+            # chart we want to allow overrides from different ConfigMaps and Secrets so we need to use the find command.
+            # etc/conf.d is now obselete but still supported.
+            for dir in conf.d config.d users.d; do
+                if [[ -d "${CLICKHOUSE_MOUNTED_CONF_DIR}/${dir}" ]]; then
+                    find "${CLICKHOUSE_MOUNTED_CONF_DIR}/${dir}" \( -type f -o -type l \) -exec cp -L -r {} "${CLICKHOUSE_CONF_DIR}/${dir}" \;
+                fi
+            done
         fi
     else
         warn "The folder $CLICKHOUSE_CONF_DIR is not writable. This is likely because a read-only filesystem was mounted in that folder. Using $CLICKHOUSE_MOUNTED_DIR is recommended"

--- a/bitnami/clickhouse/README.md
+++ b/bitnami/clickhouse/README.md
@@ -167,11 +167,11 @@ ClickHouse can be configured via environment variables or using a configuration 
 
 ### Configuration overrides
 
-The configuration can easily be setup by mounting your own configuration overrides on the directory `/bitnami/clickhouse/etc/conf.d` or `/bitnami/clickhouse/etc/users.d`:
+The configuration can easily be setup by mounting your own configuration overrides on the directory `/bitnami/clickhouse/etc/config.d` or `/bitnami/clickhouse/etc/users.d`:
 
 ```console
 docker run --name clickhouse \
-    --volume /path/to/override.xml:/bitnami/clickhouse/etc/conf.d/override.xml:ro \
+    --volume /path/to/override.xml:/bitnami/clickhouse/etc/config.d/override.xml:ro \
     bitnami/clickhouse:latest
 ```
 
@@ -184,7 +184,7 @@ services:
   clickhouse:
     image: bitnami/clickhouse:latest
     volumes:
-      - /path/to/override.xml:/bitnami/clickhouse/etc/conf.d/override.xml:ro
+      - /path/to/override.xml:/bitnami/clickhouse/etc/config.d/override.xml:ro
 ```
 
 Check the [official ClickHouse configuration documentation](https://clickhouse.com/docs/en/operations/configuration-files/) for all the possible overrides and settings.


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

`etc/conf.d` is obselete, `etc/config.d` should be used. 

### Benefits

Consistend with official Clickhouse documentation

### Possible drawbacks

Redundant `conf.d` directory

