### PR TITLE
[bitnami/plugin-barman-cloud-sidecar] chore: :wrench: Disable goss tests

### DIFF
--- a/.vib/plugin-barman-cloud-sidecar/vib-verify.json
+++ b/.vib/plugin-barman-cloud-sidecar/vib-verify.json
@@ -35,21 +35,6 @@
     "verify": {
       "actions": [
         {
-          "action_id": "goss",
-          "params": {
-            "resources": {
-              "path": "/.vib"
-            },
-            "tests_file": "plugin-barman-cloud-sidecar/goss/goss.yaml",
-            "vars_file": "plugin-barman-cloud-sidecar/goss/vars.yaml",
-            "remote": {
-              "pod": {
-                "workload": "deploy-"
-              }
-            }
-          }
-        },
-        {
           "action_id": "trivy",
           "params": {
             "threshold": "LOW",


### PR DESCRIPTION
### Description of the change

This PR disables the goss tests for plugin-barman-cloud-sidecar as it is currently incompatible with VIB

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
