### PR TITLE
[bitnami/*] Adapt tests for scratch containers PATH

### DIFF
--- a/.vib/argo-workflow-cli/goss/argo-workflow-cli.yaml
+++ b/.vib/argo-workflow-cli/goss/argo-workflow-cli.yaml
@@ -1,7 +1,7 @@
 command:
   check-argo-help:
     exec:
-    - /argo
+    - argo
     - --help
     exit-status: 0
     stdout:

--- a/.vib/argo-workflow-cli/goss/vars.yaml
+++ b/.vib/argo-workflow-cli/goss/vars.yaml
@@ -4,7 +4,7 @@ files:
       - /opt/bitnami/argo-workflows/.spdx-argo-workflows.spdx
   - mode: "0755"
     paths:
-      - /argo
+      - /opt/bitnami/argo-workflows/bin/argo
 version:
-  bin_name: /argo
+  bin_name: argo
   flag: version

--- a/.vib/argo-workflow-controller/goss/argo-workflow-controller.yaml
+++ b/.vib/argo-workflow-controller/goss/argo-workflow-controller.yaml
@@ -1,7 +1,7 @@
 command:
   check-workflow-controller-help:
     exec:
-    - /workflow-controller
+    - workflow-controller
     - --help
     exit-status: 0
     stdout:

--- a/.vib/argo-workflow-controller/goss/vars.yaml
+++ b/.vib/argo-workflow-controller/goss/vars.yaml
@@ -4,7 +4,7 @@ files:
       - /opt/bitnami/argo-workflow-controller/.spdx-argo-workflow-controller.spdx
   - mode: "0755"
     paths:
-      - /workflow-controller
+      - /opt/bitnami/argo-workflow-controller/bin/workflow-controller
 version:
-  bin_name: /workflow-controller
+  bin_name: workflow-controller
   flag: version

--- a/.vib/chainloop-artifact-cas/goss/chainloop-artifact-cas.yaml
+++ b/.vib/chainloop-artifact-cas/goss/chainloop-artifact-cas.yaml
@@ -1,8 +1,8 @@
 command:
   check-artifact-cas-help:
     exec:
-    - /artifact-cas
+    - artifact-cas
     - --help
     exit-status: 0
     stderr:
-    - "Usage of /artifact-cas"
+    - "Usage of artifact-cas"

--- a/.vib/chainloop-artifact-cas/goss/vars.yaml
+++ b/.vib/chainloop-artifact-cas/goss/vars.yaml
@@ -4,4 +4,4 @@ files:
       - /opt/bitnami/chainloop/.spdx-chainloop-artifact-cas.spdx
   - mode: "0755"
     paths:
-      - /artifact-cas
+      - /opt/bitnami/chainloop/bin/artifact-cas

--- a/.vib/chainloop-control-plane-migrations/goss/chainloop-control-plane-migrations.yaml
+++ b/.vib/chainloop-control-plane-migrations/goss/chainloop-control-plane-migrations.yaml
@@ -1,7 +1,7 @@
 command:
   check-atlas-help:
     exec:
-    - /atlas
+    - atlas
     - --help
     exit-status: 0
     stdout:

--- a/.vib/chainloop-control-plane-migrations/goss/vars.yaml
+++ b/.vib/chainloop-control-plane-migrations/goss/vars.yaml
@@ -4,7 +4,7 @@ files:
       - /opt/bitnami/chainloop/.spdx-chainloop-control-plane-migrations.spdx
   - mode: "0755"
     paths:
-      - /atlas
+      - /opt/bitnami/atlas/bin/atlas
 directories:
   - mode: "0755"
     paths:

--- a/.vib/chainloop-control-plane/goss/chainloop-control-plane.yaml
+++ b/.vib/chainloop-control-plane/goss/chainloop-control-plane.yaml
@@ -1,8 +1,8 @@
 command:
   check-control-plane-help:
     exec:
-    - /control-plane
+    - control-plane
     - --help
     exit-status: 2
     stderr:
-    - "Usage of /control-plane"
+    - "Usage of control-plane"

--- a/.vib/chainloop-control-plane/goss/vars.yaml
+++ b/.vib/chainloop-control-plane/goss/vars.yaml
@@ -4,4 +4,4 @@ files:
       - /opt/bitnami/chainloop/.spdx-chainloop.spdx
   - mode: "0755"
     paths:
-      - /control-plane
+      - /opt/bitnami/chainloop/bin/control-plane

--- a/.vib/charts-syncer/goss/charts-syncer.yaml
+++ b/.vib/charts-syncer/goss/charts-syncer.yaml
@@ -1,7 +1,7 @@
 command:
   check-charts-syncer-help:
     exec:
-    - /charts-syncer
+    - charts-syncer
     - --help
     exit-status: 0
     stdout:

--- a/.vib/charts-syncer/goss/vars.yaml
+++ b/.vib/charts-syncer/goss/vars.yaml
@@ -4,7 +4,7 @@ files:
       - /opt/bitnami/charts-syncer/.spdx-charts-syncer.spdx
   - mode: "0755"
     paths:
-      - /charts-syncer
+      - /opt/bitnami/charts-syncer/bin/charts-syncer
 version:
-  bin_name: /charts-syncer
+  bin_name: charts-syncer
   flag: version

--- a/.vib/clickhouse-operator-metrics-exporter/goss/vars.yaml
+++ b/.vib/clickhouse-operator-metrics-exporter/goss/vars.yaml
@@ -2,6 +2,9 @@ files:
   - mode: "0644"
     paths:
       - /opt/bitnami/clickhouse-operator-metrics-exporter/.spdx-clickhouse-operator-metrics-exporter.spdx
+  - mode: "0755"
+    paths:
+      - /opt/bitnami/clickhouse-operator-metrics-exporter/bin/metrics-exporter
 version:
   bin_name: metrics-exporter
   flag: --version

--- a/.vib/clickhouse-operator/goss/vars.yaml
+++ b/.vib/clickhouse-operator/goss/vars.yaml
@@ -2,6 +2,9 @@ files:
   - mode: "0644"
     paths:
       - /opt/bitnami/clickhouse-operator/.spdx-clickhouse-operator.spdx
+  - mode: "0755"
+    paths:
+      - /opt/bitnami/clickhouse-operator/bin/clickhouse-operator
 version:
   bin_name: clickhouse-operator
   flag: --version

--- a/.vib/kserve-agent/goss/kserve-agent.yaml
+++ b/.vib/kserve-agent/goss/kserve-agent.yaml
@@ -2,7 +2,7 @@
 command:
   check-help:
     exec:
-      - /opt/bitnami/kserve/bin/agent
+      - agent
       - --help
     exit-status: 2
     stderr:

--- a/.vib/kserve-localmodel-controller/goss/kserve-localmodel-controller.yaml
+++ b/.vib/kserve-localmodel-controller/goss/kserve-localmodel-controller.yaml
@@ -2,7 +2,7 @@
 command:
   check-help:
     exec:
-      - /opt/bitnami/kserve/bin/manager
+      - manager
       - --help
     exit-status: 0
     stderr:

--- a/.vib/kserve-localmodelnode-agent/goss/kserve-localmodelnode-agent.yaml
+++ b/.vib/kserve-localmodelnode-agent/goss/kserve-localmodelnode-agent.yaml
@@ -2,7 +2,7 @@
 command:
   check-help:
     exec:
-      - /opt/bitnami/kserve/bin/manager
+      - manager
       - --help
     exit-status: 0
     stderr:

--- a/.vib/kserve-router/goss/kserve-router.yaml
+++ b/.vib/kserve-router/goss/kserve-router.yaml
@@ -2,7 +2,7 @@
 command:
   check-help:
     exec:
-      - /opt/bitnami/kserve/bin/router
+      - router
       - --help
     exit-status: 2
     stderr:

--- a/.vib/kube-rbac-proxy/goss/kube-rbac-proxy.yaml
+++ b/.vib/kube-rbac-proxy/goss/kube-rbac-proxy.yaml
@@ -1,7 +1,7 @@
 command:
   check-kube-rbac-proxy-help:
     exec:
-    - /kube-rbac-proxy
+    - kube-rbac-proxy
     - --help
     exit-status: 0
     stdout:

--- a/.vib/kube-rbac-proxy/goss/vars.yaml
+++ b/.vib/kube-rbac-proxy/goss/vars.yaml
@@ -4,7 +4,7 @@ files:
       - /opt/bitnami/kube-rbac-proxy/.spdx-kube-rbac-proxy.spdx
   - mode: "0755"
     paths:
-      - /kube-rbac-proxy
+      - /opt/bitnami/kube-rbac-proxy/bin/kube-rbac-proxy
 version:
-  bin_name: /kube-rbac-proxy
+  bin_name: kube-rbac-proxy
   flag: --version

--- a/.vib/kubeapps-apprepository-controller/goss/kubeapps-apprepository-controller.yaml
+++ b/.vib/kubeapps-apprepository-controller/goss/kubeapps-apprepository-controller.yaml
@@ -1,7 +1,7 @@
 command:
   check-apprepository-controller-help:
     exec:
-    - /apprepository-controller
+    - apprepository-controller
     - --help
     exit-status: 0
     stdout:

--- a/.vib/kubeapps-apprepository-controller/goss/vars.yaml
+++ b/.vib/kubeapps-apprepository-controller/goss/vars.yaml
@@ -4,7 +4,7 @@ files:
       - /opt/bitnami/kubeapps-apprepository-controller/.spdx-kubeapps-apprepository-controller.spdx
   - mode: "0755"
     paths:
-      - /apprepository-controller
+      - /opt/bitnami/kubeapps-apprepository-controller/bin/apprepository-controller
 version:
-  bin_name: /apprepository-controller
+  bin_name: apprepository-controller
   flag: --version

--- a/.vib/kubeapps-asset-syncer/goss/kubeapps-asset-syncer.yaml
+++ b/.vib/kubeapps-asset-syncer/goss/kubeapps-asset-syncer.yaml
@@ -1,7 +1,7 @@
 command:
   check-asset-syncer-help:
     exec:
-    - /asset-syncer
+    - asset-syncer
     - --help
     exit-status: 0
     stdout:

--- a/.vib/kubeapps-asset-syncer/goss/vars.yaml
+++ b/.vib/kubeapps-asset-syncer/goss/vars.yaml
@@ -4,7 +4,7 @@ files:
       - /opt/bitnami/kubeapps-asset-syncer/.spdx-kubeapps-asset-syncer.spdx
   - mode: "0755"
     paths:
-      - /asset-syncer
+      - /opt/bitnami/kubeapps-asset-syncer/bin/asset-syncer
 version:
-  bin_name: /asset-syncer
+  bin_name: asset-syncer
   flag: --version

--- a/.vib/nats/goss/nats.yaml
+++ b/.vib/nats/goss/nats.yaml
@@ -1,7 +1,7 @@
 command:
   check-nats-server:
     exec:
-    - /nats-server
+    - nats-server
     - --help
     exit-status: 0
     stdout:

--- a/.vib/nats/goss/vars.yaml
+++ b/.vib/nats/goss/vars.yaml
@@ -2,6 +2,9 @@ files:
   - mode: "0644"
     paths:
       - /opt/bitnami/nats/.spdx-nats.spdx
+  - mode: "0755"
+    paths:
+      - /opt/bitnami/nats/bin/nats-server
 version:
-  bin_name: /nats-server
+  bin_name: nats-server
   flag: --version

--- a/.vib/node-min/goss/vars.yaml
+++ b/.vib/node-min/goss/vars.yaml
@@ -2,6 +2,9 @@ files:
   - mode: "0644"
     paths:
       - /opt/bitnami/node/.spdx-node-min.spdx
+  - mode: "0755"
+    paths:
+      - /opt/bitnami/node/bin/node
 version:
   bin_name: node
   flag: --version

--- a/.vib/oras/goss/oras.yaml
+++ b/.vib/oras/goss/oras.yaml
@@ -1,7 +1,7 @@
 command:
   check-oras-help:
     exec:
-    - /oras
+    - oras
     - help
     exit-status: 0
     stdout:

--- a/.vib/oras/goss/vars.yaml
+++ b/.vib/oras/goss/vars.yaml
@@ -4,7 +4,7 @@ files:
       - /opt/bitnami/oras/.spdx-oras.spdx
   - mode: "0755"
     paths:
-      - /oras
+      - /opt/bitnami/oras/bin/oras
 version:
-  bin_name: /oras
+  bin_name: oras
   flag: version

--- a/.vib/pinniped/goss/pinniped.yaml
+++ b/.vib/pinniped/goss/pinniped.yaml
@@ -1,18 +1,18 @@
 command:
   check-pinniped-concierge-help:
     exec:
-    - /pinniped-concierge
+    - pinniped-concierge
     - --help
     exit-status: 0
     stdout:
     - "Usage:"
     - "pinniped-concierge [flags]"
 file:
-  /pinniped-concierge:
+  /opt/bitnami/pinniped/bin/pinniped-concierge:
     exists: true
     filetype: symlink
     linked-to: pinniped-server
-  /pinniped-supervisor:
+  /opt/bitnami/pinniped/bin/pinniped-supervisor:
     exists: true
     filetype: symlink
     linked-to: pinniped-server

--- a/.vib/pinniped/goss/vars.yaml
+++ b/.vib/pinniped/goss/vars.yaml
@@ -4,8 +4,8 @@ files:
       - /opt/bitnami/pinniped/.spdx-pinniped.spdx
   - mode: "0755"
     paths:
-      - /pinniped-concierge-kube-cert-agent
-      - /pinniped-server
+      - /opt/bitnami/pinniped/bin/pinniped-concierge-kube-cert-agent
+      - /opt/bitnami/pinniped/bin/pinniped-server
 version:
-  bin_name: /pinniped-concierge
+  bin_name: pinniped-concierge
   flag: --help

--- a/.vib/rabbitmq-cluster-operator/goss/rabbitmq-cluster-operator.yaml
+++ b/.vib/rabbitmq-cluster-operator/goss/rabbitmq-cluster-operator.yaml
@@ -1,8 +1,8 @@
 command:
   check-manager-help:
     exec:
-    - /manager
+    - manager
     - --help
     exit-status: 0
     stderr:
-    - "Usage of /manager"
+    - "Usage of manager"

--- a/.vib/rabbitmq-cluster-operator/goss/vars.yaml
+++ b/.vib/rabbitmq-cluster-operator/goss/vars.yaml
@@ -4,4 +4,4 @@ files:
       - /opt/bitnami/rabbitmq-cluster-operator/.spdx-rabbitmq-cluster-operator.spdx
   - mode: "0755"
     paths:
-      - /manager
+      - /opt/bitnami/rabbitmq-cluster-operator/bin/manager

--- a/.vib/rmq-default-credential-updater/goss/rmq-default-credential-updater.yaml
+++ b/.vib/rmq-default-credential-updater/goss/rmq-default-credential-updater.yaml
@@ -1,8 +1,8 @@
 command:
   check-default-user-credential-updater-help:
     exec:
-    - /default-user-credential-updater
+    - default-user-credential-updater
     - --help
     exit-status: 0
     stderr:
-    - "Usage of /default-user-credential-updater"
+    - "Usage of default-user-credential-updater"

--- a/.vib/rmq-default-credential-updater/goss/vars.yaml
+++ b/.vib/rmq-default-credential-updater/goss/vars.yaml
@@ -4,4 +4,4 @@ files:
       - /opt/bitnami/rmq-default-credential-updater/.spdx-rmq-default-credential-updater.spdx
   - mode: "0755"
     paths:
-      - /default-user-credential-updater
+      - /opt/bitnami/rmq-default-credential-updater/bin/default-user-credential-updater

--- a/.vib/rmq-messaging-topology-operator/goss/rmq-messaging-topology-operator.yaml
+++ b/.vib/rmq-messaging-topology-operator/goss/rmq-messaging-topology-operator.yaml
@@ -5,4 +5,4 @@ command:
     - --help
     exit-status: 0
     stderr:
-    - "Usage of /manager"
+    - "Usage of manager"

--- a/.vib/rmq-messaging-topology-operator/goss/rmq-messaging-topology-operator.yaml
+++ b/.vib/rmq-messaging-topology-operator/goss/rmq-messaging-topology-operator.yaml
@@ -1,7 +1,7 @@
 command:
   check-manager-help:
     exec:
-    - /manager
+    - manager
     - --help
     exit-status: 0
     stderr:

--- a/.vib/rmq-messaging-topology-operator/goss/vars.yaml
+++ b/.vib/rmq-messaging-topology-operator/goss/vars.yaml
@@ -4,4 +4,4 @@ files:
       - /opt/bitnami/rmq-messaging-topology-operator/.spdx-rmq-messaging-topology-operator.spdx
   - mode: "0755"
     paths:
-      - /manager
+      - /opt/bitnami/rmq-default-credential-updater/bin/manager

--- a/.vib/rmq-messaging-topology-operator/goss/vars.yaml
+++ b/.vib/rmq-messaging-topology-operator/goss/vars.yaml
@@ -4,4 +4,4 @@ files:
       - /opt/bitnami/rmq-messaging-topology-operator/.spdx-rmq-messaging-topology-operator.spdx
   - mode: "0755"
     paths:
-      - /opt/bitnami/rmq-default-credential-updater/bin/manager
+      - /opt/bitnami/rmq-messaging-topology-operator/bin/manager

--- a/.vib/sealed-secrets-controller/goss/sealed-secrets-controller.yaml
+++ b/.vib/sealed-secrets-controller/goss/sealed-secrets-controller.yaml
@@ -1,8 +1,8 @@
 command:
   check-controller-help:
     exec:
-    - /controller
+    - controller
     - --help
     exit-status: 2
     stderr:
-    - "Usage of /controller"
+    - "Usage of controller"

--- a/.vib/sealed-secrets-controller/goss/vars.yaml
+++ b/.vib/sealed-secrets-controller/goss/vars.yaml
@@ -4,7 +4,7 @@ files:
       - /opt/bitnami/sealed-secrets/.spdx-sealed-secrets.spdx
   - mode: "0755"
     paths:
-      - /controller
+      - /opt/bitnami/sealed-secrets/bin/controller
 version:
-  bin_name: /controller
+  bin_name: controller
   flag: --version

--- a/.vib/sealed-secrets-kubeseal/goss/sealed-secrets-kubeseal.yaml
+++ b/.vib/sealed-secrets-kubeseal/goss/sealed-secrets-kubeseal.yaml
@@ -1,8 +1,8 @@
 command:
   check-kubeseal-help:
     exec:
-    - /kubeseal
+    - kubeseal
     - --help
     exit-status: 0
     stdout:
-    - "Usage of /kubeseal"
+    - "Usage of kubeseal"

--- a/.vib/sealed-secrets-kubeseal/goss/vars.yaml
+++ b/.vib/sealed-secrets-kubeseal/goss/vars.yaml
@@ -4,7 +4,7 @@ files:
       - /opt/bitnami/sealed-secrets-kubeseal/.spdx-sealed-secrets-kubeseal.spdx
   - mode: "0755"
     paths:
-      - /kubeseal
+      - /opt/bitnami/sealed-secrets-kubeseal/bin/kubeseal
 version:
-  bin_name: /kubeseal
+  bin_name: kubeseal
   flag: --version

--- a/.vib/thanos/goss/thanos.yaml
+++ b/.vib/thanos/goss/thanos.yaml
@@ -1,7 +1,7 @@
 command:
   check-thanos:
     exec:
-    - /bin/thanos
+    - thanos
     - --help
     exit-status: 0
     stderr:

--- a/.vib/thanos/goss/vars.yaml
+++ b/.vib/thanos/goss/vars.yaml
@@ -2,6 +2,9 @@ files:
   - mode: "0644"
     paths:
       - /opt/bitnami/thanos/.spdx-thanos.spdx
+  - mode: "0755"
+    paths:
+      - /opt/bitnami/thanos/bin/thanos
 version:
-  bin_name: /bin/thanos
+  bin_name: thanos
   flag: --version

--- a/.vib/trivy/goss/vars.yaml
+++ b/.vib/trivy/goss/vars.yaml
@@ -2,6 +2,9 @@ files:
   - mode: "0644"
     paths:
       - /opt/bitnami/trivy/.spdx-trivy.spdx
+  - mode: "0755"
+    paths:
+      - /opt/bitnami/trivy/bin/trivy
 version:
   bin_name: trivy
   flag: -v

--- a/.vib/victoriametrics-vmagent/goss/victoriametrics-vmagent.yaml
+++ b/.vib/victoriametrics-vmagent/goss/victoriametrics-vmagent.yaml
@@ -1,7 +1,7 @@
 command:
   check-victoriametrics-vmagent-version:
     exec:
-    - /opt/bitnami/victoriametrics/bin/vmagent
+    - vmagent
     - --version
     exit-status: 0
     # Replace "-" with "+" in the version string
@@ -9,9 +9,8 @@ command:
     - {{ .Env.APP_VERSION | replace "-" "+" }}
   check-victoriametrics-vmagent-help:
     exec:
-    - /opt/bitnami/victoriametrics/bin/vmagent
+    - vmagent
     - --help
     exit-status: 0
-    # Replace "-" with "+" in the version string
     stdout:
     - vmagent collects metrics

--- a/.vib/victoriametrics-vmalert/goss/victoriametrics-vmalert.yaml
+++ b/.vib/victoriametrics-vmalert/goss/victoriametrics-vmalert.yaml
@@ -1,7 +1,7 @@
 command:
   check-victoriametrics-vmalert-version:
     exec:
-    - /opt/bitnami/victoriametrics/bin/vmalert
+    - vmalert
     - --version
     exit-status: 0
     # Replace "-" with "+" in the version string
@@ -9,9 +9,8 @@ command:
     - {{ .Env.APP_VERSION | replace "-" "+" }}
   check-victoriametrics-vmalert-help:
     exec:
-    - /opt/bitnami/victoriametrics/bin/vmalert
+    - vmalert
     - --help
     exit-status: 0
-    # Replace "-" with "+" in the version string
     stdout:
     - vmalert processes alerts

--- a/.vib/victoriametrics-vmauth/goss/victoriametrics-vmauth.yaml
+++ b/.vib/victoriametrics-vmauth/goss/victoriametrics-vmauth.yaml
@@ -1,7 +1,7 @@
 command:
   check-victoriametrics-vmauth-version:
     exec:
-    - /opt/bitnami/victoriametrics/bin/vmauth
+    - vmauth
     - --version
     exit-status: 0
     # Replace "-" with "+" in the version string
@@ -9,9 +9,8 @@ command:
     - {{ .Env.APP_VERSION | replace "-" "+" }}
   check-victoriametrics-vmauth-help:
     exec:
-    - /opt/bitnami/victoriametrics/bin/vmauth
+    - vmauth
     - --help
     exit-status: 0
-    # Replace "-" with "+" in the version string
     stdout:
     - vmauth authenticates

--- a/.vib/victoriametrics-vminsert/goss/victoriametrics-vminsert.yaml
+++ b/.vib/victoriametrics-vminsert/goss/victoriametrics-vminsert.yaml
@@ -1,7 +1,7 @@
 command:
   check-victoriametrics-vminsert-version:
     exec:
-    - /opt/bitnami/victoriametrics/bin/vminsert
+    - vminsert
     - --version
     exit-status: 0
     # Replace "-" with "+" in the version string
@@ -9,9 +9,8 @@ command:
     - {{ .Env.APP_VERSION | replace "-" "+" }}
   check-victoriametrics-vminsert-help:
     exec:
-    - /opt/bitnami/victoriametrics/bin/vminsert
+    - vminsert
     - --help
     exit-status: 0
-    # Replace "-" with "+" in the version string
     stdout:
     - vminsert accepts data

--- a/.vib/victoriametrics-vmstorage/goss/victoriametrics-vmstorage.yaml
+++ b/.vib/victoriametrics-vmstorage/goss/victoriametrics-vmstorage.yaml
@@ -1,7 +1,7 @@
 command:
   check-victoriametrics-vmstorage-version:
     exec:
-    - /opt/bitnami/victoriametrics/bin/vmstorage
+    - vmstorage
     - --version
     exit-status: 0
     # Replace "-" with "+" in the version string
@@ -9,9 +9,8 @@ command:
     - {{ .Env.APP_VERSION | replace "-" "+" }}
   check-victoriametrics-vmstorage-help:
     exec:
-    - /opt/bitnami/victoriametrics/bin/vmstorage
+    - vmstorage
     - --help
     exit-status: 0
-    # Replace "-" with "+" in the version string
     stdout:
     - vmstorage stores time


### PR DESCRIPTION
### Description of the change

Update test for scratch-based containers.

We are going to move the binaries from the different directories to `/opt/bitnami/appname/bin`, similar to non-scratch containers.

Then, that path will be added to the PATH environment, so users can access the binary without having to provide its full path.

This PR only includes the changes for the tests, changes to the containers' Dockerfile will be submitted later by the 'bitnami-bot'.

### Benefits

Binaries in scratch containers can be invoked from the PATH, usually it will mean not providing the `/`.

### Possible drawbacks

Customizations that override the container entrypoint / command (depending on the case) will need to be updated to use the binary in the PATH or its new location.