### PR TITLE
[bitnami/kafka] goss: wait-for-port not available on 4.y.z

### DIFF
--- a/.vib/kafka/goss/kafka.yaml
+++ b/.vib/kafka/goss/kafka.yaml
@@ -27,3 +27,9 @@ file:
     filetype: file
     contents:
       - "![-]loggc"
+{{ if not (regexMatch "^4.+" .Env.APP_VERSION) }}
+command:
+  check-wait-for-port-binary:
+    exec: which wait-for-port
+    exit-status: 0
+{{ end }}

--- a/.vib/kafka/goss/vars.yaml
+++ b/.vib/kafka/goss/vars.yaml
@@ -1,7 +1,6 @@
 binaries:
   - java
   - kafka-server-start.sh
-  - wait-for-port
 directories:
   - mode: "0775"
     paths:


### PR DESCRIPTION
### Description of the change

This PR ensures we only check `wait-for-port` binary is available on branch `3.y.z`.

### Benefits

Goss tests compatible with both `3.y.z` and `4.y.z`.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A