### PR TITLE
Update libopenldap.sh group DN to fix issue 19716

### DIFF
--- a/bitnami/openldap/2.6/debian-12/rootfs/opt/bitnami/scripts/libopenldap.sh
+++ b/bitnami/openldap/2.6/debian-12/rootfs/opt/bitnami/scripts/libopenldap.sh
@@ -576,7 +576,7 @@ EOF
     done
     cat >> "${LDAP_SHARE_DIR}/tree.ldif" << EOF
 # Group creation
-dn: ${LDAP_GROUP/#/cn=},${LDAP_USER_OU/#/ou=},${LDAP_ROOT}
+dn: ${LDAP_GROUP/#/cn=},${LDAP_GROUP_OU/#/ou=},${LDAP_ROOT}
 cn: $LDAP_GROUP
 objectClass: groupOfNames
 # User group membership


### PR DESCRIPTION

### Description of the change

Fix remaining bug leading to groups being in the LDAP_USER_OU instead of LDAP_GROUP_OU. 
### Benefits

Groups are under ou=groups,dc=example,dc=org instead of ou=users,dc=example,dc=org, which should only contain users.

### Possible drawbacks

Maybe backward compatability issues, but they can specify LDAP_GROUP_OU=users to get the old, bad behavior.

### Applicable issues

- fixes #19716


### Additional information

The fixes that were already made referencing the issue did not actually fix the problem:
https://github.com/bitnami/containers/issues/19716#issuecomment-2644348870
