### PR TITLE
[bitnami/elasticsearch] do not fail if asked to chown read-only files

### DIFF
--- a/bitnami/elasticsearch/9/debian-12/rootfs/opt/bitnami/scripts/libelasticsearch.sh
+++ b/bitnami/elasticsearch/9/debian-12/rootfs/opt/bitnami/scripts/libelasticsearch.sh
@@ -379,7 +379,7 @@ elasticsearch_validate() {
     am_i_root && ensure_user_exists "$DB_DAEMON_USER" --group "$DB_DAEMON_GROUP"
     for dir in "$DB_TMP_DIR" "$DB_LOGS_DIR" "$DB_PLUGINS_DIR" "$DB_BASE_DIR/modules" "$DB_CONF_DIR"; do
         ensure_dir_exists "$dir"
-        am_i_root && chown -R "$DB_DAEMON_USER:$DB_DAEMON_GROUP" "$dir"
+        am_i_root && chown -R "$DB_DAEMON_USER:$DB_DAEMON_GROUP" "$dir" || true
     done
 
     debug "Validating settings in DB_* env vars..."
@@ -686,7 +686,7 @@ elasticsearch_initialize() {
     debug "Ensuring expected directories/files exist..."
     for dir in "$DB_TMP_DIR" "$DB_LOGS_DIR" "$DB_PLUGINS_DIR" "$DB_BASE_DIR/modules" "$DB_CONF_DIR"; do
         ensure_dir_exists "$dir"
-        am_i_root && chown -R "$DB_DAEMON_USER:$DB_DAEMON_GROUP" "$dir"
+        am_i_root && chown -R "$DB_DAEMON_USER:$DB_DAEMON_GROUP" "$dir" || true
     done
     for dir in "${data_dirs_list[@]}"; do
         ensure_dir_exists "$dir"


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Add `|| true` to `chown` commands that operate recursively on folders that are expected to be mounted into the container from volumes or bind mounts, so that the `chown` does not cause a fatal error if any of the target directories or their children are mounted read-only.

### Benefits

Currently when running as root the elasticsearch container will fail to start if any folder under `/opt/bitnami/elasticsearch/config` is mounted from a read-only filesystem.  In particular this happens in the corresponding bitnami Helm chart, where the TLS certificates for Elasticsearch are mounted in from a Kubernetes secret.  This change means that such cases are no longer fatal errors - the files in the read-only filesystems will not of course have their ownership changed, but there's not really anything better we can do if the filesystem is read-only.

### Possible drawbacks

If a mounted filesystem should have been read-write but was mounted read-only by mistake, it would previously have caused a fatal error, prompting the user to change their configuration; this change will make that a no-op so they might not notice.

### Applicable issues

- fixes #77525

### Additional information

This fix should probably be applied before https://github.com/bitnami/charts/pull/31960 is merged.
