### PR TITLE
Fixed order of params to start command in Keycloak run.sh

### DIFF
--- a/bitnami/keycloak/26/debian-12/rootfs/opt/bitnami/scripts/keycloak/run.sh
+++ b/bitnami/keycloak/26/debian-12/rootfs/opt/bitnami/scripts/keycloak/run.sh
@@ -25,13 +25,13 @@ is_boolean_yes "$KEYCLOAK_PRODUCTION" && start_param="start" || start_param="sta
 
 start_command=("${KEYCLOAK_BIN_DIR}/kc.sh" "-cf" "$conf_file")
 
-# Prepend extra args
+start_command+=("$start_param")
+
+# Add extra args PREPENDED AFTER `start_param`
 if [[ -n "$KEYCLOAK_EXTRA_ARGS_PREPENDED" ]]; then
     read -r -a extra_args_prepended <<<"$KEYCLOAK_EXTRA_ARGS_PREPENDED"
     start_command+=("${extra_args_prepended[@]}")
 fi
-
-start_command+=("$start_param")
 
 # Add extra args
 if [[ -n "$KEYCLOAK_EXTRA_ARGS" ]]; then


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

I have moved adding start_params to start_command before adding extra arguments. This results in a valid command if `KEYCLOAK_EXTRA_ARGS_PREPENDED` is provided

### Benefits

<!-- What benefits will be realized by the code change? -->
Keycloak can start if `KEYCLOAK_EXTRA_ARGS_PREPENDED` is provided

### Possible drawbacks

<!-- Describe any known limitations with your change -->
N/A
### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #80937

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
N/A
