### PR TITLE
[bitnami/*] feat: Enable Goss tests for several scratch images

### DIFF
--- a/.vib/charts-syncer/goss/charts-syncer.yaml
+++ b/.vib/charts-syncer/goss/charts-syncer.yaml
@@ -1,0 +1,8 @@
+command:
+  check-charts-syncer-help:
+    exec:
+    - /charts-syncer
+    - --help
+    exit-status: 0
+    stdout:
+    - "charts-syncer [command]"

--- a/.vib/charts-syncer/goss/goss.yaml
+++ b/.vib/charts-syncer/goss/goss.yaml
@@ -1,0 +1,10 @@
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+gossfile:
+  # Goss tests exclusive to the current container
+  ../../charts-syncer/goss/charts-syncer.yaml: {}
+  # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-app-version-no-shell-stdout.yaml: {}
+  ../../common/goss/templates/check-ca-certs.yaml: {}
+  ../../common/goss/templates/check-files.yaml: {}

--- a/.vib/charts-syncer/goss/vars.yaml
+++ b/.vib/charts-syncer/goss/vars.yaml
@@ -1,0 +1,10 @@
+files:
+  - mode: "0644"
+    paths:
+      - /opt/bitnami/charts-syncer/.spdx-charts-syncer.spdx
+  - mode: "0755"
+    paths:
+      - /charts-syncer
+version:
+  bin_name: /charts-syncer
+  flag: version

--- a/.vib/charts-syncer/vib-verify.json
+++ b/.vib/charts-syncer/vib-verify.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyIvc2hhcmVkL2J1c3lib3giLCAic2xlZXAiLCAiMzYwMCJdCg=="
   },
   "phases": {
     "package": {
@@ -33,6 +34,21 @@
     },
     "verify": {
       "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "charts-syncer/goss/goss.yaml",
+            "vars_file": "charts-syncer/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-charts-syncer"
+              }
+            }
+          }
+        },
         {
           "action_id": "trivy",
           "params": {

--- a/.vib/kubeapps-apprepository-controller/goss/goss.yaml
+++ b/.vib/kubeapps-apprepository-controller/goss/goss.yaml
@@ -1,0 +1,10 @@
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+gossfile:
+  # Goss tests exclusive to the current container
+  ../../kubeapps-apprepository-controller/goss/kubeapps-apprepository-controller.yaml: {}
+  # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-app-version-no-shell-stdout.yaml: {}
+  ../../common/goss/templates/check-ca-certs.yaml: {}
+  ../../common/goss/templates/check-files.yaml: {}

--- a/.vib/kubeapps-apprepository-controller/goss/kubeapps-apprepository-controller.yaml
+++ b/.vib/kubeapps-apprepository-controller/goss/kubeapps-apprepository-controller.yaml
@@ -1,0 +1,8 @@
+command:
+  check-apprepository-controller-help:
+    exec:
+    - /apprepository-controller
+    - --help
+    exit-status: 0
+    stdout:
+    - "apprepository-controller [flags]"

--- a/.vib/kubeapps-apprepository-controller/goss/vars.yaml
+++ b/.vib/kubeapps-apprepository-controller/goss/vars.yaml
@@ -1,0 +1,10 @@
+files:
+  - mode: "0644"
+    paths:
+      - /opt/bitnami/kubeapps-apprepository-controller/.spdx-kubeapps-apprepository-controller.spdx
+  - mode: "0755"
+    paths:
+      - /apprepository-controller
+version:
+  bin_name: /apprepository-controller
+  flag: --version

--- a/.vib/kubeapps-apprepository-controller/vib-verify.json
+++ b/.vib/kubeapps-apprepository-controller/vib-verify.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyIvc2hhcmVkL2J1c3lib3giLCAic2xlZXAiLCAiMzYwMCJdCg=="
   },
   "phases": {
     "package": {
@@ -33,6 +34,21 @@
     },
     "verify": {
       "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "kubeapps-apprepository-controller/goss/goss.yaml",
+            "vars_file": "kubeapps-apprepository-controller/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-kubeapps-apprepository-controller"
+              }
+            }
+          }
+        },
         {
           "action_id": "trivy",
           "params": {

--- a/.vib/kubeapps-asset-syncer/goss/goss.yaml
+++ b/.vib/kubeapps-asset-syncer/goss/goss.yaml
@@ -1,0 +1,10 @@
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+gossfile:
+  # Goss tests exclusive to the current container
+  ../../kubeapps-asset-syncer/goss/kubeapps-asset-syncer.yaml: {}
+  # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-app-version-no-shell-stdout.yaml: {}
+  ../../common/goss/templates/check-ca-certs.yaml: {}
+  ../../common/goss/templates/check-files.yaml: {}

--- a/.vib/kubeapps-asset-syncer/goss/kubeapps-asset-syncer.yaml
+++ b/.vib/kubeapps-asset-syncer/goss/kubeapps-asset-syncer.yaml
@@ -1,0 +1,8 @@
+command:
+  check-asset-syncer-help:
+    exec:
+    - /asset-syncer
+    - --help
+    exit-status: 0
+    stdout:
+    - "asset-syncer [flags]"

--- a/.vib/kubeapps-asset-syncer/goss/vars.yaml
+++ b/.vib/kubeapps-asset-syncer/goss/vars.yaml
@@ -1,0 +1,10 @@
+files:
+  - mode: "0644"
+    paths:
+      - /opt/bitnami/kubeapps-asset-syncer/.spdx-kubeapps-asset-syncer.spdx
+  - mode: "0755"
+    paths:
+      - /asset-syncer
+version:
+  bin_name: /asset-syncer
+  flag: --version

--- a/.vib/kubeapps-asset-syncer/vib-verify.json
+++ b/.vib/kubeapps-asset-syncer/vib-verify.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyIvc2hhcmVkL2J1c3lib3giLCAic2xlZXAiLCAiMzYwMCJdCg=="
   },
   "phases": {
     "package": {
@@ -33,6 +34,21 @@
     },
     "verify": {
       "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "kubeapps-asset-syncer/goss/goss.yaml",
+            "vars_file": "kubeapps-asset-syncer/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-kubeapps-asset-syncer"
+              }
+            }
+          }
+        },
         {
           "action_id": "trivy",
           "params": {

--- a/.vib/oras/goss/goss.yaml
+++ b/.vib/oras/goss/goss.yaml
@@ -1,0 +1,10 @@
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+gossfile:
+  # Goss tests exclusive to the current container
+  ../../oras/goss/oras.yaml: {}
+  # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-app-version-no-shell-stdout.yaml: {}
+  ../../common/goss/templates/check-ca-certs.yaml: {}
+  ../../common/goss/templates/check-files.yaml: {}

--- a/.vib/oras/goss/oras.yaml
+++ b/.vib/oras/goss/oras.yaml
@@ -1,0 +1,8 @@
+command:
+  check-oras-help:
+    exec:
+    - /oras
+    - help
+    exit-status: 0
+    stdout:
+    - "oras [command]"

--- a/.vib/oras/goss/vars.yaml
+++ b/.vib/oras/goss/vars.yaml
@@ -1,0 +1,10 @@
+files:
+  - mode: "0644"
+    paths:
+      - /opt/bitnami/oras/.spdx-oras.spdx
+  - mode: "0755"
+    paths:
+      - /oras
+version:
+  bin_name: /oras
+  flag: version

--- a/.vib/oras/vib-verify.json
+++ b/.vib/oras/vib-verify.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyIvc2hhcmVkL2J1c3lib3giLCAic2xlZXAiLCAiMzYwMCJdCg=="
   },
   "phases": {
     "package": {
@@ -33,6 +34,21 @@
     },
     "verify": {
       "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "oras/goss/goss.yaml",
+            "vars_file": "oras/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-oras"
+              }
+            }
+          }
+        },
         {
           "action_id": "trivy",
           "params": {

--- a/.vib/sealed-secrets-controller/goss/goss.yaml
+++ b/.vib/sealed-secrets-controller/goss/goss.yaml
@@ -1,0 +1,10 @@
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+gossfile:
+  # Goss tests exclusive to the current container
+  ../../sealed-secrets-controller/goss/sealed-secrets-controller.yaml: {}
+  # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-app-version-no-shell-stdout.yaml: {}
+  ../../common/goss/templates/check-ca-certs.yaml: {}
+  ../../common/goss/templates/check-files.yaml: {}

--- a/.vib/sealed-secrets-controller/goss/sealed-secrets-controller.yaml
+++ b/.vib/sealed-secrets-controller/goss/sealed-secrets-controller.yaml
@@ -1,0 +1,8 @@
+command:
+  check-controller-help:
+    exec:
+    - /controller
+    - --help
+    exit-status: 0
+    stdout:
+    - "Usage of /controller"

--- a/.vib/sealed-secrets-controller/goss/vars.yaml
+++ b/.vib/sealed-secrets-controller/goss/vars.yaml
@@ -1,0 +1,10 @@
+files:
+  - mode: "0644"
+    paths:
+      - /opt/bitnami/sealed-secrets/.spdx-sealed-secrets.spdx
+  - mode: "0755"
+    paths:
+      - /controller
+version:
+  bin_name: /controller
+  flag: --version

--- a/.vib/sealed-secrets-controller/vib-verify.json
+++ b/.vib/sealed-secrets-controller/vib-verify.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyIvc2hhcmVkL2J1c3lib3giLCAic2xlZXAiLCAiMzYwMCJdCg=="
   },
   "phases": {
     "package": {
@@ -33,6 +34,21 @@
     },
     "verify": {
       "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "sealed-secrets-controller/goss/goss.yaml",
+            "vars_file": "sealed-secrets-controller/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-sealed-secrets-controller"
+              }
+            }
+          }
+        },
         {
           "action_id": "trivy",
           "params": {

--- a/.vib/sealed-secrets-kubeseal/goss/goss.yaml
+++ b/.vib/sealed-secrets-kubeseal/goss/goss.yaml
@@ -1,0 +1,10 @@
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+gossfile:
+  # Goss tests exclusive to the current container
+  ../../sealed-secrets-kubeseal/goss/sealed-secrets-kubeseal.yaml: {}
+  # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-app-version-no-shell-stdout.yaml: {}
+  ../../common/goss/templates/check-ca-certs.yaml: {}
+  ../../common/goss/templates/check-files.yaml: {}

--- a/.vib/sealed-secrets-kubeseal/goss/sealed-secrets-kubeseal.yaml
+++ b/.vib/sealed-secrets-kubeseal/goss/sealed-secrets-kubeseal.yaml
@@ -1,0 +1,8 @@
+command:
+  check-kubeseal-help:
+    exec:
+    - /kubeseal
+    - --help
+    exit-status: 0
+    stdout:
+    - "Usage of /kubeseal"

--- a/.vib/sealed-secrets-kubeseal/goss/vars.yaml
+++ b/.vib/sealed-secrets-kubeseal/goss/vars.yaml
@@ -1,0 +1,10 @@
+files:
+  - mode: "0644"
+    paths:
+      - /opt/bitnami/sealed-secrets/.spdx-sealed-secrets.spdx
+  - mode: "0755"
+    paths:
+      - /kubeseal
+version:
+  bin_name: /kubeseal
+  flag: --version

--- a/.vib/sealed-secrets-kubeseal/vib-verify.json
+++ b/.vib/sealed-secrets-kubeseal/vib-verify.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyIvc2hhcmVkL2J1c3lib3giLCAic2xlZXAiLCAiMzYwMCJdCg=="
   },
   "phases": {
     "package": {
@@ -33,6 +34,21 @@
     },
     "verify": {
       "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "sealed-secrets-kubeseal/goss/goss.yaml",
+            "vars_file": "sealed-secrets-kubeseal/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-sealed-secrets-kubeseal"
+              }
+            }
+          }
+        },
         {
           "action_id": "trivy",
           "params": {


### PR DESCRIPTION
## Description of the change

This PR enables basic Goss tests for a few scratch images:

- charts-syncer
- kubeapps-apprepository-controller
- kubeapps-asset-syncer
- oras
- sealed-secrets-controller
- sealed-secrets-kubeseal