### PR TITLE
[bitnami/influxdb] test: :white_check_mark: Move influx_history test to only branch 3

### DIFF
--- a/.vib/influxdb/goss/influxdb.yaml
+++ b/.vib/influxdb/goss/influxdb.yaml
@@ -14,14 +14,15 @@ command:
     exec: which influx
     exit-status: 0
 file:
-  /.influx_history:
-    exists: true
-    mode: "0664"
-    filetype: file
   /opt/bitnami/influxdb/etc:
     exists: true
     mode: "0775"
     filetype: directory
+{{ else }}
+  /.influx_history:
+    exists: true
+    mode: "0664"
+    filetype: file
 {{ end }}
 group:
   daemon:


### PR DESCRIPTION

### Description of the change

This PR updates the goss test of influxdb. The /.influx_history file test is only present in influx 3.
