### PR TITLE
[bitnami/ejbca] goss: increase timeout for command

### DIFF
--- a/.vib/ejbca/goss/ejbca.yaml
+++ b/.vib/ejbca/goss/ejbca.yaml
@@ -5,6 +5,7 @@ command:
   check-ejbca-help:
     exec: ejbca.sh --help
     exit-status: 0
+    timeout: 20000
 group:
   wildfly:
     exists: true


### PR DESCRIPTION
### Description of the change

This PR increases the timeout for the command we use to test EJBCA

### Benefits

Goss tests are more stable

### Possible drawbacks

None

### Applicable issues

None

### Additional information

N/A
