### PR TITLE
[bitnami/rmq-*] bugfix: goss tests

### DIFF
--- a/.vib/rabbitmq-cluster-operator/goss/goss.yaml
+++ b/.vib/rabbitmq-cluster-operator/goss/goss.yaml
@@ -5,6 +5,5 @@ gossfile:
   # Goss tests exclusive to the current container
   ../../rabbitmq-cluster-operator/goss/rabbitmq-cluster-operator.yaml: {}
   # Load scripts from .vib/common/goss/templates
-  ../../common/goss/templates/check-app-version-no-shell-stdout.yaml: {}
   ../../common/goss/templates/check-ca-certs.yaml: {}
   ../../common/goss/templates/check-files.yaml: {}

--- a/.vib/rabbitmq-cluster-operator/goss/rabbitmq-cluster-operator.yaml
+++ b/.vib/rabbitmq-cluster-operator/goss/rabbitmq-cluster-operator.yaml
@@ -5,5 +5,4 @@ command:
     - --help
     exit-status: 0
     stdout:
-    - "Usage:"
-    - "manager [flags]"
+    - "Usage of /manager"

--- a/.vib/rabbitmq-cluster-operator/goss/vars.yaml
+++ b/.vib/rabbitmq-cluster-operator/goss/vars.yaml
@@ -5,6 +5,3 @@ files:
   - mode: "0755"
     paths:
       - /manager
-version:
-  bin_name: /manager
-  flag: version

--- a/.vib/rmq-default-credential-updater/goss/goss.yaml
+++ b/.vib/rmq-default-credential-updater/goss/goss.yaml
@@ -5,6 +5,5 @@ gossfile:
   # Goss tests exclusive to the current container
   ../../rmq-default-credential-updater/goss/rmq-default-credential-updater.yaml: {}
   # Load scripts from .vib/common/goss/templates
-  ../../common/goss/templates/check-app-version-no-shell-stdout.yaml: {}
   ../../common/goss/templates/check-ca-certs.yaml: {}
   ../../common/goss/templates/check-files.yaml: {}

--- a/.vib/rmq-default-credential-updater/goss/rmq-default-credential-updater.yaml
+++ b/.vib/rmq-default-credential-updater/goss/rmq-default-credential-updater.yaml
@@ -5,5 +5,4 @@ command:
     - --help
     exit-status: 0
     stdout:
-    - "Usage:"
-    - "default-user-credential-updater [flags]"
+    - "Usage of /default-user-credential-updater"

--- a/.vib/rmq-default-credential-updater/goss/vars.yaml
+++ b/.vib/rmq-default-credential-updater/goss/vars.yaml
@@ -5,6 +5,3 @@ files:
   - mode: "0755"
     paths:
       - /default-user-credential-updater
-version:
-  bin_name: /default-user-credential-updater
-  flag: version

--- a/.vib/rmq-messaging-topology-operator/goss/goss.yaml
+++ b/.vib/rmq-messaging-topology-operator/goss/goss.yaml
@@ -5,6 +5,5 @@ gossfile:
   # Goss tests exclusive to the current container
   ../../rmq-messaging-topology-operator/goss/rmq-messaging-topology-operator.yaml: {}
   # Load scripts from .vib/common/goss/templates
-  ../../common/goss/templates/check-app-version-no-shell-stdout.yaml: {}
   ../../common/goss/templates/check-ca-certs.yaml: {}
   ../../common/goss/templates/check-files.yaml: {}

--- a/.vib/rmq-messaging-topology-operator/goss/rmq-messaging-topology-operator.yaml
+++ b/.vib/rmq-messaging-topology-operator/goss/rmq-messaging-topology-operator.yaml
@@ -5,5 +5,4 @@ command:
     - --help
     exit-status: 0
     stdout:
-    - "Usage:"
-    - "manager [flags]"
+    - "Usage of /manager"

--- a/.vib/rmq-messaging-topology-operator/goss/vars.yaml
+++ b/.vib/rmq-messaging-topology-operator/goss/vars.yaml
@@ -5,6 +5,3 @@ files:
   - mode: "0755"
     paths:
       - /manager
-version:
-  bin_name: /manager
-  flag: version


### PR DESCRIPTION
### Description of the change

This PR fixes the Goss tests for rmq-operator scratch containers. These binaries don't have a "version" command nor flag, and the output on the `--help` command needs to be adapted.