### PR TITLE
[bitnami/mariadb] fix healthcheck during initialization using skip-networking

### DIFF
--- a/bitnami/mariadb/10.11/debian-12/rootfs/opt/bitnami/scripts/libmariadb.sh
+++ b/bitnami/mariadb/10.11/debian-12/rootfs/opt/bitnami/scripts/libmariadb.sh
@@ -445,7 +445,7 @@ mysql_start_bg() {
     local -a flags=("--defaults-file=${DB_CONF_FILE}" "--basedir=${DB_BASE_DIR}" "--datadir=${DB_DATA_DIR}" "--socket=${DB_SOCKET_FILE}")
 
     # Only allow local connections until MySQL is fully initialized, to avoid apps trying to connect to MySQL before it is fully initialized
-    flags+=("--bind-address=127.0.0.1")
+    flags+=("--skip-networking")
 
     # Add flags specified via the 'DB_EXTRA_FLAGS' environment variable
     read -r -a db_extra_flags <<< "$(mysql_extra_flags)"


### PR DESCRIPTION
### Description of the change

With this change, mariadb starts with `--skip-networking` option during initialization. 

### Benefits

Without networing, `healtcheck.sh` script can not connect to mysql and fails, which is necessary when having a lot of init scripts (which can take one minute to run)

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes  #76241

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
