### PR TITLE
[bitnami/openldap] DOCS: Stop recommending broken image in README

### DIFF
--- a/bitnami/openldap/README.md
+++ b/bitnami/openldap/README.md
@@ -137,7 +137,7 @@ networks:
     driver: bridge
 services:
   openldap:
-    image: bitnami/openldap:2
+    image: bitnami/openldap:2.6
     ports:
       - '1389:1389'
       - '1636:1636'


### PR DESCRIPTION
The tag '2' refers to a [broken image from four years ago](https://hub.docker.com/layers/bitnami/openldap/2/images/sha256-c488d388efd1c663a4777e4ca3267cf624af22b212c1845533b5bcd57f210e6d). Attempting to run it will give the following error messages. At least on macOS.

```
 ! openldap The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested                                                                   0.0s 
[...]
openldap-1   | 67a1d936 @(#) $OpenLDAP: slapd 2.4.58 (Mar 17 2021 00:19:19) $
openldap-1   |  @0a164ab8b404:/bitnami/blacksmith-sandox/openldap-2.4.58/servers/slapd
openldap-1   | 67a1d936 lt_dlopenext failed: (pw-sha2.so) file not found
openldap-1   | 67a1d936 config error processing cn=module{0},cn=config: <olcModuleLoad> handler exited with 1
openldap-1   | 67a1d936 slapd stopped.
openldap-1   | 67a1d936 connections_destroy: nothing to destroy.
openldap-1 exited with code 1
```

Upgrading the [reference to 2.6 (aka latest)](https://hub.docker.com/layers/bitnami/openldap/2.6/images/sha256-549fe416c8dbff1d3a8feb1489853af80b8134360eb63584c12172cbbc1ab2a9) at the moment will make the errors go away.

Not sure why, but probably something fixed in the past. 

It could of course also be argued that Bitnami should change their tagging policy as it could be expected that the 2 tag would point to latest 2.x.x, but that will be a huge project, so this is an easier change.