### PR TITLE
[bitnami/sealed-secrets-*] Fix Goss tests

### DIFF
--- a/.vib/sealed-secrets-controller/goss/sealed-secrets-controller.yaml
+++ b/.vib/sealed-secrets-controller/goss/sealed-secrets-controller.yaml
@@ -3,6 +3,6 @@ command:
     exec:
     - /controller
     - --help
-    exit-status: 0
-    stdout:
+    exit-status: 2
+    stderr:
     - "Usage of /controller"

--- a/.vib/sealed-secrets-kubeseal/goss/vars.yaml
+++ b/.vib/sealed-secrets-kubeseal/goss/vars.yaml
@@ -1,7 +1,7 @@
 files:
   - mode: "0644"
     paths:
-      - /opt/bitnami/sealed-secrets/.spdx-sealed-secrets.spdx
+      - /opt/bitnami/sealed-secrets-kubeseal/.spdx-sealed-secrets-kubeseal.spdx
   - mode: "0755"
     paths:
       - /kubeseal


### PR DESCRIPTION
### Description of the change

This PR fixes the Goss tests for Sealed Secrets images given the controller shows "help" info on stderr and kubeseal SPDX file uses a different path.