### PR TITLE
[valkey-cluster] fix: respect VALKEY_EXTRA_FLAGS

### DIFF
--- a/bitnami/valkey-cluster/8.1/debian-12/rootfs/opt/bitnami/scripts/valkey-cluster/run.sh
+++ b/bitnami/valkey-cluster/8.1/debian-12/rootfs/opt/bitnami/scripts/valkey-cluster/run.sh
@@ -32,6 +32,10 @@ else
     ARGS+=("--protected-mode" "no")
 fi
 
+ # Add flags specified via the 'VALKEY_EXTRA_FLAGS' environment variable
+ read -r -a extra_flags <<< "$VALKEY_EXTRA_FLAGS"
+ [[ "${#extra_flags[@]}" -gt 0 ]] && ARGS+=("${extra_flags[@]}")
+
 ARGS+=("$@")
 
 if is_boolean_yes "$VALKEY_CLUSTER_CREATOR" && ! [[ -f "${VALKEY_DATA_DIR}/nodes.conf" ]]; then


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Changed fix bitnami/valkey-cluster/8.1/debian-12/rootfs/opt/bitnami/scripts/valkey-cluster/run.sh

### Benefits

env VALKEY_EXTRA_FLAGS can be config.

### Possible drawbacks

Nothing

### Applicable issues

- fixes https://github.com/bitnami/containers/issues/80647

### Additional information

Testing:

```bash
cd bitnami/valkey-cluster/8.1/debian-12
```

change `docker-compose.yaml`:
```yaml
# Copyright Broadcom, Inc. All Rights Reserved.
# SPDX-License-Identifier: APACHE-2.0

services:
  valkey-node-0:
    build:
      context: .
    volumes:
      - valkey-cluster_data-0:/bitnami/valkey/data
    environment:
      - 'VALKEY_PASSWORD=bitnami'
      - 'VALKEY_NODES=valkey-node-0 valkey-node-1 valkey-node-2 valkey-node-3 valkey-node-4 valkey-node-5'

  valkey-node-1:
    build:
      context: .
    volumes:
      - valkey-cluster_data-1:/bitnami/valkey/data
    environment:
      - 'VALKEY_PASSWORD=bitnami'
      - 'VALKEY_NODES=valkey-node-0 valkey-node-1 valkey-node-2 valkey-node-3 valkey-node-4 valkey-node-5'

  valkey-node-2:
    build:
      context: .
    volumes:
      - valkey-cluster_data-2:/bitnami/valkey/data
    environment:
      - 'VALKEY_PASSWORD=bitnami'
      - 'VALKEY_NODES=valkey-node-0 valkey-node-1 valkey-node-2 valkey-node-3 valkey-node-4 valkey-node-5'

  valkey-node-3:
    build:
      context: .
    volumes:
      - valkey-cluster_data-3:/bitnami/valkey/data
    environment:
      - 'VALKEY_PASSWORD=bitnami'
      - 'VALKEY_NODES=valkey-node-0 valkey-node-1 valkey-node-2 valkey-node-3 valkey-node-4 valkey-node-5'

  valkey-node-4:
    build:
      context: .
    volumes:
      - valkey-cluster_data-4:/bitnami/valkey/data
    environment:
      - 'VALKEY_PASSWORD=bitnami'
      - 'VALKEY_NODES=valkey-node-0 valkey-node-1 valkey-node-2 valkey-node-3 valkey-node-4 valkey-node-5'

  valkey-node-5:
    build:
      context: .
    volumes:
      - valkey-cluster_data-5:/bitnami/valkey/data
    depends_on:
      - valkey-node-0
      - valkey-node-1
      - valkey-node-2
      - valkey-node-3
      - valkey-node-4
    environment:
      - 'VALKEY_PASSWORD=bitnami'
      - 'REDISCLI_AUTH=bitnami'
      - 'VALKEY_CLUSTER_REPLICAS=1'
      - 'VALKEY_NODES=valkey-node-0 valkey-node-1 valkey-node-2 valkey-node-3 valkey-node-4 valkey-node-5'
      - 'VALKEY_CLUSTER_CREATOR=yes'
      - 'VALKEY_EXTRA_FLAGS=--loglevel debug'

volumes:
  valkey-cluster_data-0:
    driver: local
  valkey-cluster_data-1:
    driver: local
  valkey-cluster_data-2:
    driver: local
  valkey-cluster_data-3:
    driver: local
  valkey-cluster_data-4:
    driver: local
  valkey-cluster_data-5:
    driver: local
```
```bash
docker compose up -d
docker compose exec valkey-node-5 redis-cli -a bitnami CONFIG GET loglevel
```
output:
```bash
Warning: Using a password with '-a' or '-u' option on the command line interface may not be safe.
1) "loglevel"
2) "debug"
```