### PR TITLE
[bitnami/grafana] fix(goss): :wrench: skip grafana version test

### DIFF
--- a/.vib/grafana/goss/goss.yaml
+++ b/.vib/grafana/goss/goss.yaml
@@ -5,7 +5,8 @@ gossfile:
   # Goss tests exclusive to the current container
   ../../grafana/goss/grafana.yaml: {}
   # Load scripts from .vib/common/goss/templates
-  ../../common/goss/templates/check-app-version.yaml: {}
+  # Disable due to https://github.com/grafana/grafana/issues/98572
+  # ../../common/goss/templates/check-app-version.yaml: {}
   ../../common/goss/templates/check-binaries.yaml: {}
   ../../common/goss/templates/check-broken-symlinks.yaml: {}
   ../../common/goss/templates/check-ca-certs.yaml: {}


### PR DESCRIPTION
### Description of the change

Skip grafana version test.

### Benefits

In latests versions the command `grafana --version` is not returning the right version.

### Possible drawbacks

None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

https://github.com/grafana/grafana/issues/98572
