### PR TITLE
[bitnami/jax] Update goss tests

### DIFF
--- a/.vib/jax/goss/jax.yaml
+++ b/.vib/jax/goss/jax.yaml
@@ -12,4 +12,4 @@ command:
     timeout: 8000
     exit-status: 0
     stdout:
-      - "0.3721109"
+      - "1.6226422"


### PR DESCRIPTION
### Description of the change

Update Goss tests.

```
root@5cbb9a5caa2b:/app# python -c 'import jax.numpy as jnp; from jax import grad, jit, vmap; from jax import random; key = random.PRNGKey(0); x = random.normal(key, (10,)); print(x)'
[ 1.6226422   2.0252647  -0.43359444 -0.07861735  0.1760909  -0.97208923
 -0.49529874  0.4943786   0.6643493  -0.9501635 ]
```