### PR TITLE
[bitnami/superset] Increase goss version test timeout

### DIFF
--- a/.vib/superset/goss/superset.yaml
+++ b/.vib/superset/goss/superset.yaml
@@ -4,6 +4,7 @@
 command:
   check-app-version:
     exec: echo "SECRET_KEY='123456789abcdef'" > /tmp/superset_config.py && SUPERSET_CONFIG_PATH="/tmp/superset_config.py" superset version
+    timeout: 30000
     exit-status: 0
     stdout:
     - "{{ .Env.APP_VERSION }}"


### PR DESCRIPTION
### Description of the change

Increases version test command timeout from default 10s to 30s.

Tested locally, if I set container resources to `cpu=0.5` and `memory=500m`, the container test may take a bit more than 10 seconds, which may be the cause of some test failures.

```
I have no name!@e58d8fec1319:/vib$ echo "SECRET_KEY='123456789abcdef'" > /tmp/superset_config.py && time SUPERSET_CONFIG_PATH="/tmp/superset_config.py" superset version
Loaded your LOCAL configuration at [/tmp/superset_config.py]
2025-02-26 15:33:55,096:INFO:superset.utils.screenshots:No PIL installation found
2025-02-26 15:33:55,974:INFO:superset.utils.pdf:No PIL installation found
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
Superset 4.1.1
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=


real    0m10.409s
user    0m4.780s
sys     0m0.444s
```