### PR TITLE
[bitnami/java-min] bugfix: use the right flag for java 1.8

### DIFF
--- a/.vib/java-min/goss/java-min.yaml
+++ b/.vib/java-min/goss/java-min.yaml
@@ -2,11 +2,19 @@ command:
   check-java-version:
     exec:
     - java
+    {{- if regexMatch "^1.8.+" .Env.APP_VERSION }}
     - --version
     exit-status: 0
     # Replace "-" with "+" in the version string
     stdout:
     - {{ .Env.APP_VERSION | replace "-" "+" }}
+    {{- else }}
+    - -version
+    exit-status: 0
+    # Replace "-" with "_" in the version string
+    stdout:
+    - {{ .Env.APP_VERSION | replace "-" "_" }}
+    {{- end }}
   check-hello-world:
     exec:
     - java


### PR DESCRIPTION
### Description of the change

This PR updates the `check-java-version` goss test so a different flag is used for this version.