### PR TITLE
[bitnami/openldap] DOCS: Add instructions for verifying that the service is working

### DIFF
--- a/bitnami/openldap/README.md
+++ b/bitnami/openldap/README.md
@@ -170,6 +170,12 @@ Launch the containers using:
 docker-compose up -d
 ```
 
+Verify that LDAP service is accessible with:
+
+```console
+ldapsearch -x -H ldap://localhost:1389 -D "cn=admin,dc=example,dc=org" -w adminpassword -b "dc=example,dc=org"
+```
+
 ## Configuration
 
 The Bitnami Docker OpenLDAP can be easily setup with the following environment variables:


### PR DESCRIPTION
Resolves https://github.com/bitnami/containers/issues/76862 . This however implies that the option `LDAP_ROOT` doesn't do anything. Another finding is that the referenced option `LDAP_ADMIN_DN` is undocumented in this README.