### PR TITLE
[bitnami/clickhouse-keeper] bugfix: goss tests

### DIFF
--- a/.vib/clickhouse-keeper/goss/clickhouse-keeper.yaml
+++ b/.vib/clickhouse-keeper/goss/clickhouse-keeper.yaml
@@ -17,7 +17,7 @@ file:
     exists: true
     filetype: symlink
     linked-to: /dev/stderr
-  /opt/bitnami/clickhouse-keeper/etc/keeper_config.xml.original:
+  /opt/bitnami/clickhouse-keeper/etc.default/keeper_config.xml:
     exists: true
     filetype: file
     contents:


### PR DESCRIPTION
### Description of the change

This PR adapts the Goss tests for the new logic to support mounting custom configuration.