### PR TITLE
[bitnami/node-min] Add Goss test

### DIFF
--- a/.vib/common/goss/templates/check-minimal.yaml
+++ b/.vib/common/goss/templates/check-minimal.yaml
@@ -1,0 +1,45 @@
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+########################
+# Test coverage for minimal containers
+# Needed vars:
+# - None
+########################
+file:
+  /etc/group:
+    exists: true
+    mode: "0644"
+    owner: root
+    group: root
+    filetype: file
+  /etc/passwd:
+    exists: true
+    mode: "0644"
+    owner: root
+    group: root
+    filetype: file
+  /home/nonroot:
+    exists: true
+    mode: "0755"
+    owner: nonroot
+    group: nonroot
+    filetype: directory
+  /etc/os-release:
+    exists: true
+    filetype: symlink
+    linked-to: /usr/lib/os-release
+  /usr/lib/os-release:
+    exists: true
+    mode: "0644"
+    owner: root
+    group: root
+    filetype: file
+  /tmp:
+    exists: true
+    mode: "0777"
+    filetype: directory
+  /var:
+    exists: true
+    mode: "0775"
+    filetype: directory

--- a/.vib/common/goss/templates/check-minimal.yaml
+++ b/.vib/common/goss/templates/check-minimal.yaml
@@ -37,9 +37,9 @@ file:
     filetype: file
   /tmp:
     exists: true
-    mode: "0777"
+    mode: "1777"
     filetype: directory
   /var:
     exists: true
-    mode: "0775"
+    mode: "0755"
     filetype: directory

--- a/.vib/common/goss/templates/check-openssl-fips.yaml
+++ b/.vib/common/goss/templates/check-openssl-fips.yaml
@@ -1,0 +1,39 @@
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+########################
+# Test coverage for openssl and FIPS
+# Needed vars:
+# - None
+########################
+file:
+  /etc/ssl/fipsmodule.cnf:
+    exists: true
+    mode: "0644"
+    owner: root
+    group: root
+    filetype: file
+  /etc/ssl/provider_fips.cnf:
+    exists: true
+    mode: "0644"
+    owner: root
+    group: root
+    filetype: file
+  /etc/ssl/openssl.cnf:
+    exists: true
+    mode: "0644"
+    owner: root
+    group: root
+    filetype: file
+  /usr/lib/libcrypto.so:
+    exists: true
+    filetype: symlink
+  /usr/lib/libssl.so:
+    exists: true
+    filetype: symlink
+  /usr/lib/ossl-modules/fips.so:
+    exists: true
+    mode: "755"
+    owner: root
+    group: root
+    filetype: file

--- a/.vib/common/goss/templates/check-openssl-fips.yaml
+++ b/.vib/common/goss/templates/check-openssl-fips.yaml
@@ -33,7 +33,7 @@ file:
     filetype: symlink
   /usr/lib/ossl-modules/fips.so:
     exists: true
-    mode: "755"
+    mode: "0755"
     owner: root
     group: root
     filetype: file

--- a/.vib/node-min/goss/goss.yaml
+++ b/.vib/node-min/goss/goss.yaml
@@ -6,4 +6,7 @@ gossfile:
   ../../node-min/goss/node-min.yaml: {}
   # Load scripts from .vib/common/goss/templates
   ../../common/goss/templates/check-app-version-no-shell-stdout.yaml: {}
+  ../../common/goss/templates/check-ca-certs.yaml: {}
   ../../common/goss/templates/check-files.yaml: {}
+  ../../common/goss/templates/check-minimal.yaml: {}
+  ../../common/goss/templates/check-openssl-fips.yaml: {}

--- a/.vib/node-min/goss/goss.yaml
+++ b/.vib/node-min/goss/goss.yaml
@@ -1,0 +1,9 @@
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+gossfile:
+  # Goss tests exclusive to the current container
+  ../../node-min/goss/node-min.yaml: {}
+  # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-app-version-no-shell-stdout.yaml: {}
+  ../../common/goss/templates/check-files.yaml: {}

--- a/.vib/node-min/goss/node-min.yaml
+++ b/.vib/node-min/goss/node-min.yaml
@@ -1,0 +1,9 @@
+command:
+  check-hello-world:
+    exec:
+    - node
+    - --eval
+    - console.log('Hello World');
+    exit-status: 0
+    stdout:
+    - "Hello World"

--- a/.vib/node-min/goss/vars.yaml
+++ b/.vib/node-min/goss/vars.yaml
@@ -1,0 +1,7 @@
+files:
+  - mode: "0644"
+    paths:
+      - /opt/bitnami/node/.spdx-node-min.spdx
+version:
+  bin_name: node
+  flag: --version

--- a/.vib/node-min/vib-verify.json
+++ b/.vib/node-min/vib-verify.json
@@ -34,6 +34,21 @@
     "verify": {
       "actions": [
         {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "node-min/goss/goss.yaml",
+            "vars_file": "node-min/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-node-min"
+              }
+            }
+          }
+        },
+        {
           "action_id": "trivy",
           "params": {
             "threshold": "LOW",

--- a/.vib/node-min/vib-verify.json
+++ b/.vib/node-min/vib-verify.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyJub2RlIiwgIi0tZXZhbCIsICJzZXRUaW1lb3V0KCgpID0+IHt9LCAzNjAwICogMTAwMCk7Il0K"
   },
   "phases": {
     "package": {

--- a/TESTING.md
+++ b/TESTING.md
@@ -257,24 +257,26 @@ Not every suite will be composed of the same tests, as it will depend on the typ
 Sometimes it is of interest to run the tests locally, for example during development. Though there may be different approaches, you may follow the steps below to execute the tests locally:
 
 1. Download the [GOSS binary for Linux](https://github.com/goss-org/goss/releases/)
-
-2. Add the binary and test files to the tested container as volumes
+2. Launch the container using some command that ensures it will not exit immediately. Find two examples below:
 
     ```bash
-    $ docker run -d -it bitnami/app_name bash -c "tail -f /dev/null"
-    e696196fba
-
-    $ docker cp /local/path/to/binary/goss-linux-amd64 e6961:/usr/local/bin/gossctl
-    $ docker cp /local/path/to/repo/containers/.vib e6961:/goss
+    $ docker run --rm --name app_name -d -it bitnami/app_name bash -c "tail -f /dev/null"
+    $ docker run --rm --name app_name -d -it --entrypoint node bitnami/app_name --eval "setTimeout(() => {}, 3600 * 1000);"
     ```
 
-3. Grant execution permissions to the binary and launch the tests
+3. Add the binary and test files to the tested container as volumes
 
     ```bash
-    $ docker exec e6961 chmod +x /usr/local/bin/gossctl
-    $ docker exec e6961 bash -c 'cd /goss && gossctl --gossfile /goss/app_name/goss/goss.yaml --vars /goss/app_name/goss/vars.yaml validate'
-    .........
+    $ chmod +x /local/path/to/binary/goss-linux-amd64
+    $ docker cp /local/path/to/binary/goss-linux-amd64 app_name:/usr/local/bin/gossctl
+    $ docker cp /local/path/to/repo/containers/.vib app_name:/vib
+    ```
 
+4. Launch the tests
+
+    ```bash
+    $ docker exec --workdir /vib app_name goss --gossfile /vib/app_name/goss/goss.yaml --vars /vib/app_name/goss/vars.yaml validate
+    .........
     Total Duration: 1.203s
     Count: 11, Failed: 0, Skipped: 0
     ```

--- a/TESTING.md
+++ b/TESTING.md
@@ -260,21 +260,21 @@ Sometimes it is of interest to run the tests locally, for example during develop
 2. Launch the container using some command that ensures it will not exit immediately. Find two examples below:
 
     ```bash
-    $ docker run --rm --name app_name -d -it bitnami/app_name bash -c "tail -f /dev/null"
-    $ docker run --rm --name app_name -d -it --entrypoint node bitnami/app_name --eval "setTimeout(() => {}, 3600 * 1000);"
+    docker run --rm --name app_name -d -it bitnami/app_name bash -c "tail -f /dev/null"
+    docker run --rm --name app_name -d -it --entrypoint node bitnami/app_name --eval "setTimeout(() => {}, 3600 * 1000);"
     ```
 
 3. Add the binary and test files to the tested container as volumes
 
     ```bash
-    $ chmod +x /local/path/to/binary/goss-linux-amd64
-    $ docker cp /local/path/to/binary/goss-linux-amd64 app_name:/usr/local/bin/gossctl
-    $ docker cp /local/path/to/repo/containers/.vib app_name:/vib
+    chmod +x /local/path/to/binary/goss-linux-amd64
+    docker cp /local/path/to/binary/goss-linux-amd64 app_name:/usr/local/bin/gossctl
+    docker cp /local/path/to/repo/containers/.vib app_name:/vib
     ```
 
 4. Launch the tests
 
-    ```bash
+    ```console
     $ docker exec --workdir /vib app_name goss --gossfile /vib/app_name/goss/goss.yaml --vars /vib/app_name/goss/vars.yaml validate
     .........
     Total Duration: 1.203s

--- a/TESTING.md
+++ b/TESTING.md
@@ -261,6 +261,11 @@ Sometimes it is of interest to run the tests locally, for example during develop
 
     ```bash
     docker run --rm --name app_name -d -it bitnami/app_name bash -c "tail -f /dev/null"
+    ```
+
+    or for a scratch container (e.g. Node.js minimal):
+
+    ```bash
     docker run --rm --name app_name -d -it --entrypoint node bitnami/app_name --eval "setTimeout(() => {}, 3600 * 1000);"
     ```
 


### PR DESCRIPTION
### Description of the change

This PR adds basic Goss tests for `node-min` that ensures expected files and directories exist, the version is correct, the SPDX file is available and a basic JS script can be executed.
