### PR TITLE
[bitnami/ruby] Deprecate branch 3.1

### DIFF
--- a/bitnami/ruby/3.1/README.md
+++ b/bitnami/ruby/3.1/README.md
@@ -1,5 +1,0 @@
-# Only latest stable branch maintained in the free Bitnami catalog
-
-Starting December 10th 2024, only the latest stable branch of any container will receive updates in the free Bitnami catalog. To access up-to-date releases for all upstream-supported branches, consider upgrading to Bitnami Premium. Previous versions already released will not be deleted. They are still available to pull from DockerHub.
-
-Please check the Bitnami Premium page in our partner [Arrow Electronics](https://www.arrow.com/globalecs/na/vendors/bitnami?utm_source=GitHub&utm_medium=containers) for more information.


### PR DESCRIPTION
This branch reached its EOL, see https://endoflife.date/ruby