### PR TITLE
[bitnami/memcached-exporter] goss: use stderr instead of stdout

### DIFF
--- a/.vib/memcached-exporter/goss/goss.yaml
+++ b/.vib/memcached-exporter/goss/goss.yaml
@@ -3,6 +3,6 @@
 
 gossfile:
   # Load scripts from .vib/common/goss/templates
-  ../../common/goss/templates/check-app-version-no-shell-stdout.yaml: {}
+  ../../common/goss/templates/check-app-version-no-shell-stderr.yaml: {}
   ../../common/goss/templates/check-ca-certs.yaml: {}
   ../../common/goss/templates/check-files.yaml: {}


### PR DESCRIPTION
### Description of the change

Modify goss tests to use `check-app-version-no-shell-stderr.yaml` instead of `check-app-version-no-shell-stdout.yaml`