### PR TITLE
[vib/common] Allow timeout parameter in check-app-version

### DIFF
--- a/.vib/common/goss/templates/check-app-version-no-shell-stderr.yaml
+++ b/.vib/common/goss/templates/check-app-version-no-shell-stderr.yaml
@@ -14,5 +14,8 @@ command:
     - {{ .Vars.version.bin_name }}
     - {{ .Vars.version.flag }}
     exit-status: 0
+    {{- if contains "timeout" (.Vars.version | toString) }}
+    timeout: {{ .Vars.version.timeout }}
+    {{- end }}
     stderr:
     - "{{ .Env.APP_VERSION }}"

--- a/.vib/common/goss/templates/check-app-version-no-shell-stdout.yaml
+++ b/.vib/common/goss/templates/check-app-version-no-shell-stdout.yaml
@@ -14,5 +14,8 @@ command:
     - {{ .Vars.version.bin_name }}
     - {{ .Vars.version.flag }}
     exit-status: 0
+    {{- if contains "timeout" (.Vars.version | toString) }}
+    timeout: {{ .Vars.version.timeout }}
+    {{- end }}
     stdout:
     - "{{ .Env.APP_VERSION }}"

--- a/.vib/common/goss/templates/check-app-version.yaml
+++ b/.vib/common/goss/templates/check-app-version.yaml
@@ -12,5 +12,8 @@ command:
   check-app-version:
     exec: {{ .Vars.version.bin_name }} {{ .Vars.version.flag }} 2>&1
     exit-status: 0
+    {{- if contains "timeout" (.Vars.version | toString) }}
+    timeout: {{ .Vars.version.timeout }}
+    {{- end }}
     stdout:
     - "{{ .Env.APP_VERSION }}"


### PR DESCRIPTION
### Description of the change

Defines a new optional `timeout` parameter for the check-app-version common goss test.

### Benefits

Improves Goss tests definition and customization.

### Possible drawbacks

None.