### PR TITLE
[bitnami/nginx][bitnami/openresty] Update goss tests

### DIFF
--- a/.vib/nginx/goss/vars.yaml
+++ b/.vib/nginx/goss/vars.yaml
@@ -30,6 +30,7 @@ modules:
     - geoip2
     - substitutions-filter
     - vts
+    - http-dav
   enabled:
     - http_stub_status
     - http_gzip_static
@@ -40,7 +41,6 @@ modules:
     - mail_ssl
     - http_gunzip
     - http_auth_request
-    - http_dav
     - http_sub
     - http_geoip
     - stream_realip

--- a/.vib/openresty/goss/openresty.yaml
+++ b/.vib/openresty/goss/openresty.yaml
@@ -44,5 +44,12 @@ command:
     exec: openresty -V 2>&1
     exit-status: 0
     stdout:
-      - "pcre-jit"
-      - "compat"
+    {{ range $added_module := .Vars.modules.added }}
+      - "nginx-module-{{ $added_module }}"
+    {{ end }}
+    {{ range $enabled_module := .Vars.modules.enabled }}
+      - "with-{{ $enabled_module }}_module"
+    {{ end }}
+    {{ range $additional_config := .Vars.config_opts }}
+      - "with-{{ $additional_config }}"
+    {{ end }}

--- a/.vib/openresty/goss/vars.yaml
+++ b/.vib/openresty/goss/vars.yaml
@@ -14,3 +14,23 @@ directories:
       - /docker-entrypoint-initdb.d
       - /home/openresty
 root_dir: /opt/bitnami
+config_opts:
+  - pcre-jit
+  - compat
+modules:
+  added:
+    - http-dav
+  enabled:
+    - http_stub_status
+    - http_gzip_static
+    - http_realip
+    - http_stub_status
+    - http_v2
+    - http_ssl
+    - mail_ssl
+    - http_gunzip
+    - http_auth_request
+    - http_sub
+    - http_geoip
+    - stream_realip
+    - stream_ssl


### PR DESCRIPTION
### Description of the change

Update Goss tests for NGINX and OpenResty now that the module `ngx_http_dav_module` is built as a dynamic module.