### PR TITLE
[bitnami/node-min] Increase sized threshold for 22.16.0

### DIFF
--- a/.vib/node-min/22/vib-verify.json
+++ b/.vib/node-min/22/vib-verify.json
@@ -24,7 +24,7 @@
             ],
             "size_thresholds": [
               {
-                "size": "47MB",
+                "size": "48MB",
                 "kind": "COMPRESSED"
               }
             ]


### PR DESCRIPTION
Tests for new version (22.16.0) are failing due to:
```
ERROR: The compressed size of the image (47.49MB) is greater than the threshold (47MB)
```