### PR TITLE
[bitnami/postgres-repmgr] Remove old pid file if it exists

### DIFF
--- a/bitnami/postgresql-repmgr/17/debian-12/rootfs/opt/bitnami/scripts/librepmgr.sh
+++ b/bitnami/postgresql-repmgr/17/debian-12/rootfs/opt/bitnami/scripts/librepmgr.sh
@@ -848,6 +848,11 @@ repmgr_initialize() {
     ensure_dir_exists "$POSTGRESQL_DATA_DIR"
     am_i_root && chown "$POSTGRESQL_DAEMON_USER:$POSTGRESQL_DAEMON_GROUP" "$POSTGRESQL_DATA_DIR"
 
+    # remove old pid file if it exists
+    if [[ -f "/tmp/repmgr.pid" ]]; then
+        rm /tmp/repmgr.pid
+    fi
+
     if [[ "$REPMGR_ROLE" = "standby" ]]; then
         repmgr_wait_primary_node || exit 1
         repmgr_rewind


### PR DESCRIPTION
See [#999](https://github.com/bitnami/containers/issues/999#issuecomment-2785607092)

Additional considerations:
- would we want to disable the pid file altogether, with `--no-pid-file`? It doesn't make a lot of sense to have in a containerized environment
- would we want to try to parse the repmgr config file to know where the pid is configured to be located? probably not but worth mentioning.