### PR TITLE
[bitnami/kibana] remove unsable function `kibana_set_key_value` function and move to `kibana_conf_set`

### DIFF
--- a/bitnami/kibana/8/debian-12/rootfs/opt/bitnami/scripts/libkibana.sh
+++ b/bitnami/kibana/8/debian-12/rootfs/opt/bitnami/scripts/libkibana.sh
@@ -17,23 +17,6 @@
 # Functions
 
 ########################
-# Set Elasticsearch keystore values
-# Globals:
-#   ELASTICSEARCH_*
-# Arguments:
-#   None
-# Returns:
-#   None
-#########################
-kibana_set_key_value() {
-    local key="${1:?missing key}"
-    local value="${2:?missing value}"
-
-    debug "Storing key: ${key}"
-    kibana-keystore add --stdin --force "$key" <<<"$value"
-}
-
-########################
 # Waits for Elasticsearch to be available and creates the user 'kibana_user', if it doesn't exists
 # Globals:
 #   KIBANA_*
@@ -252,20 +235,12 @@ kibana_initialize() {
                 kibana_conf_set "server.ssl.certificate" "$SERVER_CERT_LOCATION"
                 kibana_conf_set "server.ssl.key" "$SERVER_KEY_LOCATION"
                 if ! is_empty_value "$SERVER_KEY_PASSWORD"; then
-                    if [[ "$SERVER_FLAVOR" = "opensearch-dashboards" ]]; then
-                        kibana_conf_set "server.ssl.keyPassphrase" "$SERVER_KEY_PASSWORD"
-                    else
-                        kibana_set_key_value "server.ssl.keyPassphrase" "$SERVER_KEY_PASSWORD"
-                    fi
+                    kibana_conf_set "server.ssl.keyPassphrase" "$SERVER_KEY_PASSWORD"
                 fi
             else
                 kibana_conf_set "server.ssl.keystore.path" "$SERVER_KEYSTORE_LOCATION"
                 if ! is_empty_value "$SERVER_KEYSTORE_PASSWORD"; then
-                    if [[ "$SERVER_FLAVOR" = "opensearch-dashboards" ]]; then
-                        kibana_conf_set "server.ssl.keystore.password" "$SERVER_KEY_PASSWORD"
-                    else
-                        kibana_set_key_value "server.ssl.keystore.password" "$SERVER_KEY_PASSWORD"
-                    fi
+                    kibana_conf_set "server.ssl.keystore.password" "$SERVER_KEYSTORE_PASSWORD"
                 fi
             fi
         fi
@@ -279,11 +254,7 @@ kibana_initialize() {
                 else
                     kibana_conf_set "${dbFlavor}.ssl.truststore.path" "$SERVER_DB_TRUSTSTORE_LOCATION"
                     if ! is_empty_value "$SERVER_DB_TRUSTSTORE_PASSWORD"; then
-                        if [[ "$SERVER_FLAVOR" = "opensearch-dashboards" ]]; then
-                            kibana_conf_set "${dbFlavor}.ssl.truststore.password" "$SERVER_DB_TRUSTSTORE_PASSWORD"
-                        else
-                            kibana_set_key_value "${dbFlavor}.ssl.truststore.password" "$SERVER_DB_TRUSTSTORE_PASSWORD"
-                        fi
+                        kibana_conf_set "${dbFlavor}.ssl.truststore.password" "$SERVER_DB_TRUSTSTORE_PASSWORD"
                     fi
                 fi
             fi


### PR DESCRIPTION
### Description of the change

remove unsable function `kibana_set_key_value` function and move to `kibana_conf_set` in `containers/bitnami/kibana/8/debian-12/rootfs/opt/bitnami/scripts/libkibana.sh`

### Possible drawbacks

- have to configure the `keystore-password` in kibana.yaml might expose security concern or somethings related.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #76379

### Additional information

- this #76379 causing unable to use binami/kibana images with Java Keystore Configuration the full Issues report is in refer issue
- I have already tesing in my local environment and its work properly as expects
- keystore password configuration is exists on kibana.yaml
```yaml
path:
  data: /bitnami/kibana/data
pid:
  file: /opt/bitnami/kibana/tmp/kibana.pid
server:
  host: 0.0.0.0
  port: 5061
  ssl:
    enabled: true
    keystore:
      path: /opt/bitnami/kibana/config/certs/kibana.keystore.p12
      password: kibana-password
elasticsearch:
  hosts: https://elasticsearch:9200
  username: kibana_system
  password: kibana
  ssl:
    verificationMode: certificate
    truststore:
      path: /opt/bitnami/kibana/config/certs/elasticsearch.truststore.p12
      password: elasticsearch-password
```
and no Error logs exist on starting container process
- ENV in images build testing process
```.env
KIBANA_ELASTICSEARCH_URL: elasticsearch
KIBANA_ELASTICSEARCH_PORT_NUMBER: 9200
KIBANA_PASSWORD: kibana
KIBANA_PORT_NUMBER: 5061
KIBANA_SERVER_ENABLE_TLS: true
KIBANA_ELASTICSEARCH_ENABLE_TLS: true
KIBANA_ELASTICSEARCH_TLS_VERIFICATION_MODE: certificate
KIBANA_ELASTICSEARCH_TRUSTSTORE_LOCATION: /opt/bitnami/kibana/config/certs/elasticsearch.truststore.p12
KIBANA_ELASTICSEARCH_TRUSTSTORE_PASSWORD: elasticsearch-password
KIBANA_ELASTICSEARCH_TLS_USE_PEM: false
KIBANA_SERVER_KEYSTORE_LOCATION: /opt/bitnami/kibana/config/certs/kibana.keystore.p12
KIBANA_SERVER_KEYSTORE_PASSWORD: kibana-password
```

- I'm quite new here if there anythings unclear or need more information, feel free to reach me anytime.
