### PR TITLE
[bitnami/influxdb] ci: adapt Goss tests to work with 3.x series - ii

### DIFF
--- a/.vib/influxdb/goss/goss.yaml
+++ b/.vib/influxdb/goss/goss.yaml
@@ -5,12 +5,10 @@ gossfile:
   # Goss tests exclusive to the current container
   ../../influxdb/goss/influxdb.yaml: {}
   # Load scripts from .vib/common/goss/templates
-  ../../common/goss/templates/check-app-version.yaml: {}
   ../../common/goss/templates/check-binaries.yaml: {}
   ../../common/goss/templates/check-broken-symlinks.yaml: {}
   ../../common/goss/templates/check-ca-certs.yaml: {}
   ../../common/goss/templates/check-directories.yaml: {}
-  ../../common/goss/templates/check-files.yaml: {}
   ../../common/goss/templates/check-linked-libraries.yaml: {}
   ../../common/goss/templates/check-sed-in-place.yaml: {}
   ../../common/goss/templates/check-spdx.yaml: {}

--- a/.vib/influxdb/goss/influxdb.yaml
+++ b/.vib/influxdb/goss/influxdb.yaml
@@ -1,6 +1,28 @@
 # Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
+command:
+  check-influxdb-version:
+    exec:
+    - {{ if regexMatch "^2.+" .Env.APP_VERSION }}influxd{{ else }}influxdb3{{ end }}
+    - {{ if regexMatch "^2.+" .Env.APP_VERSION }}version{{ else }}--version{{ end }}
+    exit-status: 0
+    stdout:
+    - "{{ .Env.APP_VERSION }}"
+{{ if regexMatch "^2.+" .Env.APP_VERSION }}
+  check-influx-binary:
+    exec: which influx
+    exit-status: 0
+file:
+  /.influx_history:
+    exists: true
+    mode: "0644"
+    filetype: file
+  /opt/bitnami/influxdb/etc:
+    exists: true
+    mode: "0775"
+    filetype: directory
+{{ end }}
 group:
   daemon:
     exists: true

--- a/.vib/influxdb/goss/influxdb.yaml
+++ b/.vib/influxdb/goss/influxdb.yaml
@@ -16,7 +16,7 @@ command:
 file:
   /.influx_history:
     exists: true
-    mode: "0644"
+    mode: "0664"
     filetype: file
   /opt/bitnami/influxdb/etc:
     exists: true

--- a/.vib/influxdb/goss/vars.yaml
+++ b/.vib/influxdb/goss/vars.yaml
@@ -1,25 +1,8 @@
 binaries:
-  {{ if regexMatch "^2.+" .Env.APP_VERSION }}
-  - influx
-  - influxd
-  {{ else }}
-  - influxdb3
-  {{ end }}
   - wait-for-port
 directories:
   - mode: "0775"
     paths:
-      {{ if regexMatch "^2.+" .Env.APP_VERSION }}
-      - /opt/bitnami/influxdb/etc
-      {{ end }}
       - /bitnami/influxdb
       - /docker-entrypoint-initdb.d
-files:
-  {{ if regexMatch "^2.+" .Env.APP_VERSION }}
-  - paths:
-      - /.influx_history
-  {{ end }}
 root_dir: /opt/bitnami
-version:
-  bin_name: {{ if regexMatch "^2.+" .Env.APP_VERSION }}influxd{{ else }}influxdb3{{ end }}
-  flag: {{ if regexMatch "^2.+" .Env.APP_VERSION }}version{{ else }}--version{{ end }}


### PR DESCRIPTION
### Description of the change

Follows up https://github.com/bitnami/containers/pull/81078 moving `if regexMatch "^2.+" .Env.APP_VERSION` conditions to `.vib/influxdb/goss/influxdb.yaml` given the `vars.yaml` doesn't support templates.
