### PR TITLE
[bitnmi/java-min] bugfix: amend runtime parameters for vib verify

### DIFF
--- a/.vib/java-min/vib-verify.json
+++ b/.vib/java-min/vib-verify.json
@@ -4,7 +4,7 @@
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
     },
-    "runtime_parameters": "Y29tbWFuZDogWyJqd2Vic2VydmVyIiwgImIiLCAiMC4wLjAuMCJdCg=="
+    "runtime_parameters": "Y29tbWFuZDogWyJqd2Vic2VydmVyIiwgIi1iIiwgIjAuMC4wLjAiXQo="
   },
   "phases": {
     "package": {


### PR DESCRIPTION
### Description of the change

Fix typo on  runtime parameters for `java-min`:

```diff
-command: ["jwebserver", "b", "0.0.0.0"]`
+command: ["jwebserver", "-b", "0.0.0.0"]`
```
