### PR TITLE
[bitnami/influxdb] ci: adapt Goss tests to work with 3.x series

### DIFF
--- a/.vib/influxdb/goss/vars.yaml
+++ b/.vib/influxdb/goss/vars.yaml
@@ -1,17 +1,25 @@
 binaries:
+  {{ if regexMatch "^2.+" .Env.APP_VERSION }}
   - influx
   - influxd
+  {{ else }}
+  - influxdb3
+  {{ end }}
   - wait-for-port
 directories:
   - mode: "0775"
     paths:
+      {{ if regexMatch "^2.+" .Env.APP_VERSION }}
       - /opt/bitnami/influxdb/etc
+      {{ end }}
       - /bitnami/influxdb
       - /docker-entrypoint-initdb.d
 files:
+  {{ if regexMatch "^2.+" .Env.APP_VERSION }}
   - paths:
       - /.influx_history
+  {{ end }}
 root_dir: /opt/bitnami
 version:
-  bin_name: influxd
-  flag: version
+  bin_name: {{ if regexMatch "^2.+" .Env.APP_VERSION }}influxd{{ else }}influxdb3{{ end }}
+  flag: {{ if regexMatch "^2.+" .Env.APP_VERSION }}version{{ else }}--version{{ end }}


### PR DESCRIPTION
### Description of the change

This PR adapts Goss tests for InfluxDB so they're compatible both with `2.x` and `3.x` series.