### PR TITLE
[bitnami/charts-syncer] bugfix: goss tests

### DIFF
--- a/.vib/charts-syncer/goss/goss.yaml
+++ b/.vib/charts-syncer/goss/goss.yaml
@@ -5,6 +5,6 @@ gossfile:
   # Goss tests exclusive to the current container
   ../../charts-syncer/goss/charts-syncer.yaml: {}
   # Load scripts from .vib/common/goss/templates
-  ../../common/goss/templates/check-app-version-no-shell-stdout.yaml: {}
+  ../../common/goss/templates/check-app-version-no-shell-stderr.yaml: {}
   ../../common/goss/templates/check-ca-certs.yaml: {}
   ../../common/goss/templates/check-files.yaml: {}


### PR DESCRIPTION
### Description of the change

This PR fixes the Goss tests for **charts-syncer** given it shows the version on `/charts-syncer version` command on stderr instead of stdout.