### PR TITLE
fix(goss): Remove wait-for-port from checked binaries

### DIFF
--- a/.vib/minio/goss/vars.yaml
+++ b/.vib/minio/goss/vars.yaml
@@ -1,7 +1,6 @@
 binaries:
   - minio
   - mc
-  - wait-for-port
 directories:
   - mode: "0775"
     paths:


### PR DESCRIPTION
### Description of the change

wait-for-port was recently removed from the components of MinIO. Does not make sense to continue checking it.

### Benefits

Pass the tests properly.

### Possible drawbacks

None
