### PR TITLE
[bitnami/zookeeper] Update libzookeeper.sh use is_mounted_dir_empty

### DIFF
--- a/bitnami/zookeeper/3.9/debian-12/rootfs/opt/bitnami/scripts/libzookeeper.sh
+++ b/bitnami/zookeeper/3.9/debian-12/rootfs/opt/bitnami/scripts/libzookeeper.sh
@@ -165,7 +165,7 @@ zookeeper_initialize() {
         info "User injected custom configuration detected!"
     fi
 
-    if is_dir_empty "$ZOO_DATA_DIR"; then
+    if is_mounted_dir_empty "$ZOO_DATA_DIR"; then
         info "Deploying ZooKeeper from scratch..."
         echo "$ZOO_SERVER_ID" >"${ZOO_DATA_DIR}/myid"
 


### PR DESCRIPTION
is_dir_empty fails on vanilla K8s with vsphere-thin storage class because lost+found present in data dir

### Description of the change

use is_mounted_dir_empty instead of is_dir_empty

### Benefits

on vanilla K8s, with vsphere-thin storage class, datadir/myid is not created.
since lost+found is present in datadir
then zookeeper is not configured correctly
and does not start

### Possible drawbacks

none

### Applicable issues

- fixes #

### Additional information

none

