### PR TITLE
[bitnami/java-min] Reduce size threshold for branch 24

### DIFF
--- a/.vib/java-min/vib-verify.json
+++ b/.vib/java-min/vib-verify.json
@@ -24,7 +24,7 @@
             ],
             "size_thresholds": [
               {
-                "size": "270MB",
+                "size": "95MB",
                 "kind": "COMPRESSED"
               }
             ]


### PR DESCRIPTION
### Description of the change

Reduce java-min 24 size thresholds after fixing container image issue.