### PR TITLE
[bitnami/moodle] modify readme by non-containerized dbs

### DIFF
--- a/bitnami/moodle/README.md
+++ b/bitnami/moodle/README.md
@@ -262,6 +262,45 @@ moodle:
     bitnami/moodle:latest
   ```
 
+## Connecting to a Non-Containerized Database
+
+**Bitnami's Moodle container does not provide support for database engines that are not fully compatible with MySQL**, such as Amazon Aurora MySQL.
+
+These engines may accept SQL syntax but differ subtly in behavior or feature support. A common failure scenario involves the `ROW_FORMAT=DYNAMIC` setting used by default in Bitnami's `docker-compose.yml` for Moodle.
+
+### Technical Explanation: `ROW_FORMAT=DYNAMIC` Compatibility Issues
+
+Bitnami's Moodle container initializes the database with a `ROW_FORMAT=DYNAMIC` directive in table definitions. This setting is important because:
+
+* Moodle relies on tables that may contain large `TEXT` or `LONGTEXT` fields.
+* `ROW_FORMAT=DYNAMIC` allows these fields to be stored outside the main row, avoiding the [row size limit](https://dev.mysql.com/doc/refman/8.0/en/innodb-row-format.html) (usually 8126 bytes in InnoDB). However, not all MySQL-compatible engines support `ROW_FORMAT=DYNAMIC` correctly.
+
+This leads to issues such as:
+
+* Incomplete database schema creation
+* Installation or upgrade failures
+* Unexpected data truncation or performance degradation
+
+### Recommended Permissions for the Moodle Database User
+
+To avoid permission-related errors during setup or runtime, configure the database and user as follows (based on [Moodle documentation](https://moodledev.io/docs/installation/database/mysql)):
+
+```sql
+-- Create the Moodle database
+CREATE DATABASE moodle_db DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+
+-- Create the Moodle database user
+CREATE USER 'moodle_user'@'%' IDENTIFIED BY 'password_test';
+
+-- Grant the necessary permissions
+GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, CREATE TEMPORARY TABLES, DROP, INDEX, ALTER 
+ON moodle_db.* TO 'moodle_user'@'%';
+
+FLUSH PRIVILEGES;
+```
+
+Note: Replace 'password_test' with a secure password in production environments.
+
 ### Examples
 
 This would be an example of SMTP configuration using a Gmail account:


### PR DESCRIPTION
### Detail
This PR adds a new section to the documentation titled "Connecting to a Non-Containerized Database", which provides detailed guidance on:

* The required MySQL user permissions for Moodle to function properly.
* A technical explanation of potential compatibility issues when using external or cloud-managed MySQL-compatible databases (e.g., Amazon Aurora).
* Specific problems related to the ROW_FORMAT=DYNAMIC directive included in the default docker-compose.yml used by the Bitnami Moodle container.

### 🧩 Problem Addressed

The current Bitnami documentation does not mention:
* The exact privileges the Moodle MySQL user must have.
* Compatibility concerns when using external databases that are not fully MySQL-compliant.

This omission can result in hard-to-debug issues like schema creation failures, permission errors, or "Row size too large" errors during initial setup or upgrades.
### ✅ Proposed Solution
* Add a Markdown section with SQL examples for creating the Moodle database and user with proper permissions.
* Add warnings about unsupported or partially supported database engines (e.g., Amazon Aurora).
* Include a technical explanation of how ROW_FORMAT=DYNAMIC interacts with different database engines and why this can lead to installation or runtime issues.

### 📎 References
* [Moodle official database setup guide](https://docs.moodle.org/20/en/Create_Moodle_site_database#MySQL)
* [MySQL InnoDB row format documentation](https://dev.mysql.com/doc/refman/8.0/en/innodb-row-format.html)

### 🛠️ Notes
* This does not change any application logic or container configuration.
* It is intended solely to improve the developer/operator onboarding experience when using non-containerized databases with Bitnami's Moodle image.
