### PR TITLE
[bitnami/couchdb] adding renamed secret parameter

### DIFF
--- a/bitnami/couchdb/3/debian-12/rootfs/opt/bitnami/scripts/libcouchdb.sh
+++ b/bitnami/couchdb/3/debian-12/rootfs/opt/bitnami/scripts/libcouchdb.sh
@@ -119,6 +119,7 @@ couchdb_update_conf_file() {
     couchdb_conf_set "chttpd" "require_valid_user" "true"
     couchdb_conf_set "couch_httpd_auth" "require_valid_user" "true"
     couchdb_conf_set "httpd" "WWW-Authenticate" 'Basic realm="administrator"'
+    is_empty_value "$COUCHDB_SECRET" || couchdb_conf_set "chttpd_auth" "secret" "$COUCHDB_SECRET"
     is_empty_value "$COUCHDB_SECRET" || couchdb_conf_set "couch_httpd_auth" "secret" "$COUCHDB_SECRET"
 }
 


### PR DESCRIPTION
### Description of the change

CouchDB moved parameter `secret` from `couch_httpd_auth` section to `chttpd_auth` section see [documentation](https://docs.couchdb.org/en/stable/config/auth.html#chttpd_auth/secret).

### Benefits

Be able to run image with app version from 3.2+. 


### Possible drawbacks
None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #79239

### Additional information
None
