### PR TITLE
[bitnami/java-min] Fix goss tests

### DIFF
--- a/.vib/java-min/goss/java-min.yaml
+++ b/.vib/java-min/goss/java-min.yaml
@@ -3,17 +3,17 @@ command:
     exec:
     - java
     {{- if regexMatch "^1.8.+" .Env.APP_VERSION }}
-    - --version
-    exit-status: 0
-    # Replace "-" with "+" in the version string
-    stdout:
-    - {{ .Env.APP_VERSION | replace "-" "+" }}
-    {{- else }}
     - -version
     exit-status: 0
     # Replace "-" with "_" in the version string
     stdout:
     - {{ .Env.APP_VERSION | replace "-" "_" }}
+    {{- else }}
+    - --version
+    exit-status: 0
+    # Replace "-" with "+" in the version string
+    stdout:
+    - {{ .Env.APP_VERSION | replace "-" "+" }}
     {{- end }}
   check-hello-world:
     exec:


### PR DESCRIPTION
### Description of the change

At https://github.com/bitnami/containers/pull/77078 we introduce a condition to switch the version flag to use for Java 1.8. However, the condition was wrong and we need to switch if/else blocks.