### PR TITLE
[bitnami/mlflow] ci: increase goss tests timeout

### DIFF
--- a/.vib/mlflow/goss/mlflow.yaml
+++ b/.vib/mlflow/goss/mlflow.yaml
@@ -8,8 +8,8 @@ user:
     gid: 0
 command:
   mlflow-serve:
-    exec: cd /app && timeout --signal 2 --preserve-status 5 mlflow server
-    timeout: 10000
+    exec: cd /app && timeout --signal 2 --preserve-status 10 mlflow server
+    timeout: 15000
     exit-status: 1
     stderr:
       - "Listening at"


### PR DESCRIPTION
### Description of the change

This PR increases the timeout used on Mlflow goss tests

### Benefits

Tests are more stable

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A