### PR TITLE
[bitnami/postgresql-repmgr] Support running scripts on primary node when container starts

### DIFF
--- a/bitnami/postgresql-repmgr/17/debian-12/rootfs/opt/bitnami/scripts/libpostgresql.sh
+++ b/bitnami/postgresql-repmgr/17/debian-12/rootfs/opt/bitnami/scripts/libpostgresql.sh
@@ -748,6 +748,46 @@ postgresql_initialize() {
 }
 
 ########################
+# Run custom start scripts
+# Globals:
+#   POSTGRESQL_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+postgresql_custom_start_scripts() {
+    info "Loading custom start scripts..."
+    if [[ -d "$POSTGRESQL_STARTSCRIPTS_DIR" ]] && [[ -n $(find "$POSTGRESQL_STARTSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql.gz\)") ]] ; then
+        info "Loading user's custom files from $POSTGRESQL_STARTSCRIPTS_DIR ..."
+        postgresql_start_bg "false"
+        find "$POSTGRESQL_STARTSCRIPTS_DIR/" -type f -regex ".*\.\(sh\|sql\|sql.gz\)" | sort | while read -r f; do
+            case "$f" in
+            *.sh)
+                if [[ -x "$f" ]]; then
+                    debug "Executing $f"
+                    "$f"
+                else
+                    debug "Sourcing $f"
+                    . "$f"
+                fi
+                ;;
+            *.sql)
+                debug "Executing $f"
+                postgresql_execute "$POSTGRESQL_DATABASE" "$POSTGRESQL_INITSCRIPTS_USERNAME" "$POSTGRESQL_INITSCRIPTS_PASSWORD" <"$f"
+                ;;
+            *.sql.gz)
+                debug "Executing $f"
+                gunzip -c "$f" | postgresql_execute "$POSTGRESQL_DATABASE" "$POSTGRESQL_INITSCRIPTS_USERNAME" "$POSTGRESQL_INITSCRIPTS_PASSWORD"
+                ;;
+            *) debug "Ignoring $f" ;;
+            esac
+        done
+        touch "$POSTGRESQL_VOLUME_DIR"/.user_scripts_initialized
+    fi
+}
+
+########################
 # Run custom pre-initialization scripts
 # Globals:
 #   POSTGRESQL_*

--- a/bitnami/postgresql-repmgr/17/debian-12/rootfs/opt/bitnami/scripts/librepmgr.sh
+++ b/bitnami/postgresql-repmgr/17/debian-12/rootfs/opt/bitnami/scripts/librepmgr.sh
@@ -895,6 +895,8 @@ repmgr_initialize() {
         else
             debug "Skipping repmgr configuration..."
         fi
+        # Allow running custom start scripts - always run after initialization
+        postgresql_custom_start_scripts
     elif [[ "$REPMGR_ROLE" = "standby" ]]; then
         local -r psql_major_version="$(postgresql_get_major_version)"
 

--- a/bitnami/postgresql-repmgr/17/debian-12/rootfs/opt/bitnami/scripts/postgresql-env.sh
+++ b/bitnami/postgresql-repmgr/17/debian-12/rootfs/opt/bitnami/scripts/postgresql-env.sh
@@ -242,6 +242,7 @@ export POSTGRESQL_TMP_DIR="$POSTGRESQL_BASE_DIR/tmp"
 export POSTGRESQL_PID_FILE="$POSTGRESQL_TMP_DIR/postgresql.pid"
 export POSTGRESQL_BIN_DIR="$POSTGRESQL_BASE_DIR/bin"
 export POSTGRESQL_INITSCRIPTS_DIR="/docker-entrypoint-initdb.d"
+export POSTGRESQL_STARTSCRIPTS_DIR="/docker-entrypoint-startdb.d"
 export POSTGRESQL_PREINITSCRIPTS_DIR="/docker-entrypoint-preinitdb.d"
 export PATH="${POSTGRESQL_BIN_DIR}:${BITNAMI_ROOT_DIR}/common/bin:${PATH}"
 

--- a/bitnami/postgresql-repmgr/README.md
+++ b/bitnami/postgresql-repmgr/README.md
@@ -685,6 +685,7 @@ Refer to [issues/27124](https://github.com/bitnami/containers/issues/27124) for 
 | `POSTGRESQL_PID_FILE`                        | PostgreSQL PID file                                             | `$POSTGRESQL_TMP_DIR/postgresql.pid`          |
 | `POSTGRESQL_BIN_DIR`                         | PostgreSQL executables directory                                | `$POSTGRESQL_BASE_DIR/bin`                    |
 | `POSTGRESQL_INITSCRIPTS_DIR`                 | Init scripts directory                                          | `/docker-entrypoint-initdb.d`                 |
+| `POSTGRESQL_STARTSCRIPTS_DIR`                | Start scripts directory                                         | `/docker-entrypoint-startdb.d`                |
 | `POSTGRESQL_PREINITSCRIPTS_DIR`              | Pre-init scripts directory                                      | `/docker-entrypoint-preinitdb.d`              |
 | `POSTGRESQL_DAEMON_USER`                     | PostgreSQL system user                                          | `postgres`                                    |
 | `POSTGRESQL_DAEMON_GROUP`                    | PostgreSQL system group                                         | `postgres`                                    |


### PR DESCRIPTION
Revival of #70737

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This adds the ability to run scripts on startup *always*, a feature that is present in other containers such as mariadb with the `/docker-entrypoint-startdb.d` endpoint

### Benefits

It is currently a huge pain in the behind to run scripts at startup everytime the container starts, requiring an undocumented change to the entrypoint for which there is no information anywhere

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #70606 
