### PR TITLE
[bitnami/discourse] Fix sidekiq volume mount in docker compose

### DIFF
--- a/bitnami/discourse/docker-compose.yml
+++ b/bitnami/discourse/docker-compose.yml
@@ -45,7 +45,7 @@ services:
     depends_on:
       - discourse
     volumes:
-      - 'sidekiq_data:/bitnami/discourse'
+      - 'discourse_data:/bitnami/discourse'
     command: /opt/bitnami/scripts/discourse-sidekiq/run.sh
     environment:
       # ALLOW_EMPTY_PASSWORD is recommended only for development.

--- a/bitnami/discourse/docker-compose.yml
+++ b/bitnami/discourse/docker-compose.yml
@@ -64,5 +64,3 @@ volumes:
     driver: local
   discourse_data:
     driver: local
-  sidekiq_data:
-    driver: local


### PR DESCRIPTION


<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
In 2.4.4-debian-10-r8 release, a change was made as noted in the readme that says:

> Discourse and Sidekiq now make use of the same volume to persist data. This solves issues related to being unable to locate some files generated on-demand by the Sidekiq job scheduler.

This change applies this same volume to the docker-compose file. 

### Benefits

Without the change, sidekiq stalls indefinitely at startup waiting for the discourse DB to be populated. This fixes issues e.g. as noted in #52988

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

None that I'm aware of. I believe this change is required for the docker compose file to work now.

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- It's at least related to #52988

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
