### PR TITLE
[bitnami/pgbouncer] Configure ownership for the socket directory

### DIFF
--- a/bitnami/pgbouncer/1/debian-12/rootfs/opt/bitnami/scripts/libpgbouncer.sh
+++ b/bitnami/pgbouncer/1/debian-12/rootfs/opt/bitnami/scripts/libpgbouncer.sh
@@ -338,6 +338,12 @@ pgbouncer_initialize() {
     # Configuring permissions for tmp and logs folders
     am_i_root && configure_permissions_ownership "$PGBOUNCER_TMP_DIR $PGBOUNCER_LOG_DIR" -u "$PGBOUNCER_DAEMON_USER" -g "$PGBOUNCER_DAEMON_GROUP"
 
+    # Configure ownership and permissions for the socket directory if PGBOUNCER_SOCKET_DIR is set.
+    # This ensures the directory is usable by PGBOUNCER_DAEMON_USER, especially if it's a root-owned mount point.
+    if ! is_empty_value "$PGBOUNCER_SOCKET_DIR"; then
+        am_i_root && configure_permissions_ownership "$PGBOUNCER_SOCKET_DIR" -u "$PGBOUNCER_DAEMON_USER" -g "$PGBOUNCER_DAEMON_GROUP" --dir-mode "0755"
+    fi
+
     # Avoid exit code of previous commands to affect the result of this function
     true
 }


### PR DESCRIPTION
### What this PR does / why we need it

This PR addresses an issue where the PGBouncer Docker image fails to start when configured to use a Unix domain socket in a directory that is mounted with `root` ownership. This scenario is common in environments like AWS ECS Fargate.

The problem occurs because:
1. A volume is mounted at the path specified by `PGBOUNCER_SOCKET_DIR` (e.g., `/var/run/pgbouncer`). In Fargate, such volumes are root-owned (see aws/containers-roadmap#938).
2. The container starts as `root` for initial setup.
3. The `run.sh` script drops privileges to the `pgbouncer` user (or `PGBOUNCER_DAEMON_USER`) before starting the PGBouncer daemon.
4. The non-root `pgbouncer` user lacks write permission to the root-owned `PGBOUNCER_SOCKET_DIR`, causing a `bind(): Permission denied` error when PGBouncer attempts to create its socket file.

This PR modifies the `pgbouncer_initialize` function in `/opt/bitnami/scripts/libpgbouncer.sh`. When the script is executed as root (which it is during the initial entrypoint execution), it will now ensure that the directory specified by `PGBOUNCER_SOCKET_DIR` has its ownership changed to `PGBOUNCER_DAEMON_USER:PGBOUNCER_DAEMON_GROUP` and the permissions changed to `0755`. This allows the PGBouncer daemon, running as `PGBOUNCER_DAEMON_USER`, to successfully create and use the Unix domain socket in the specified directory.

### Which issue(s) this PR fixes

Fixes #81120

### Special notes for your reviewer

The core change is in `/opt/bitnami/scripts/libpgbouncer.sh` within the `pgbouncer_initialize` function. A new block has been added to:
- Check if `PGBOUNCER_SOCKET_DIR` is defined.
- If running as root, call `configure_permissions_ownership` for `$PGBOUNCER_SOCKET_DIR`, setting the user to `$PGBOUNCER_DAEMON_USER`, group to `$PGBOUNCER_DAEMON_GROUP`. The directory permissions are set to `0775`, allowing other users/group members to traverse the directory.

This approach ensures that even if `PGBOUNCER_SOCKET_DIR` points to a volume mounted with `root` ownership, its permissions are corrected before PGBouncer attempts to use it.

### Release note

Fixes an issue where PGBouncer could fail to start due to permission errors when `PGBOUNCER_SOCKET_DIR` was a root-owned mounted volume. The PGBouncer initialization script now correctly sets ownership and permissions of the socket directory.
