### PR TITLE
[bitnami/grafana] fix(tests): Remove deprecated plugins from tests

### DIFF
--- a/.vib/grafana/goss/vars.yaml
+++ b/.vib/grafana/goss/vars.yaml
@@ -20,21 +20,11 @@ directories:
   - paths:
     - /opt/bitnami/grafana/default-plugins/
 plugins:
-  - agenty-flowcharting-panel
-  - briangann-datatable-panel
-  - briangann-gauge-panel
-  - digiapulssi-organisations-panel
   - grafana-clock-panel
-  - grafana-piechart-panel
-  - grafana-polystat-panel
+  - briangann-gauge-panel
   - jdbranham-diagram-panel
-  - larona-epict-panel
-  - marcuscalidus-svg-panel
-  - michaeldmoore-annunciator-panel
-  - michaeldmoore-multistat-panel
-  - natel-discrete-panel
-  - neocat-cal-heatmap-panel
-  - pierosavi-imageit-panel
-  - scadavis-synoptic-pane
-  - snuids-trafficlights-panel
   - vonage-status-panel
+  - larona-epict-panel
+  - pierosavi-imageit-panel
+  - grafana-polystat-panel
+  - scadavis-synoptic-panel


### PR DESCRIPTION
### Description of the change

Remove deprecated plugins from Grafana tests.

### Benefits

Keep tests aligned with latests versions.

### Possible drawbacks

None

### Applicable issues

- related to #80087

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
