### PR TITLE
[bitnima/redis-cluster] Fix env REDIS_EXTRA_FLAGS unused

### DIFF
--- a/bitnami/redis-cluster/7.4/debian-12/rootfs/opt/bitnami/scripts/redis-cluster/run.sh
+++ b/bitnami/redis-cluster/7.4/debian-12/rootfs/opt/bitnami/scripts/redis-cluster/run.sh
@@ -32,6 +32,10 @@ else
     ARGS+=("--protected-mode" "no")
 fi
 
+# Add flags specified via the 'REDIS_EXTRA_FLAGS' environment variable
+read -r -a extra_flags <<< "$REDIS_EXTRA_FLAGS"
+[[ "${#extra_flags[@]}" -gt 0 ]] && ARGS+=("${extra_flags[@]}")
+
 ARGS+=("$@")
 
 if is_boolean_yes "$REDIS_CLUSTER_CREATOR" && ! [[ -f "${REDIS_DATA_DIR}/nodes.conf" ]]; then


### PR DESCRIPTION
Fix [bitnima/redis-cluster] container environment variable REDIS_EXTRA_FLAGS to using.

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change
Changed fix `bitnami/redis-cluster/7.4/debian-12/rootfs/opt/bitnami/scripts/redis-cluster/run.sh`
<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits
env `REDIS_EXTRA_FLAGS` can be config.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks
Nothing
<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #78609

### Additional information

Testing:

```shell
cd bitnami/redis-cluster/7.4/debian-12
docker-buildx build -t bitnami/redis-cluster:7.4.2-fix-env-REDIS_EXTRA_FLAGS-to-use .
```
Change `loglevel` to debug
```yaml
services:
  redis-node-0:
    image: docker.io/bitnami/redis-cluster:7.4.2-fix-env-REDIS_EXTRA_FLAGS-to-use
    volumes:
      - redis-cluster_data-0:/bitnami/redis/data
    environment:
      - 'REDIS_PASSWORD=bitnami'
      - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
      - 'REDIS_EXTRA_FLAGS=--loglevel debug'
```

Docker exec into the `redis-node-0`:
```shell
I have no name!@31c8a60028fe:/$ redis-cli
127.0.0.1:6379> CONFIG GET loglevel
(error) NOAUTH Authentication required.
127.0.0.1:6379> 
127.0.0.1:6379> 
127.0.0.1:6379> auth bitnami
OK
127.0.0.1:6379> CONFIG GET loglevel
1) "loglevel"
2) "debug"
127.0.0.1:6379> 
```
The `loglevel ` has been changed to debugging