### PR TITLE
[bitnami/grafana] don't error out on read-only config dir

### DIFF
--- a/bitnami/grafana/11/debian-12/rootfs/opt/bitnami/scripts/grafana/entrypoint.sh
+++ b/bitnami/grafana/11/debian-12/rootfs/opt/bitnami/scripts/grafana/entrypoint.sh
@@ -30,9 +30,9 @@ print_welcome_page
 
 # We add the copy from default config in the entrypoint to not break users
 # bypassing the setup.sh logic. If the file already exists do not overwrite (in
-# case someone mounts a configuration file in /opt/bitnami/postgresql/conf)
+# case someone mounts a configuration file in /opt/bitnami/grafana/conf).
 debug "Copying files from $GRAFANA_DEFAULT_CONF_DIR to $GRAFANA_CONF_DIR"
-cp -nr "$GRAFANA_DEFAULT_CONF_DIR"/. "$GRAFANA_CONF_DIR"
+cp -nr "$GRAFANA_DEFAULT_CONF_DIR"/. "$GRAFANA_CONF_DIR" || true
 
 if [[ "$1" = "/opt/bitnami/scripts/grafana/run.sh" ]] || ! is_exec "$1"; then
     # This catches the error-code from libgrafana.sh for the immediate exit when the grafana-operator is used. And ensure that the exit code is kept silently.


### PR DESCRIPTION
### Description of the change

Errors when copying the example configuration files to the Grafana config dir are now ignored.

### Benefits

The Grafana config dir as a whole or subdirectories may become read-only to the container, e.g. when mounting configmaps or secrets. Currently, these configurations require overwriting the entrypoint, which is undesirable.

### Possible drawbacks