### PR TITLE
[bitnami/kubescape] Add controls-inputs goss tests

### DIFF
--- a/.vib/kubescape/goss/kubescape.yaml
+++ b/.vib/kubescape/goss/kubescape.yaml
@@ -17,7 +17,7 @@ command:
     stdout:
       - "\"security\":"
 file:
-  /opt/bitnami/kubescape/.kubescape/control-inputs-bn.json:
+  /opt/bitnami/kubescape/.kubescape/controls-inputs-bn.json:
     exists: true
     filetype: file
     contents:

--- a/.vib/kubescape/goss/kubescape.yaml
+++ b/.vib/kubescape/goss/kubescape.yaml
@@ -16,3 +16,9 @@ command:
     timeout: 60000
     stdout:
       - "\"security\":"
+file:
+  /opt/bitnami/kubescape/.kubescape/control-inputs-bn.json:
+    exists: true
+    filetype: file
+    contents:
+      - "_FILE"


### PR DESCRIPTION
### Description of the change

Adds additional goss tests for the bitnami/kubescape container.

This test checks that the new `control-inputs-bn.json` file exists and contains the workaround for bitnami/charts false positive on `_FILE` environment variables.