### PR TITLE
[bitnami/kafka] ci: different logging framework for 4.y.z series

### DIFF
--- a/.vib/kafka/goss/kafka.yaml
+++ b/.vib/kafka/goss/kafka.yaml
@@ -7,6 +7,11 @@ file:
     exists: false
   /opt/bitnami/kafka/conf:
     exists: false
+  {{ if regexMatch "^4.+" .Env.APP_VERSION }}
+  /opt/bitnami/kafka/config/log4j2.yaml:
+    exists: true
+    filetype: file
+  {{ else }}
   /opt/bitnami/kafka/config/log4j.properties:
     exists: true
     filetype: file
@@ -16,6 +21,7 @@ file:
       - "ConsoleAppender"
       - "!DatePattern"
       - "!Appender.File"
+  {{ end }}
   /opt/bitnami/kafka/bin/kafka-server-start.sh:
     exists: true
     filetype: file


### PR DESCRIPTION
### Description of the change

This PR adapts the Goss tests for Kafka to check for a different log configuration file depending on the version.

### Benefits

Goss tests for Kafka are valid for both `3.y.z` and `4.y.z` series

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A
