### PR TITLE
[bitnami/aspnet-min] bugfix: goss tests

### DIFF
--- a/.vib/aspnet-min/goss/aspnet-min.yaml
+++ b/.vib/aspnet-min/goss/aspnet-min.yaml
@@ -3,6 +3,6 @@ command:
     exec:
     - dotnet
     - --help
-    exit-status: 0
+    exit-status: 129
     stdout:
     - "Usage: dotnet [host-options] [path-to-application]"

--- a/.vib/aspnet-min/goss/vars.yaml
+++ b/.vib/aspnet-min/goss/vars.yaml
@@ -2,7 +2,7 @@ files:
   - mode: "0644"
     paths:
       - /opt/bitnami/os/.spdx-os-aspnet-min.spdx
-      - /opt/bitnami/aspnet/.spdx-aspnet.spdx
+      - /opt/bitnami/aspnet/.spdx-aspnet-min.spdx
   - mode: "0755"
     paths:
       - /opt/bitnami/aspnet/bin/dotnet


### PR DESCRIPTION
### Description of the change

Fix bug introduced at https://github.com/bitnami/containers/pull/77077 given the exit status when running `dotnet --help` is actually `129`. Also, the SPDX file path was wrong.