### PR TITLE
[bitnami/wordpress-nginx] remove custom php error_log config in favor of FPM log_file

### DIFF
--- a/bitnami/wordpress-nginx/6/debian-12/rootfs/opt/bitnami/scripts/php/postunpack.sh
+++ b/bitnami/wordpress-nginx/6/debian-12/rootfs/opt/bitnami/scripts/php/postunpack.sh
@@ -40,7 +40,6 @@ touch "${PHP_CONF_DIR}/common.conf"
 
 # Log to stdout/stderr for easy debugging
 ln -sf "/dev/stdout" "$PHP_FPM_LOG_FILE"
-php_conf_set "error_log" "/dev/stderr"
 
 # Copy all initially generated configuration files to the default directory
 # (this is to avoid breaking when entrypoint is being overridden)


### PR DESCRIPTION
### Description of the change

PHP errors are not displayed in docker logs because the `/dev/stderr` of the forked PHP process is not gathered by the PHP-FPM process.

### Benefits

After removing this line, we can see PHP errors in the docker logs.

### Possible drawbacks

It is possible that other deployment setups rely on the old behavior and gather PHP logs in a different way.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #81807
