### PR TITLE
[bitnami/common] Update SPDX common test

### DIFF
--- a/.vib/common/goss/scripts/check-spdx.sh
+++ b/.vib/common/goss/scripts/check-spdx.sh
@@ -6,6 +6,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-mapfile -t files < <( find /bitnami "$BITNAMI_ROOT_DIR" -type f -name '.spdx-*.json' )
+mapfile -t files < <( find /bitnami "$BITNAMI_ROOT_DIR" -type f -name '.spdx-*.spdx' )
 
 [[ ${#files[@]} -gt 0 ]]


### PR DESCRIPTION
### Description of the change

We are moving back to the original `.spdx` file extension due to other internal issues we have found in the test and release process. The `.json` file extension is now a symlink to `.spdx`. We only need to check for real `.spdx` files here.