### PR TITLE
[bitnami/*-min] VIB: Add container `size_thresholds`

### DIFF
--- a/.vib/aspnet-min/8/vib-verify.json
+++ b/.vib/aspnet-min/8/vib-verify.json
@@ -4,7 +4,7 @@
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
     },
-    "runtime_parameters": "Y29tbWFuZDogWyJweXRob24zIiwgIi1jIiwgImltcG9ydCB0aW1lOyB0aW1lLnNsZWVwKDM2MDApIl0K"
+    "runtime_parameters": "Y29tbWFuZDogWyIvc2hhcmVkL2J1c3lib3giLCAic2xlZXAiLCAiMzYwMCJdCg=="
   },
   "phases": {
     "package": {
@@ -24,7 +24,7 @@
             ],
             "size_thresholds": [
               {
-                "size": "20MB",
+                "size": "65MB",
                 "kind": "COMPRESSED"
               }
             ]
@@ -46,11 +46,11 @@
             "resources": {
               "path": "/.vib"
             },
-            "tests_file": "python-min/goss/goss.yaml",
-            "vars_file": "python-min/goss/vars.yaml",
+            "tests_file": "aspnet-min/goss/goss.yaml",
+            "vars_file": "aspnet-min/goss/vars.yaml",
             "remote": {
               "pod": {
-                "workload": "deploy-python-min"
+                "workload": "deploy-aspnet-min"
               }
             }
           }

--- a/.vib/aspnet-min/vib-verify.json
+++ b/.vib/aspnet-min/vib-verify.json
@@ -21,6 +21,12 @@
             "architectures": [
               "linux/amd64",
               "linux/arm64"
+            ],
+            "size_thresholds": [
+              {
+                "size": "70MB",
+                "kind": "COMPRESSED"
+              }
             ]
           }
         },

--- a/.vib/java-min/1.8/vib-verify.json
+++ b/.vib/java-min/1.8/vib-verify.json
@@ -4,7 +4,7 @@
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
     },
-    "runtime_parameters": "Y29tbWFuZDogWyJweXRob24zIiwgIi1jIiwgImltcG9ydCB0aW1lOyB0aW1lLnNsZWVwKDM2MDApIl0K"
+    "runtime_parameters": "Y29tbWFuZDogWyIvc2hhcmVkL2J1c3lib3giLCAic2xlZXAiLCAiMzYwMCJdCg=="
   },
   "phases": {
     "package": {
@@ -24,7 +24,7 @@
             ],
             "size_thresholds": [
               {
-                "size": "20MB",
+                "size": "120MB",
                 "kind": "COMPRESSED"
               }
             ]
@@ -46,11 +46,11 @@
             "resources": {
               "path": "/.vib"
             },
-            "tests_file": "python-min/goss/goss.yaml",
-            "vars_file": "python-min/goss/vars.yaml",
+            "tests_file": "java-min/goss/goss.yaml",
+            "vars_file": "java-min/goss/vars.yaml",
             "remote": {
               "pod": {
-                "workload": "deploy-python-min"
+                "workload": "deploy-java-min"
               }
             }
           }

--- a/.vib/java-min/11/vib-verify.json
+++ b/.vib/java-min/11/vib-verify.json
@@ -4,7 +4,7 @@
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
     },
-    "runtime_parameters": "Y29tbWFuZDogWyJweXRob24zIiwgIi1jIiwgImltcG9ydCB0aW1lOyB0aW1lLnNsZWVwKDM2MDApIl0K"
+    "runtime_parameters": "Y29tbWFuZDogWyIvc2hhcmVkL2J1c3lib3giLCAic2xlZXAiLCAiMzYwMCJdCg=="
   },
   "phases": {
     "package": {
@@ -24,7 +24,7 @@
             ],
             "size_thresholds": [
               {
-                "size": "20MB",
+                "size": "70MB",
                 "kind": "COMPRESSED"
               }
             ]
@@ -46,11 +46,11 @@
             "resources": {
               "path": "/.vib"
             },
-            "tests_file": "python-min/goss/goss.yaml",
-            "vars_file": "python-min/goss/vars.yaml",
+            "tests_file": "java-min/goss/goss.yaml",
+            "vars_file": "java-min/goss/vars.yaml",
             "remote": {
               "pod": {
-                "workload": "deploy-python-min"
+                "workload": "deploy-java-min"
               }
             }
           }

--- a/.vib/java-min/17/vib-verify.json
+++ b/.vib/java-min/17/vib-verify.json
@@ -4,7 +4,7 @@
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
     },
-    "runtime_parameters": "Y29tbWFuZDogWyJweXRob24zIiwgIi1jIiwgImltcG9ydCB0aW1lOyB0aW1lLnNsZWVwKDM2MDApIl0K"
+    "runtime_parameters": "Y29tbWFuZDogWyIvc2hhcmVkL2J1c3lib3giLCAic2xlZXAiLCAiMzYwMCJdCg=="
   },
   "phases": {
     "package": {
@@ -24,7 +24,7 @@
             ],
             "size_thresholds": [
               {
-                "size": "20MB",
+                "size": "75MB",
                 "kind": "COMPRESSED"
               }
             ]
@@ -46,11 +46,11 @@
             "resources": {
               "path": "/.vib"
             },
-            "tests_file": "python-min/goss/goss.yaml",
-            "vars_file": "python-min/goss/vars.yaml",
+            "tests_file": "java-min/goss/goss.yaml",
+            "vars_file": "java-min/goss/vars.yaml",
             "remote": {
               "pod": {
-                "workload": "deploy-python-min"
+                "workload": "deploy-java-min"
               }
             }
           }

--- a/.vib/java-min/21/vib-verify.json
+++ b/.vib/java-min/21/vib-verify.json
@@ -4,7 +4,7 @@
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
     },
-    "runtime_parameters": "Y29tbWFuZDogWyJweXRob24zIiwgIi1jIiwgImltcG9ydCB0aW1lOyB0aW1lLnNsZWVwKDM2MDApIl0K"
+    "runtime_parameters": "Y29tbWFuZDogWyIvc2hhcmVkL2J1c3lib3giLCAic2xlZXAiLCAiMzYwMCJdCg=="
   },
   "phases": {
     "package": {
@@ -24,7 +24,7 @@
             ],
             "size_thresholds": [
               {
-                "size": "20MB",
+                "size": "80MB",
                 "kind": "COMPRESSED"
               }
             ]
@@ -46,11 +46,11 @@
             "resources": {
               "path": "/.vib"
             },
-            "tests_file": "python-min/goss/goss.yaml",
-            "vars_file": "python-min/goss/vars.yaml",
+            "tests_file": "java-min/goss/goss.yaml",
+            "vars_file": "java-min/goss/vars.yaml",
             "remote": {
               "pod": {
-                "workload": "deploy-python-min"
+                "workload": "deploy-java-min"
               }
             }
           }

--- a/.vib/java-min/vib-verify.json
+++ b/.vib/java-min/vib-verify.json
@@ -21,6 +21,12 @@
             "architectures": [
               "linux/amd64",
               "linux/arm64"
+            ],
+            "size_thresholds": [
+              {
+                "size": "265MB",
+                "kind": "COMPRESSED"
+              }
             ]
           }
         },

--- a/.vib/libgcc/vib-verify.json
+++ b/.vib/libgcc/vib-verify.json
@@ -21,6 +21,12 @@
             "architectures": [
               "linux/amd64",
               "linux/arm64"
+            ],
+            "size_thresholds": [
+              {
+                "size": "9MB",
+                "kind": "COMPRESSED"
+              }
             ]
           }
         },

--- a/.vib/node-min/18/vib-verify.json
+++ b/.vib/node-min/18/vib-verify.json
@@ -4,7 +4,7 @@
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
     },
-    "runtime_parameters": "Y29tbWFuZDogWyJweXRob24zIiwgIi1jIiwgImltcG9ydCB0aW1lOyB0aW1lLnNsZWVwKDM2MDApIl0K"
+    "runtime_parameters": "Y29tbWFuZDogWyJub2RlIiwgIi0tZXZhbCIsICJzZXRUaW1lb3V0KCgpID0+IHt9LCAzNjAwICogMTAwMCk7Il0K"
   },
   "phases": {
     "package": {
@@ -24,7 +24,7 @@
             ],
             "size_thresholds": [
               {
-                "size": "20MB",
+                "size": "40MB",
                 "kind": "COMPRESSED"
               }
             ]
@@ -46,11 +46,11 @@
             "resources": {
               "path": "/.vib"
             },
-            "tests_file": "python-min/goss/goss.yaml",
-            "vars_file": "python-min/goss/vars.yaml",
+            "tests_file": "node-min/goss/goss.yaml",
+            "vars_file": "node-min/goss/vars.yaml",
             "remote": {
               "pod": {
-                "workload": "deploy-python-min"
+                "workload": "deploy-node-min"
               }
             }
           }

--- a/.vib/node-min/20/vib-verify.json
+++ b/.vib/node-min/20/vib-verify.json
@@ -4,7 +4,7 @@
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
     },
-    "runtime_parameters": "Y29tbWFuZDogWyJweXRob24zIiwgIi1jIiwgImltcG9ydCB0aW1lOyB0aW1lLnNsZWVwKDM2MDApIl0K"
+    "runtime_parameters": "Y29tbWFuZDogWyJub2RlIiwgIi0tZXZhbCIsICJzZXRUaW1lb3V0KCgpID0+IHt9LCAzNjAwICogMTAwMCk7Il0K"
   },
   "phases": {
     "package": {
@@ -24,7 +24,7 @@
             ],
             "size_thresholds": [
               {
-                "size": "20MB",
+                "size": "40MB",
                 "kind": "COMPRESSED"
               }
             ]
@@ -46,11 +46,11 @@
             "resources": {
               "path": "/.vib"
             },
-            "tests_file": "python-min/goss/goss.yaml",
-            "vars_file": "python-min/goss/vars.yaml",
+            "tests_file": "node-min/goss/goss.yaml",
+            "vars_file": "node-min/goss/vars.yaml",
             "remote": {
               "pod": {
-                "workload": "deploy-python-min"
+                "workload": "deploy-node-min"
               }
             }
           }

--- a/.vib/node-min/22/vib-verify.json
+++ b/.vib/node-min/22/vib-verify.json
@@ -4,7 +4,7 @@
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
     },
-    "runtime_parameters": "Y29tbWFuZDogWyJweXRob24zIiwgIi1jIiwgImltcG9ydCB0aW1lOyB0aW1lLnNsZWVwKDM2MDApIl0K"
+    "runtime_parameters": "Y29tbWFuZDogWyJub2RlIiwgIi0tZXZhbCIsICJzZXRUaW1lb3V0KCgpID0+IHt9LCAzNjAwICogMTAwMCk7Il0K"
   },
   "phases": {
     "package": {
@@ -24,7 +24,7 @@
             ],
             "size_thresholds": [
               {
-                "size": "20MB",
+                "size": "45MB",
                 "kind": "COMPRESSED"
               }
             ]
@@ -46,11 +46,11 @@
             "resources": {
               "path": "/.vib"
             },
-            "tests_file": "python-min/goss/goss.yaml",
-            "vars_file": "python-min/goss/vars.yaml",
+            "tests_file": "node-min/goss/goss.yaml",
+            "vars_file": "node-min/goss/vars.yaml",
             "remote": {
               "pod": {
-                "workload": "deploy-python-min"
+                "workload": "deploy-node-min"
               }
             }
           }

--- a/.vib/node-min/vib-verify.json
+++ b/.vib/node-min/vib-verify.json
@@ -21,6 +21,12 @@
             "architectures": [
               "linux/amd64",
               "linux/arm64"
+            ],
+            "size_thresholds": [
+              {
+                "size": "50MB",
+                "kind": "COMPRESSED"
+              }
             ]
           }
         },

--- a/.vib/php-fpm-min/8.1/vib-verify.json
+++ b/.vib/php-fpm-min/8.1/vib-verify.json
@@ -3,8 +3,7 @@
     "resources": {
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
-    },
-    "runtime_parameters": "Y29tbWFuZDogWyJweXRob24zIiwgIi1jIiwgImltcG9ydCB0aW1lOyB0aW1lLnNsZWVwKDM2MDApIl0K"
+    }
   },
   "phases": {
     "package": {
@@ -24,7 +23,7 @@
             ],
             "size_thresholds": [
               {
-                "size": "20MB",
+                "size": "40MB",
                 "kind": "COMPRESSED"
               }
             ]
@@ -46,11 +45,11 @@
             "resources": {
               "path": "/.vib"
             },
-            "tests_file": "python-min/goss/goss.yaml",
-            "vars_file": "python-min/goss/vars.yaml",
+            "tests_file": "php-fpm-min/goss/goss.yaml",
+            "vars_file": "php-fpm-min/goss/vars.yaml",
             "remote": {
               "pod": {
-                "workload": "deploy-python-min"
+                "workload": "deploy-php-fpm-min"
               }
             }
           }

--- a/.vib/php-fpm-min/8.2/vib-verify.json
+++ b/.vib/php-fpm-min/8.2/vib-verify.json
@@ -3,8 +3,7 @@
     "resources": {
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
-    },
-    "runtime_parameters": "Y29tbWFuZDogWyJweXRob24zIiwgIi1jIiwgImltcG9ydCB0aW1lOyB0aW1lLnNsZWVwKDM2MDApIl0K"
+    }
   },
   "phases": {
     "package": {
@@ -24,7 +23,7 @@
             ],
             "size_thresholds": [
               {
-                "size": "20MB",
+                "size": "40MB",
                 "kind": "COMPRESSED"
               }
             ]
@@ -46,11 +45,11 @@
             "resources": {
               "path": "/.vib"
             },
-            "tests_file": "python-min/goss/goss.yaml",
-            "vars_file": "python-min/goss/vars.yaml",
+            "tests_file": "php-fpm-min/goss/goss.yaml",
+            "vars_file": "php-fpm-min/goss/vars.yaml",
             "remote": {
               "pod": {
-                "workload": "deploy-python-min"
+                "workload": "deploy-php-fpm-min"
               }
             }
           }

--- a/.vib/php-fpm-min/8.3/vib-verify.json
+++ b/.vib/php-fpm-min/8.3/vib-verify.json
@@ -3,8 +3,7 @@
     "resources": {
       "url": "{SHA_ARCHIVE}",
       "path": "{VIB_ENV_PATH}"
-    },
-    "runtime_parameters": "Y29tbWFuZDogWyJweXRob24zIiwgIi1jIiwgImltcG9ydCB0aW1lOyB0aW1lLnNsZWVwKDM2MDApIl0K"
+    }
   },
   "phases": {
     "package": {
@@ -24,7 +23,7 @@
             ],
             "size_thresholds": [
               {
-                "size": "20MB",
+                "size": "40MB",
                 "kind": "COMPRESSED"
               }
             ]
@@ -46,11 +45,11 @@
             "resources": {
               "path": "/.vib"
             },
-            "tests_file": "python-min/goss/goss.yaml",
-            "vars_file": "python-min/goss/vars.yaml",
+            "tests_file": "php-fpm-min/goss/goss.yaml",
+            "vars_file": "php-fpm-min/goss/vars.yaml",
             "remote": {
               "pod": {
-                "workload": "deploy-python-min"
+                "workload": "deploy-php-fpm-min"
               }
             }
           }

--- a/.vib/php-fpm-min/vib-verify.json
+++ b/.vib/php-fpm-min/vib-verify.json
@@ -20,6 +20,12 @@
             "architectures": [
               "linux/amd64",
               "linux/arm64"
+            ],
+            "size_thresholds": [
+              {
+                "size": "45MB",
+                "kind": "COMPRESSED"
+              }
             ]
           }
         },

--- a/.vib/ruby-min/vib-verify.json
+++ b/.vib/ruby-min/vib-verify.json
@@ -21,6 +21,12 @@
             "architectures": [
               "linux/amd64",
               "linux/arm64"
+            ],
+            "size_thresholds": [
+              {
+                "size": "30MB",
+                "kind": "COMPRESSED"
+              }
             ]
           }
         },

--- a/.vib/static/vib-verify.json
+++ b/.vib/static/vib-verify.json
@@ -21,6 +21,12 @@
             "architectures": [
               "linux/amd64",
               "linux/arm64"
+            ],
+            "size_thresholds": [
+              {
+                "size": "1MB",
+                "kind": "COMPRESSED"
+              }
             ]
           }
         },


### PR DESCRIPTION
### Description of the change

Adds the new `size_thresholds` check to our minimal container tests.

### Benefits

Ensure we keep track of the size for the minimal images.

### Additional information

I used an approach where I kept the `<appname>/vib-verify.json` for the *latest* branch, and I used `<appname>/<branch>/ vib-verify.json` for the previous branches.

I did it this way because it feels more natural when adding/deprecating branches, so I think it would help us prevent issues:
When a branch is deprecated, you remove the `/<branch>` folder. When a new branch is added, you update the base pipeline file and move the current its own folder.

This also feels natural because of the sizes are increasing, so newer branches will be equal/smaller than the current threshold, or the tests will have to be updated.

The main drawback would be when new branch is significantly smaller, so it will be tested with a wider threshold unless we notice it and update the tests.
