### PR TITLE
Fix image name typo

### DIFF
--- a/bitnami/harbor-portal/README.md
+++ b/bitnami/harbor-portal/README.md
@@ -11,7 +11,7 @@
 This container is part of the [Harbor solution](https://github.com/bitnami/charts/tree/main/bitnami/harbor) that is primarily intended to be deployed in Kubernetes.
 
 ```console
-docker run --name harbor bitnami/harbor-protal:latest
+docker run --name harbor bitnami/harbor-portal:latest
 ```
 
 ## Why use Bitnami Images?


### PR DESCRIPTION
### Description of the change
Fixes image name in the readme

### Benefits
Folks will get the correct image when running the command

### Possible drawbacks
None I can think of

### Applicable issues
n/a

### Additional information
n/a