### PR TITLE
[bitnami/harbor-*] Update validation to check certificates exist

### DIFF
--- a/.vib/harbor-adapter-trivy/goss/harbor-adapter-trivy.yaml
+++ b/.vib/harbor-adapter-trivy/goss/harbor-adapter-trivy.yaml
@@ -23,7 +23,7 @@ command:
   check-directories-exist-with-user:
     exec: ls -dl /etc/ssl/certs /etc/pki/tls/certs/ 2>/dev/null | grep "drwxrwxr-x.*trivy-scanner"
     exit-status: 0
-  # Ensure permissions for Internal TLS
-  check-permissions-system-certs:
-    exec: ls -l /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.trust.crt /etc/ssl/certs/ca-certificates.crt 2>/dev/null | grep "^.\{5\}w"
+  # Ensure certificates exist
+  check-system-certs:
+    exec: if [ $( ls -l /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.trust.crt /etc/ssl/certs/ca-certificates.crt 2>/dev/null | wc -l) -eq 0 ]; then exit 1; fi
     exit-status: 0

--- a/.vib/harbor-adapter-trivy/goss/harbor-adapter-trivy.yaml
+++ b/.vib/harbor-adapter-trivy/goss/harbor-adapter-trivy.yaml
@@ -25,5 +25,5 @@ command:
     exit-status: 0
   # Ensure certificates exist
   check-system-certs:
-    exec: if [ $( ls -l /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.trust.crt /etc/ssl/certs/ca-certificates.crt 2>/dev/null | wc -l) -eq 0 ]; then exit 1; fi
+    exec: if [ $(ls -l /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.trust.crt /etc/ssl/certs/ca-certificates.crt 2>/dev/null | wc -l) -eq 0 ]; then exit 1; fi
     exit-status: 0

--- a/.vib/harbor-core/goss/harbor-core.yaml
+++ b/.vib/harbor-core/goss/harbor-core.yaml
@@ -33,7 +33,7 @@ file:
   /opt/bitnami/harbor-core/bin/swagger:
     exists: false
 command:
-  # Ensure permissions for Internal TLS
-  check-permissions-system-certs:
-    exec: ls -l /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.trust.crt /etc/ssl/certs/ca-certificates.crt 2>/dev/null | grep "^.\{5\}w"
+  # Ensure certificates exist
+  check-system-certs:
+    exec: if [ $( ls -l /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.trust.crt /etc/ssl/certs/ca-certificates.crt 2>/dev/null | wc -l) -eq 0 ]; then exit 1; fi
     exit-status: 0

--- a/.vib/harbor-core/goss/harbor-core.yaml
+++ b/.vib/harbor-core/goss/harbor-core.yaml
@@ -35,5 +35,5 @@ file:
 command:
   # Ensure certificates exist
   check-system-certs:
-    exec: if [ $( ls -l /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.trust.crt /etc/ssl/certs/ca-certificates.crt 2>/dev/null | wc -l) -eq 0 ]; then exit 1; fi
+    exec: if [ $(ls -l /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.trust.crt /etc/ssl/certs/ca-certificates.crt 2>/dev/null | wc -l) -eq 0 ]; then exit 1; fi
     exit-status: 0

--- a/.vib/harbor-exporter/goss/harbor-exporter.yaml
+++ b/.vib/harbor-exporter/goss/harbor-exporter.yaml
@@ -20,7 +20,7 @@ command:
   check-directories-exist-with-user:
     exec: ls -dl /etc/ssl/certs /etc/pki/tls/certs/ 2>/dev/null | grep "drwxrwxr-x.*harbor"
     exit-status: 0
-  # Ensure permissions for Internal TLS
-  check-permissions-system-certs:
-    exec: ls -l /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.trust.crt /etc/ssl/certs/ca-certificates.crt 2>/dev/null | grep "^.\{5\}w"
+  # Ensure certificates exist
+  check-system-certs:
+    exec: if [ $( ls -l /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.trust.crt /etc/ssl/certs/ca-certificates.crt 2>/dev/null | wc -l) -eq 0 ]; then exit 1; fi
     exit-status: 0

--- a/.vib/harbor-exporter/goss/harbor-exporter.yaml
+++ b/.vib/harbor-exporter/goss/harbor-exporter.yaml
@@ -22,5 +22,5 @@ command:
     exit-status: 0
   # Ensure certificates exist
   check-system-certs:
-    exec: if [ $( ls -l /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.trust.crt /etc/ssl/certs/ca-certificates.crt 2>/dev/null | wc -l) -eq 0 ]; then exit 1; fi
+    exec: if [ $(ls -l /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.trust.crt /etc/ssl/certs/ca-certificates.crt 2>/dev/null | wc -l) -eq 0 ]; then exit 1; fi
     exit-status: 0

--- a/.vib/harbor-jobservice/goss/harbor-jobservice.yaml
+++ b/.vib/harbor-jobservice/goss/harbor-jobservice.yaml
@@ -20,7 +20,7 @@ command:
   check-directories-exist-with-user:
     exec: ls -dl /etc/ssl/certs /etc/pki/tls/certs/ 2>/dev/null | grep "drwxrwxr-x.*harbor"
     exit-status: 0
-  # Ensure permissions for Internal TLS
-  check-permissions-system-certs:
-    exec: ls -l /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.trust.crt /etc/ssl/certs/ca-certificates.crt 2>/dev/null | grep "^.\{5\}w"
+  # Ensure certificates exist
+  check-system-certs:
+    exec: if [ $( ls -l /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.trust.crt /etc/ssl/certs/ca-certificates.crt 2>/dev/null | wc -l) -eq 0 ]; then exit 1; fi
     exit-status: 0

--- a/.vib/harbor-jobservice/goss/harbor-jobservice.yaml
+++ b/.vib/harbor-jobservice/goss/harbor-jobservice.yaml
@@ -22,5 +22,5 @@ command:
     exit-status: 0
   # Ensure certificates exist
   check-system-certs:
-    exec: if [ $( ls -l /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.trust.crt /etc/ssl/certs/ca-certificates.crt 2>/dev/null | wc -l) -eq 0 ]; then exit 1; fi
+    exec: if [ $(ls -l /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.trust.crt /etc/ssl/certs/ca-certificates.crt 2>/dev/null | wc -l) -eq 0 ]; then exit 1; fi
     exit-status: 0

--- a/.vib/harbor-portal/goss/harbor-portal.yaml
+++ b/.vib/harbor-portal/goss/harbor-portal.yaml
@@ -21,9 +21,9 @@ file:
       - "/opt/bitnami/harbor"
       - "/opt/bitnami/nginx/conf/mime.types"
 command:
-  # Ensure permissions for Internal TLS
-  check-permissions-system-certs:
-    exec: ls -l /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.trust.crt /etc/ssl/certs/ca-certificates.crt 2>/dev/null | grep "^.\{5\}w.*harbor"
+  # Ensure certificates exist
+  check-system-certs:
+    exec: if [ $( ls -l /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.trust.crt /etc/ssl/certs/ca-certificates.crt 2>/dev/null | wc -l) -eq 0 ]; then exit 1; fi
     exit-status: 0
   # Ensure a set of directories exist and the non-root user has write privileges to them
   check-directories-exist-with-user:

--- a/.vib/harbor-portal/goss/harbor-portal.yaml
+++ b/.vib/harbor-portal/goss/harbor-portal.yaml
@@ -23,7 +23,7 @@ file:
 command:
   # Ensure certificates exist
   check-system-certs:
-    exec: if [ $( ls -l /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.trust.crt /etc/ssl/certs/ca-certificates.crt 2>/dev/null | wc -l) -eq 0 ]; then exit 1; fi
+    exec: if [ $(ls -l /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.trust.crt /etc/ssl/certs/ca-certificates.crt 2>/dev/null | wc -l) -eq 0 ]; then exit 1; fi
     exit-status: 0
   # Ensure a set of directories exist and the non-root user has write privileges to them
   check-directories-exist-with-user:

--- a/.vib/harbor-registry/goss/harbor-registry.yaml
+++ b/.vib/harbor-registry/goss/harbor-registry.yaml
@@ -29,5 +29,5 @@ command:
     exit-status: 0
   # Ensure certificates exist
   check-system-certs:
-    exec: if [ $( ls -l /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.trust.crt /etc/ssl/certs/ca-certificates.crt 2>/dev/null | wc -l) -eq 0 ]; then exit 1; fi
+    exec: if [ $(ls -l /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.trust.crt /etc/ssl/certs/ca-certificates.crt 2>/dev/null | wc -l) -eq 0 ]; then exit 1; fi
     exit-status: 0

--- a/.vib/harbor-registry/goss/harbor-registry.yaml
+++ b/.vib/harbor-registry/goss/harbor-registry.yaml
@@ -27,7 +27,7 @@ command:
   check-directories-exist-with-user:
     exec: ls -dl /etc/ssl/certs /etc/pki/tls/certs/ 2>/dev/null | grep "drwxrwxr-x.*harbor"
     exit-status: 0
-  # Ensure permissions for Internal TLS
-  check-permissions-system-certs:
-    exec: ls -l /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.trust.crt /etc/ssl/certs/ca-certificates.crt 2>/dev/null | grep "^.\{5\}w.*harbor"
+  # Ensure certificates exist
+  check-system-certs:
+    exec: if [ $( ls -l /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.trust.crt /etc/ssl/certs/ca-certificates.crt 2>/dev/null | wc -l) -eq 0 ]; then exit 1; fi
     exit-status: 0

--- a/.vib/harbor-registryctl/goss/harbor-registryctl.yaml
+++ b/.vib/harbor-registryctl/goss/harbor-registryctl.yaml
@@ -25,9 +25,9 @@ command:
   check-directories-exist-with-user:
     exec: ls -dl /etc/ssl/certs /etc/pki/tls/certs/ 2>/dev/null | grep "drwxrwxr-x.*harbor"
     exit-status: 0
-  # Ensure permissions for Internal TLS
-  check-permissions-system-certs:
-    exec: ls -l /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.trust.crt /etc/ssl/certs/ca-certificates.crt 2>/dev/null | grep "^.\{5\}w.*harbor"
+  # Ensure certificates exist
+  check-system-certs:
+    exec: if [ $( ls -l /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.trust.crt /etc/ssl/certs/ca-certificates.crt 2>/dev/null | wc -l) -eq 0 ]; then exit 1; fi
     exit-status: 0
   check-harbor-registryctl-binary:
     exec: harbor_registryctl --help

--- a/.vib/harbor-registryctl/goss/harbor-registryctl.yaml
+++ b/.vib/harbor-registryctl/goss/harbor-registryctl.yaml
@@ -27,7 +27,7 @@ command:
     exit-status: 0
   # Ensure certificates exist
   check-system-certs:
-    exec: if [ $( ls -l /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.trust.crt /etc/ssl/certs/ca-certificates.crt 2>/dev/null | wc -l) -eq 0 ]; then exit 1; fi
+    exec: if [ $(ls -l /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.trust.crt /etc/ssl/certs/ca-certificates.crt 2>/dev/null | wc -l) -eq 0 ]; then exit 1; fi
     exit-status: 0
   check-harbor-registryctl-binary:
     exec: harbor_registryctl --help


### PR DESCRIPTION
### Description of the change

Validation is failing for some platforms due to permissions configuration is different. However, this test doesn't make sense anymore as ownership is configured as root:root or harbor:root

- Harbor Core

```
root@2e4c10b4dab6:/opt/bitnami/harbor-core# ls -l /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.trust.crt /etc/ssl/certs/ca-certificates.crt
ls: cannot access '/etc/pki/tls/certs/ca-bundle.crt': No such file or directory
ls: cannot access '/etc/pki/tls/certs/ca-bundle.trust.crt': No such file or directory
-rw-rw-r-- 1 root root 213777 Mar  5 00:08 /etc/ssl/certs/ca-certificates.crt
```

- Harbor Registry
```
root@35b17d203938:/# ls -l /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.trust.crt /etc/ssl/certs/ca-certificates.crt            
ls: cannot access '/etc/pki/tls/certs/ca-bundle.crt': No such file or directory
ls: cannot access '/etc/pki/tls/certs/ca-bundle.trust.crt': No such file or directory
-rw-rw-r-- 1 harbor root 213777 Mar  5 00:23 /etc/ssl/certs/ca-certificates.crt
```

Certificates differ in the different distros

https://github.com/bitnami/containers/blob/main/bitnami/harbor-core/2/debian-12/rootfs/opt/bitnami/scripts/libharbor.sh#L54

### Benefits

Validation passes

### Possible drawbacks

None as we are not changing the permissions configuration.
