### PR TITLE
[bitnami/argo-cd] ci: remove expected directory

### DIFF
--- a/.vib/argo-cd/goss/vars.yaml
+++ b/.vib/argo-cd/goss/vars.yaml
@@ -10,7 +10,6 @@ directories:
     - /bitnami/argocd
     mode: "0775"
   - paths:
-    - /opt/bitnami/argo-cd/app
     - /opt/bitnami/argo-cd/bin
 root_dir: /opt/bitnami
 sed_in_place:


### PR DESCRIPTION
### Description of the change

This PR removes an expected directory on Goss tests given it's not present on the latest version.

### Benefits

Fix CI tests.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A
