### PR TITLE
[bitnami/java-min] tests: use /shared/busybox to sleep

### DIFF
--- a/.vib/java-min/goss/java-min.yaml
+++ b/.vib/java-min/goss/java-min.yaml
@@ -15,12 +15,6 @@ command:
     exit-status: 0
     stdout:
     - "Hello World"
-process:
-  jwebserver:
-    running: true
-port:
-  tcp6:8000:
-    listening: true
 {{- $releaseFile := readFile "/etc/os-release" }}
 {{- if contains "photon" $releaseFile }}
 file:

--- a/.vib/java-min/goss/vars.yaml
+++ b/.vib/java-min/goss/vars.yaml
@@ -8,6 +8,5 @@ files:
       - /opt/bitnami/java/bin/java
       - /opt/bitnami/java/bin/jfr
       - /opt/bitnami/java/bin/jrunscript
-      - /opt/bitnami/java/bin/jwebserver
       - /opt/bitnami/java/bin/keytool
       - /opt/bitnami/java/bin/rmiregistry

--- a/.vib/java-min/vib-verify.json
+++ b/.vib/java-min/vib-verify.json
@@ -35,6 +35,21 @@
     "verify": {
       "actions": [
         {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "java-min/goss/goss.yaml",
+            "vars_file": "java-min/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-java-min"
+              }
+            }
+          }
+        },
+        {
           "action_id": "trivy",
           "params": {
             "threshold": "LOW",

--- a/.vib/java-min/vib-verify.json
+++ b/.vib/java-min/vib-verify.json
@@ -4,7 +4,7 @@
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
     },
-    "runtime_parameters": "Y29tbWFuZDogWyJqd2Vic2VydmVyIiwgIi1iIiwgIjAuMC4wLjAiXQo="
+    "runtime_parameters": "Y29tbWFuZDogWyIvc2hhcmVkL2J1c3lib3giLCAic2xlZXAiLCAiMzAiXQo="
   },
   "phases": {
     "package": {

--- a/.vib/java-min/vib-verify.json
+++ b/.vib/java-min/vib-verify.json
@@ -4,7 +4,7 @@
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
     },
-    "runtime_parameters": "Y29tbWFuZDogWyIvc2hhcmVkL2J1c3lib3giLCAic2xlZXAiLCAiMzAiXQo="
+    "runtime_parameters": "Y29tbWFuZDogWyIvc2hhcmVkL2J1c3lib3giLCAic2xlZXAiLCAiMzYwMCJdCg=="
   },
   "phases": {
     "package": {


### PR DESCRIPTION
### Description of the change

This PR reverts 5d3a9dc06acf2e41b64971f27cd42f4d99924297 and replaces then runtime parameters to use so we use `sleep 3600` to start the container and keep it running while we rung Goss tests:

```console
$ echo 'command: ["/shared/busybox", "sleep", "3600"]' | base64
Y29tbWFuZDogWyIvc2hhcmVkL2J1c3lib3giLCAic2xlZXAiLCAiMzYwMCJdCg==
```

It also removes some checks that only applied to Java 23 when using `jwebserver` to start the container

### Benefits

CI to test java-min

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A