### PR TITLE
Deprecate MariaDB/MariaDB Galera 11.2 and 11.6

### DIFF
--- a/bitnami/mariadb-galera/11.2/README.md
+++ b/bitnami/mariadb-galera/11.2/README.md
@@ -1,5 +1,0 @@
-# Only latest stable branch maintained in the free Bitnami catalog
-
-Starting December 10th 2024, only the latest stable branch of any container will receive updates in the free Bitnami catalog. To access up-to-date releases for all upstream-supported branches, consider upgrading to Bitnami Premium. Previous versions already released will not be deleted. They are still available to pull from DockerHub.
-
-Please check the Bitnami Premium page in our partner [Arrow Electronics](https://www.arrow.com/globalecs/na/vendors/bitnami?utm_source=GitHub&utm_medium=containers) for more information.

--- a/bitnami/mariadb-galera/11.6/README.md
+++ b/bitnami/mariadb-galera/11.6/README.md
@@ -1,5 +1,0 @@
-# Only latest stable branch maintained in the free Bitnami catalog
-
-Starting December 10th 2024, only the latest stable branch of any container will receive updates in the free Bitnami catalog. To access up-to-date releases for all upstream-supported branches, consider upgrading to Bitnami Premium. Previous versions already released will not be deleted. They are still available to pull from DockerHub.
-
-Please check the Bitnami Premium page in our partner [Arrow Electronics](https://www.arrow.com/globalecs/na/vendors/bitnami?utm_source=GitHub&utm_medium=containers) for more information.

--- a/bitnami/mariadb/11.2/README.md
+++ b/bitnami/mariadb/11.2/README.md
@@ -1,5 +1,0 @@
-# Only latest stable branch maintained in the free Bitnami catalog
-
-Starting December 10th 2024, only the latest stable branch of any container will receive updates in the free Bitnami catalog. To access up-to-date releases for all upstream-supported branches, consider upgrading to Bitnami Premium. Previous versions already released will not be deleted. They are still available to pull from DockerHub.
-
-Please check the Bitnami Premium page in our partner [Arrow Electronics](https://www.arrow.com/globalecs/na/vendors/bitnami?utm_source=GitHub&utm_medium=containers) for more information.

--- a/bitnami/mariadb/11.6/README.md
+++ b/bitnami/mariadb/11.6/README.md
@@ -1,5 +1,0 @@
-# Only latest stable branch maintained in the free Bitnami catalog
-
-Starting December 10th 2024, only the latest stable branch of any container will receive updates in the free Bitnami catalog. To access up-to-date releases for all upstream-supported branches, consider upgrading to Bitnami Premium. Previous versions already released will not be deleted. They are still available to pull from DockerHub.
-
-Please check the Bitnami Premium page in our partner [Arrow Electronics](https://www.arrow.com/globalecs/na/vendors/bitnami?utm_source=GitHub&utm_medium=containers) for more information.


### PR DESCRIPTION
Those branches reached their EOL, see https://endoflife.date/mariadb