### PR TITLE
[bitnami/statsd-exporter] fix: `--help` instead of `help` for default subcommand

### DIFF
--- a/bitnami/statsd-exporter/0/debian-12/Dockerfile
+++ b/bitnami/statsd-exporter/0/debian-12/Dockerfile
@@ -54,4 +54,4 @@ EXPOSE 9102 9125
 WORKDIR /opt/bitnami/statsd-exporter
 USER 1001
 ENTRYPOINT [ "/opt/bitnami/statsd-exporter/bin/statsd_exporter" ]
-CMD [ "help" ]
+CMD [ "--help" ]


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->
### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Currently, if you run the image with no commands, you'll get the following error

```log
> docker run --rm bitnami/statsd-exporter:latest
statsd_exporter: error: unexpected help, try --help
```

With this change, you get the actual help message

### Benefits

<!-- What benefits will be realized by the code change? -->
- usage of statsd is printed if no command is provided
- container doesn't error out if you don't provide a command
### Possible drawbacks

<!-- Describe any known limitations with your change -->
- any deployment that relies on the container failing if a command isn't provided may break
  - not sure how big a deal this is, as helm charts should provide the required command

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
