### PR TITLE
[bitnami/*] feat: Enable Goss tests for several scratch images - ii

### DIFF
--- a/.vib/argo-workflow-cli/goss/argo-workflow-cli.yaml
+++ b/.vib/argo-workflow-cli/goss/argo-workflow-cli.yaml
@@ -1,0 +1,9 @@
+command:
+  check-argo-help:
+    exec:
+    - /argo
+    - --help
+    exit-status: 0
+    stdout:
+    - "Usage:"
+    - "argo [flags]"

--- a/.vib/argo-workflow-cli/goss/goss.yaml
+++ b/.vib/argo-workflow-cli/goss/goss.yaml
@@ -1,0 +1,10 @@
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+gossfile:
+  # Goss tests exclusive to the current container
+  ../../argo-workflow-cli/goss/argo-workflow-cli.yaml: {}
+  # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-app-version-no-shell-stdout.yaml: {}
+  ../../common/goss/templates/check-ca-certs.yaml: {}
+  ../../common/goss/templates/check-files.yaml: {}

--- a/.vib/argo-workflow-cli/goss/vars.yaml
+++ b/.vib/argo-workflow-cli/goss/vars.yaml
@@ -1,0 +1,10 @@
+files:
+  - mode: "0644"
+    paths:
+      - /opt/bitnami/argo-workflows/.spdx-argo-workflows.spdx
+  - mode: "0755"
+    paths:
+      - /argo
+version:
+  bin_name: /argo
+  flag: version

--- a/.vib/argo-workflow-cli/vib-verify.json
+++ b/.vib/argo-workflow-cli/vib-verify.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyIvc2hhcmVkL2J1c3lib3giLCAic2xlZXAiLCAiMzYwMCJdCg=="
   },
   "phases": {
     "package": {
@@ -33,6 +34,21 @@
     },
     "verify": {
       "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "argo-workflow-cli/goss/goss.yaml",
+            "vars_file": "argo-workflow-cli/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-argo-workflow-cli"
+              }
+            }
+          }
+        },
         {
           "action_id": "trivy",
           "params": {

--- a/.vib/argo-workflow-controller/goss/argo-workflow-controller.yaml
+++ b/.vib/argo-workflow-controller/goss/argo-workflow-controller.yaml
@@ -1,0 +1,9 @@
+command:
+  check-workflow-controller-help:
+    exec:
+    - /workflow-controller
+    - --help
+    exit-status: 0
+    stdout:
+    - "Usage:"
+    - "workflow-controller [flags]"

--- a/.vib/argo-workflow-controller/goss/goss.yaml
+++ b/.vib/argo-workflow-controller/goss/goss.yaml
@@ -1,0 +1,10 @@
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+gossfile:
+  # Goss tests exclusive to the current container
+  ../../argo-workflow-controller/goss/argo-workflow-controller.yaml: {}
+  # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-app-version-no-shell-stdout.yaml: {}
+  ../../common/goss/templates/check-ca-certs.yaml: {}
+  ../../common/goss/templates/check-files.yaml: {}

--- a/.vib/argo-workflow-controller/goss/vars.yaml
+++ b/.vib/argo-workflow-controller/goss/vars.yaml
@@ -1,0 +1,10 @@
+files:
+  - mode: "0644"
+    paths:
+      - /opt/bitnami/argo-workflow-controller/.spdx-argo-workflow-controller.spdx
+  - mode: "0755"
+    paths:
+      - /workflow-controller
+version:
+  bin_name: /workflow-controller
+  flag: version

--- a/.vib/argo-workflow-controller/vib-verify.json
+++ b/.vib/argo-workflow-controller/vib-verify.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyIvc2hhcmVkL2J1c3lib3giLCAic2xlZXAiLCAiMzYwMCJdCg=="
   },
   "phases": {
     "package": {
@@ -33,6 +34,21 @@
     },
     "verify": {
       "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "argo-workflow-controller/goss/goss.yaml",
+            "vars_file": "argo-workflow-controller/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-argo-workflow-controller"
+              }
+            }
+          }
+        },
         {
           "action_id": "trivy",
           "params": {

--- a/.vib/chainloop-artifact-cas/goss/chainloop-artifact-cas.yaml
+++ b/.vib/chainloop-artifact-cas/goss/chainloop-artifact-cas.yaml
@@ -1,0 +1,8 @@
+command:
+  check-artifact-cas-help:
+    exec:
+    - /artifact-cas
+    - --help
+    exit-status: 0
+    stderr:
+    - "Usage of /artifact-cas"

--- a/.vib/chainloop-artifact-cas/goss/goss.yaml
+++ b/.vib/chainloop-artifact-cas/goss/goss.yaml
@@ -1,0 +1,9 @@
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+gossfile:
+  # Goss tests exclusive to the current container
+  ../../chainloop-artifact-cas/goss/chainloop-artifact-cas.yaml: {}
+  # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-ca-certs.yaml: {}
+  ../../common/goss/templates/check-files.yaml: {}

--- a/.vib/chainloop-artifact-cas/goss/vars.yaml
+++ b/.vib/chainloop-artifact-cas/goss/vars.yaml
@@ -1,0 +1,7 @@
+files:
+  - mode: "0644"
+    paths:
+      - /opt/bitnami/chainloop/.spdx-chainloop-artifact-cas.spdx
+  - mode: "0755"
+    paths:
+      - /artifact-cas

--- a/.vib/chainloop-artifact-cas/vib-verify.json
+++ b/.vib/chainloop-artifact-cas/vib-verify.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyIvc2hhcmVkL2J1c3lib3giLCAic2xlZXAiLCAiMzYwMCJdCg=="
   },
   "phases": {
     "package": {
@@ -33,6 +34,21 @@
     },
     "verify": {
       "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "chainloop-artifact-cas/goss/goss.yaml",
+            "vars_file": "chainloop-artifact-cas/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-chainloop-artifact-cas"
+              }
+            }
+          }
+        },
         {
           "action_id": "trivy",
           "params": {

--- a/.vib/chainloop-control-plane-migrations/goss/chainloop-control-plane-migrations.yaml
+++ b/.vib/chainloop-control-plane-migrations/goss/chainloop-control-plane-migrations.yaml
@@ -1,0 +1,8 @@
+command:
+  check-atlas-help:
+    exec:
+    - /atlas
+    - --help
+    exit-status: 0
+    stdout:
+    - "atlas [command]"

--- a/.vib/chainloop-control-plane-migrations/goss/goss.yaml
+++ b/.vib/chainloop-control-plane-migrations/goss/goss.yaml
@@ -1,0 +1,11 @@
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+gossfile:
+  # Goss tests exclusive to the current container
+  ../../chainloop-control-plane-migrations/goss/chainloop-control-plane-migrations.yaml: {}
+  # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-ca-certs.yaml: {}
+  ../../common/goss/templates/check-directories.yaml: {}
+  ../../common/goss/templates/check-files.yaml: {}
+

--- a/.vib/chainloop-control-plane-migrations/goss/vars.yaml
+++ b/.vib/chainloop-control-plane-migrations/goss/vars.yaml
@@ -1,0 +1,11 @@
+files:
+  - mode: "0644"
+    paths:
+      - /opt/bitnami/chainloop/.spdx-chainloop-control-plane-migrations.spdx
+  - mode: "0755"
+    paths:
+      - /atlas
+directories:
+  - mode: "0755"
+    paths:
+      - /migrations

--- a/.vib/chainloop-control-plane-migrations/vib-verify.json
+++ b/.vib/chainloop-control-plane-migrations/vib-verify.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyIvc2hhcmVkL2J1c3lib3giLCAic2xlZXAiLCAiMzYwMCJdCg=="
   },
   "phases": {
     "package": {
@@ -33,6 +34,21 @@
     },
     "verify": {
       "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "chainloop-control-plane-migrations/goss/goss.yaml",
+            "vars_file": "chainloop-control-plane-migrations/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-chainloop-control-plane-migrations"
+              }
+            }
+          }
+        },
         {
           "action_id": "trivy",
           "params": {

--- a/.vib/chainloop-control-plane/goss/chainloop-control-plane.yaml
+++ b/.vib/chainloop-control-plane/goss/chainloop-control-plane.yaml
@@ -1,0 +1,8 @@
+command:
+  check-control-plane-help:
+    exec:
+    - /control-plane
+    - --help
+    exit-status: 2
+    stderr:
+    - "Usage of /control-plane"

--- a/.vib/chainloop-control-plane/goss/goss.yaml
+++ b/.vib/chainloop-control-plane/goss/goss.yaml
@@ -1,0 +1,9 @@
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+gossfile:
+  # Goss tests exclusive to the current container
+  ../../chainloop-control-plane/goss/chainloop-control-plane.yaml: {}
+  # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-ca-certs.yaml: {}
+  ../../common/goss/templates/check-files.yaml: {}

--- a/.vib/chainloop-control-plane/goss/vars.yaml
+++ b/.vib/chainloop-control-plane/goss/vars.yaml
@@ -1,0 +1,7 @@
+files:
+  - mode: "0644"
+    paths:
+      - /opt/bitnami/chainloop/.spdx-chainloop.spdx
+  - mode: "0755"
+    paths:
+      - /control-plane

--- a/.vib/chainloop-control-plane/vib-verify.json
+++ b/.vib/chainloop-control-plane/vib-verify.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyIvc2hhcmVkL2J1c3lib3giLCAic2xlZXAiLCAiMzYwMCJdCg=="
   },
   "phases": {
     "package": {
@@ -33,6 +34,21 @@
     },
     "verify": {
       "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "chainloop-control-plane/goss/goss.yaml",
+            "vars_file": "chainloop-control-plane/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-chainloop-control-plane"
+              }
+            }
+          }
+        },
         {
           "action_id": "trivy",
           "params": {

--- a/.vib/kaniko/goss/goss.yaml
+++ b/.vib/kaniko/goss/goss.yaml
@@ -1,0 +1,10 @@
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+gossfile:
+  # Goss tests exclusive to the current container
+  ../../kaniko/goss/kaniko.yaml: {}
+  # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-app-version-no-shell-stdout.yaml: {}
+  ../../common/goss/templates/check-ca-certs.yaml: {}
+  ../../common/goss/templates/check-files.yaml: {}

--- a/.vib/kaniko/goss/kaniko.yaml
+++ b/.vib/kaniko/goss/kaniko.yaml
@@ -1,0 +1,17 @@
+command:
+  check-executor-help:
+    exec:
+    - /kaniko/executor
+    - --help
+    exit-status: 0
+    stdout:
+    - "Usage:"
+    - "executor [command]"
+  check-warmer-help:
+    exec:
+    - /kaniko/warmer
+    - --help
+    exit-status: 0
+    stdout:
+    - "Usage:"
+    - "cache warmer [flags]"

--- a/.vib/kaniko/goss/vars.yaml
+++ b/.vib/kaniko/goss/vars.yaml
@@ -1,0 +1,14 @@
+files:
+  - mode: "0644"
+    paths:
+      - /opt/bitnami/kaniko/.spdx-kaniko.spdx
+  - mode: "0755"
+    paths:
+      - /kaniko/docker-credential-acr-env
+      - /kaniko/docker-credential-ecr-login
+      - /kaniko/docker-credential-gcr
+      - /kaniko/executor
+      - /kaniko/warmer
+version:
+  bin_name: /kaniko/executor
+  flag: version

--- a/.vib/kaniko/vib-verify.json
+++ b/.vib/kaniko/vib-verify.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyIvc2hhcmVkL2J1c3lib3giLCAic2xlZXAiLCAiMzYwMCJdCg=="
   },
   "phases": {
     "package": {
@@ -33,6 +34,21 @@
     },
     "verify": {
       "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "kaniko/goss/goss.yaml",
+            "vars_file": "kaniko/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-kaniko"
+              }
+            }
+          }
+        },
         {
           "action_id": "trivy",
           "params": {

--- a/.vib/kube-rbac-proxy/goss/goss.yaml
+++ b/.vib/kube-rbac-proxy/goss/goss.yaml
@@ -1,0 +1,10 @@
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+gossfile:
+  # Goss tests exclusive to the current container
+  ../../kube-rbac-proxy/goss/kube-rbac-proxy.yaml: {}
+  # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-app-version-no-shell-stdout.yaml: {}
+  ../../common/goss/templates/check-ca-certs.yaml: {}
+  ../../common/goss/templates/check-files.yaml: {}

--- a/.vib/kube-rbac-proxy/goss/kube-rbac-proxy.yaml
+++ b/.vib/kube-rbac-proxy/goss/kube-rbac-proxy.yaml
@@ -1,0 +1,9 @@
+command:
+  check-kube-rbac-proxy-help:
+    exec:
+    - /kube-rbac-proxy
+    - --help
+    exit-status: 0
+    stdout:
+    - "Usage:"
+    - "kube-rbac-proxy [flags]"

--- a/.vib/kube-rbac-proxy/goss/vars.yaml
+++ b/.vib/kube-rbac-proxy/goss/vars.yaml
@@ -1,0 +1,10 @@
+files:
+  - mode: "0644"
+    paths:
+      - /opt/bitnami/kube-rbac-proxy/.spdx-kube-rbac-proxy.spdx
+  - mode: "0755"
+    paths:
+      - /kube-rbac-proxy
+version:
+  bin_name: /kube-rbac-proxy
+  flag: --version

--- a/.vib/kube-rbac-proxy/vib-verify.json
+++ b/.vib/kube-rbac-proxy/vib-verify.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyIvc2hhcmVkL2J1c3lib3giLCAic2xlZXAiLCAiMzYwMCJdCg=="
   },
   "phases": {
     "package": {
@@ -33,6 +34,21 @@
     },
     "verify": {
       "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "kube-rbac-proxy/goss/goss.yaml",
+            "vars_file": "kube-rbac-proxy/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-kube-rbac-proxy"
+              }
+            }
+          }
+        },
         {
           "action_id": "trivy",
           "params": {

--- a/.vib/pinniped/goss/goss.yaml
+++ b/.vib/pinniped/goss/goss.yaml
@@ -1,0 +1,10 @@
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+gossfile:
+  # Goss tests exclusive to the current container
+  ../../pinniped/goss/pinniped.yaml: {}
+  # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-app-version-no-shell-stderr.yaml: {}
+  ../../common/goss/templates/check-ca-certs.yaml: {}
+  ../../common/goss/templates/check-files.yaml: {}

--- a/.vib/pinniped/goss/pinniped.yaml
+++ b/.vib/pinniped/goss/pinniped.yaml
@@ -1,0 +1,18 @@
+command:
+  check-pinniped-concierge-help:
+    exec:
+    - /pinniped-concierge
+    - --help
+    exit-status: 0
+    stdout:
+    - "Usage:"
+    - "pinniped-concierge [flags]"
+file:
+  /pinniped-concierge:
+    exists: true
+    filetype: symlink
+    linked-to: pinniped-server
+  /pinniped-supervisor:
+    exists: true
+    filetype: symlink
+    linked-to: pinniped-server

--- a/.vib/pinniped/goss/vars.yaml
+++ b/.vib/pinniped/goss/vars.yaml
@@ -1,0 +1,11 @@
+files:
+  - mode: "0644"
+    paths:
+      - /opt/bitnami/pinniped/.spdx-pinniped.spdx
+  - mode: "0755"
+    paths:
+      - /pinniped-concierge-kube-cert-agent
+      - /pinniped-server
+version:
+  bin_name: /pinniped-concierge
+  flag: --help

--- a/.vib/pinniped/vib-verify.json
+++ b/.vib/pinniped/vib-verify.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyIvc2hhcmVkL2J1c3lib3giLCAic2xlZXAiLCAiMzYwMCJdCg=="
   },
   "phases": {
     "package": {
@@ -33,6 +34,21 @@
     },
     "verify": {
       "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "pinniped/goss/goss.yaml",
+            "vars_file": "pinniped/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-pinniped"
+              }
+            }
+          }
+        },
         {
           "action_id": "trivy",
           "params": {

--- a/.vib/rabbitmq-cluster-operator/goss/goss.yaml
+++ b/.vib/rabbitmq-cluster-operator/goss/goss.yaml
@@ -1,0 +1,10 @@
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+gossfile:
+  # Goss tests exclusive to the current container
+  ../../rabbitmq-cluster-operator/goss/rabbitmq-cluster-operator.yaml: {}
+  # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-app-version-no-shell-stdout.yaml: {}
+  ../../common/goss/templates/check-ca-certs.yaml: {}
+  ../../common/goss/templates/check-files.yaml: {}

--- a/.vib/rabbitmq-cluster-operator/goss/rabbitmq-cluster-operator.yaml
+++ b/.vib/rabbitmq-cluster-operator/goss/rabbitmq-cluster-operator.yaml
@@ -1,0 +1,9 @@
+command:
+  check-manager-help:
+    exec:
+    - /manager
+    - --help
+    exit-status: 0
+    stdout:
+    - "Usage:"
+    - "manager [flags]"

--- a/.vib/rabbitmq-cluster-operator/goss/vars.yaml
+++ b/.vib/rabbitmq-cluster-operator/goss/vars.yaml
@@ -1,0 +1,10 @@
+files:
+  - mode: "0644"
+    paths:
+      - /opt/bitnami/rabbitmq-cluster-operator/.spdx-rabbitmq-cluster-operator.spdx
+  - mode: "0755"
+    paths:
+      - /manager
+version:
+  bin_name: /manager
+  flag: version

--- a/.vib/rabbitmq-cluster-operator/vib-verify.json
+++ b/.vib/rabbitmq-cluster-operator/vib-verify.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyIvc2hhcmVkL2J1c3lib3giLCAic2xlZXAiLCAiMzYwMCJdCg=="
   },
   "phases": {
     "package": {
@@ -33,6 +34,21 @@
     },
     "verify": {
       "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "rabbitmq-cluster-operator/goss/goss.yaml",
+            "vars_file": "rabbitmq-cluster-operator/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-rabbitmq-cluster-operator"
+              }
+            }
+          }
+        },
         {
           "action_id": "trivy",
           "params": {

--- a/.vib/rmq-default-credential-updater/goss/goss.yaml
+++ b/.vib/rmq-default-credential-updater/goss/goss.yaml
@@ -1,0 +1,10 @@
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+gossfile:
+  # Goss tests exclusive to the current container
+  ../../rmq-default-credential-updater/goss/rmq-default-credential-updater.yaml: {}
+  # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-app-version-no-shell-stdout.yaml: {}
+  ../../common/goss/templates/check-ca-certs.yaml: {}
+  ../../common/goss/templates/check-files.yaml: {}

--- a/.vib/rmq-default-credential-updater/goss/rmq-default-credential-updater.yaml
+++ b/.vib/rmq-default-credential-updater/goss/rmq-default-credential-updater.yaml
@@ -1,0 +1,9 @@
+command:
+  check-default-user-credential-updater-help:
+    exec:
+    - /default-user-credential-updater
+    - --help
+    exit-status: 0
+    stdout:
+    - "Usage:"
+    - "default-user-credential-updater [flags]"

--- a/.vib/rmq-default-credential-updater/goss/vars.yaml
+++ b/.vib/rmq-default-credential-updater/goss/vars.yaml
@@ -1,0 +1,10 @@
+files:
+  - mode: "0644"
+    paths:
+      - /opt/bitnami/rmq-default-credential-updater/.spdx-rmq-default-credential-updater.spdx
+  - mode: "0755"
+    paths:
+      - /default-user-credential-updater
+version:
+  bin_name: /default-user-credential-updater
+  flag: version

--- a/.vib/rmq-default-credential-updater/vib-verify.json
+++ b/.vib/rmq-default-credential-updater/vib-verify.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyIvc2hhcmVkL2J1c3lib3giLCAic2xlZXAiLCAiMzYwMCJdCg=="
   },
   "phases": {
     "package": {
@@ -33,6 +34,21 @@
     },
     "verify": {
       "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "rmq-default-credential-updater/goss/goss.yaml",
+            "vars_file": "rmq-default-credential-updater/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-rmq-default-credential-updater"
+              }
+            }
+          }
+        },
         {
           "action_id": "trivy",
           "params": {

--- a/.vib/rmq-messaging-topology-operator/goss/goss.yaml
+++ b/.vib/rmq-messaging-topology-operator/goss/goss.yaml
@@ -1,0 +1,10 @@
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+gossfile:
+  # Goss tests exclusive to the current container
+  ../../rmq-messaging-topology-operator/goss/rmq-messaging-topology-operator.yaml: {}
+  # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-app-version-no-shell-stdout.yaml: {}
+  ../../common/goss/templates/check-ca-certs.yaml: {}
+  ../../common/goss/templates/check-files.yaml: {}

--- a/.vib/rmq-messaging-topology-operator/goss/rmq-messaging-topology-operator.yaml
+++ b/.vib/rmq-messaging-topology-operator/goss/rmq-messaging-topology-operator.yaml
@@ -1,0 +1,9 @@
+command:
+  check-manager-help:
+    exec:
+    - /manager
+    - --help
+    exit-status: 0
+    stdout:
+    - "Usage:"
+    - "manager [flags]"

--- a/.vib/rmq-messaging-topology-operator/goss/vars.yaml
+++ b/.vib/rmq-messaging-topology-operator/goss/vars.yaml
@@ -1,0 +1,10 @@
+files:
+  - mode: "0644"
+    paths:
+      - /opt/bitnami/rmq-messaging-topology-operator/.spdx-rmq-messaging-topology-operator.spdx
+  - mode: "0755"
+    paths:
+      - /manager
+version:
+  bin_name: /manager
+  flag: version

--- a/.vib/rmq-messaging-topology-operator/vib-verify.json
+++ b/.vib/rmq-messaging-topology-operator/vib-verify.json
@@ -3,7 +3,8 @@
     "resources": {
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
-    }
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyIvc2hhcmVkL2J1c3lib3giLCAic2xlZXAiLCAiMzYwMCJdCg=="
   },
   "phases": {
     "package": {
@@ -33,6 +34,21 @@
     },
     "verify": {
       "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "rmq-messaging-topology-operator/goss/goss.yaml",
+            "vars_file": "rmq-messaging-topology-operator/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-rmq-messaging-topology-operator"
+              }
+            }
+          }
+        },
         {
           "action_id": "trivy",
           "params": {


### PR DESCRIPTION
### Description of the change

Follows up https://github.com/bitnami/containers/pull/77079 enabling basic Goss tests for:

- argo-workflow-controller
- argo-workflows
- chainloop-artifact-cas
- chainloop-control-plane-migrations
- chainloop
- kaniko
- kube-rbac-proxy
- pinniped
- rabbitmq-cluster-operator
- rmq-default-credential-updater
- rmq-messaging-topology-operator