### PR TITLE
[bitnami/php-fpm-min] Add Goss test

### DIFF
--- a/.vib/php-fpm-min/goss/goss.yaml
+++ b/.vib/php-fpm-min/goss/goss.yaml
@@ -1,0 +1,12 @@
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+gossfile:
+  # Goss tests exclusive to the current container
+  ../../php-fpm-min/goss/php-fpm-min.yaml: {}
+  # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-app-version-no-shell-stdout.yaml: {}
+  ../../common/goss/templates/check-ca-certs.yaml: {}
+  ../../common/goss/templates/check-files.yaml: {}
+  ../../common/goss/templates/check-minimal.yaml: {}
+  ../../common/goss/templates/check-openssl-fips.yaml: {}

--- a/.vib/php-fpm-min/goss/php-fpm-min.yaml
+++ b/.vib/php-fpm-min/goss/php-fpm-min.yaml
@@ -1,0 +1,6 @@
+process:
+  php-fpm:
+    running: true
+port:
+  tcp6:9000:
+    listening: true

--- a/.vib/php-fpm-min/goss/vars.yaml
+++ b/.vib/php-fpm-min/goss/vars.yaml
@@ -1,0 +1,9 @@
+files:
+  - mode: "0644"
+    paths:
+      - /opt/bitnami/php/.spdx-php-min.spdx
+      - /opt/bitnami/php/tmp/php-fpm.pid
+      - /opt/bitnami/php/etc/php-fpm.conf
+version:
+  bin_name: php-fpm
+  flag: --version

--- a/.vib/php-fpm-min/vib-verify.json
+++ b/.vib/php-fpm-min/vib-verify.json
@@ -34,6 +34,21 @@
     "verify": {
       "actions": [
         {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "php-fpm-min/goss/goss.yaml",
+            "vars_file": "php-fpm-min/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-php-fpm-min"
+              }
+            }
+          }
+        },
+        {
           "action_id": "trivy",
           "params": {
             "threshold": "LOW",


### PR DESCRIPTION
### Description of the change

This PR adds basic Goss tests for `php-fpm-min` that ensures expected files and directories exist, the version is correct, the SPDX file is available and expected port and process are in used.