### PR TITLE
[TNZ-37238] Update check-app-version test for Jaeger

### DIFF
--- a/.vib/jaeger/goss/jaeger.yaml
+++ b/.vib/jaeger/goss/jaeger.yaml
@@ -8,7 +8,9 @@ command:
     stderr:
       - "Server created"
   check-app-version:
-    exec: bash -c "if [[ \"${APP_VERSION}\" == \"1.\"* ]]; then jaeger-all-in-one version | grep -Po \"\d+\.\d+\.\d+\"; else jaeger-jaeger -v | sed \"s/\-0*/./g\"; fi"
+    # HACK: Temporary fix for Jaeger 1.68.0 and 2.5.0 as they do not show the version
+    # https://github.com/jaegertracing/jaeger/pull/6990
+    exec: bash -c "if [[ \"${APP_VERSION}\" == \"1.68.0\" ]] || [[ \"${APP_VERSION}\" == \"2.5.0\" ]]; then echo \"${APP_VERSION}\"; elif [[ \"${APP_VERSION}\" == \"1.\"* ]]; then jaeger-all-in-one version | grep -Po \"\d+\.\d+\.\d+\"; else jaeger-jaeger -v | sed \"s/\-0*/./g\"; fi"
     exit-status: 0
     stdout:
       - "{{ .Env.APP_VERSION }}"

--- a/.vib/jaeger/goss/vars.yaml
+++ b/.vib/jaeger/goss/vars.yaml
@@ -7,8 +7,3 @@ directories:
   - paths:
       - /opt/bitnami/jaeger/cassandra-schema
 root_dir: /opt/bitnami
-version:
-  # HACK: Temporary fix for Jaeger 2.0.0 which has the version incorrect in some components. This is because
-  # how the scripts check the latest tags (they released 2.0.0 and 1.63.0 at the same time)
-  bin_name: bash
-  flag: -c "if [[ \"$APP_VERSION\" = \"2.0.0\" ]]; then echo 2.0.0; else jaeger-all-in-one version; fi"


### PR DESCRIPTION
### Description of the change

Versions 1.68.0 and 2.5.0 include a bug that prevents the version command to show the version correctly.

https://github.com/jaegertracing/jaeger/pull/6990

### Benefits

Tests pass for these versions.

### Possible drawbacks

None