### PR TITLE
[bitnami/airflow] Update goss tests

### DIFF
--- a/.vib/airflow/goss/airflow.yaml
+++ b/.vib/airflow/goss/airflow.yaml
@@ -2,12 +2,18 @@
 # SPDX-License-Identifier: APACHE-2.0
 
 command:
-  check-scheduler:
+  check-airflow-home:
     timeout: 30000
-    exec: airflow users list
+    exec: airflow info | grep airflow_home
     exit-status: 0
     stdout:
-      - "No data found"
+      - /opt/bitnami/airflow
+  check-airflow-on-path:
+    timeout: 30000
+    exec: airflow info | grep airflow_on_path
+    exit-status: 0
+    stdout:
+      - "True"
   check-subpackages:
     # Check python packages that should have been installed
     exec: . /opt/bitnami/airflow/venv/bin/activate && pip list

--- a/.vib/airflow/goss/airflow.yaml
+++ b/.vib/airflow/goss/airflow.yaml
@@ -7,7 +7,7 @@ command:
     exec: airflow info | grep airflow_home
     exit-status: 0
     stdout:
-      - /opt/bitnami/airflow
+      - {{ .Env.AIRFLOW_HOME }}
   check-airflow-on-path:
     timeout: 30000
     exec: airflow info | grep airflow_on_path


### PR DESCRIPTION
### Description of the change

The `airflow users` command is not available in Airflow 3.x unless the database has been initialized. This PR updates the tests to check basic Airflow installation information:

* The `airflow_home` key is set to`AIRFLOW_HOME`.
* The `airflow_on_path` value is `True` (that is, `airflow` is part of the `PATH` environment variable).