### PR TITLE
[bitnami/zookeeper] fix for stale openssl commands

### DIFF
--- a/bitnami/zookeeper/3.9/debian-12/rootfs/opt/bitnami/scripts/libzookeeper.sh
+++ b/bitnami/zookeeper/3.9/debian-12/rootfs/opt/bitnami/scripts/libzookeeper.sh
@@ -597,7 +597,7 @@ zookeeper_healthcheck() {
     local args=()
     local port="$ZOO_PORT_NUMBER"
 
-    if [[ "$ZOO_TLS_CLIENT_ENABLE" = true ]]; then
+    if [[ "$ZOO_TLS_CLIENT_ENABLE" = true ]] && is_boolean_yes "$ZOOKEEPER_ENABLE_AUTH"; then
         port="$ZOO_TLS_PORT_NUMBER"
         command="openssl"
         args+=("s_client" "-quiet" "-crlf" "-connect" "localhost:${port}")


### PR DESCRIPTION
This fix will avoid performing openssl commands that will become a zombie if openssl is configured but no auth (mutual ssl) is set in the health check.

Related to https://github.com/bitnami/charts/issues/29603