### PR TITLE
[bitnami/suitecrm] fix: SKIP_BOOTSTRAP not working properly with suitecrm 8

### DIFF
--- a/bitnami/suitecrm/8/debian-12/rootfs/opt/bitnami/scripts/libsuitecrm.sh
+++ b/bitnami/suitecrm/8/debian-12/rootfs/opt/bitnami/scripts/libsuitecrm.sh
@@ -425,7 +425,15 @@ suitecrm_7_pass_wizard() {
     return "$wizard_exit_code"
 }
 
-
+########################
+# Encodes a given string
+# Globals:
+#   *
+# Arguments:
+#   None
+# Returns:
+#   Encoded string
+#########################
 urlencode() {
   local string="${1}"
   local length="${#string}"
@@ -440,7 +448,6 @@ urlencode() {
   echo "$encoded"
 }
 
-
 ########################
 # Rebuild SuiteCRM's configuration file
 # Globals:
@@ -451,8 +458,6 @@ urlencode() {
 #   true if succeded, false otherwise
 #########################
 suitecrm_rebuild_files() {
-
-
     encoded_user=$(urlencode "$SUITECRM_DATABASE_USER")
     encoded_pass=$(urlencode "$SUITECRM_DATABASE_PASSWORD")
     # Build host:port if port is given
@@ -462,7 +467,7 @@ suitecrm_rebuild_files() {
         host_string="$SUITECRM_DATABASE_HOST"
     fi
 
-    if [[ -n "$SUITECRM_APP_SECRET" ]]; then
+    if [[ -n "${SUITECRM_APP_SECRET:-}" ]]; then
         app_secret=$(openssl rand -hex 16)
     else
         app_secret="$SUITECRM_APP_SECRET"
@@ -489,8 +494,6 @@ require_once('include/utils.php');
 // Based on 'install.php' includes
 require_once('include/SugarLogger/LoggerManager.php');
 require_once('sugar_version.php');
-#require_once('install/install_utils.php');
-#require_once('install/install_defaults.php');
 require_once('suitecrm_version.php');
 require_once('include/TimeDate.php');
 require_once('include/Localization/Localization.php');

--- a/bitnami/suitecrm/8/debian-12/rootfs/opt/bitnami/scripts/libsuitecrm.sh
+++ b/bitnami/suitecrm/8/debian-12/rootfs/opt/bitnami/scripts/libsuitecrm.sh
@@ -511,6 +511,18 @@ require_once('include/utils/file_utils.php');
 \$clean_config['unique_key']=empty('$SUITECRM_APP_SECRET') ? md5(create_guid()) : '$SUITECRM_APP_SECRET';
 \$clean_config['default_theme']='suite8';
 \$clean_config['cron']['allowed_cron_users'] = array(0 => 'daemon');
+
+// Add custom override settings from comma-separated list
+// This allows to set allowed http referers, for example a reverse proxy hostname 
+if (!empty('$SUITECRM_REFERERS')) {
+    \$hosts = array_map('trim', explode(',', '$SUITECRM_REFERERS'));
+    foreach (\$hosts as \$host) {
+        if (!empty(\$host)) {
+            \$clean_config['http_referer']['list'][] = \$host;
+        }
+    }
+}
+
 rebuildConfigFile(\$clean_config, \$sugar_version);
 
 // Rebuild the .htaccess file

--- a/bitnami/suitecrm/8/debian-12/rootfs/opt/bitnami/scripts/suitecrm/postunpack.sh
+++ b/bitnami/suitecrm/8/debian-12/rootfs/opt/bitnami/scripts/suitecrm/postunpack.sh
@@ -51,5 +51,6 @@ web_server_validate
 if [[ -d "${SUITECRM_BASE_DIR}/public" ]]; then
     ensure_web_server_app_configuration_exists "suitecrm" --type php  --document-root "${BITNAMI_ROOT_DIR}/suitecrm/public"
 else
-    ensure_web_server_app_configuration_exists "suitecrm" --type php 
+    # This is executed for SuiteCRM 7
+    ensure_web_server_app_configuration_exists "suitecrm" --type php --apache-move-htaccess "no"
 fi

--- a/bitnami/suitecrm/8/debian-12/rootfs/opt/bitnami/scripts/suitecrm/postunpack.sh
+++ b/bitnami/suitecrm/8/debian-12/rootfs/opt/bitnami/scripts/suitecrm/postunpack.sh
@@ -49,7 +49,7 @@ web_server_validate
 # Not moving .htaccess because SuiteCRM generates some of them during installation
 # Backward compatibility with SuiteCRM 7
 if [[ -d "${SUITECRM_BASE_DIR}/public" ]]; then
-    ensure_web_server_app_configuration_exists "suitecrm" --type php --apache-move-htaccess "no" --document-root "${BITNAMI_ROOT_DIR}/suitecrm/public"
+    ensure_web_server_app_configuration_exists "suitecrm" --type php  --document-root "${BITNAMI_ROOT_DIR}/suitecrm/public"
 else
-    ensure_web_server_app_configuration_exists "suitecrm" --type php --apache-move-htaccess "no"
+    ensure_web_server_app_configuration_exists "suitecrm" --type php 
 fi


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This is my go at making SuiteCRM 8 work properly with `SKIP_BOOSTRAP` flag set to true, which currently doesn't work. I think when migrating from 7 to 8 this path was missed.

This flag allows you to not have to keep the whole SuiteCRM installation in a persisted volume by initializing everything from scratch but the database. 

The thing that still doesn't work which I haven't had a go at is the SMTP set up. 

What I've solved:

* Create .env.local file to support new SuiteCRM 8 config, as well as added necessary properties and updates to the legacy config.php (like cron, and unique_key)
* .htacces file at public/legacy/.htaccess was included, which blocked necessary resources to run the page


This has been more of a surgical fix, but in general the code should/could be cleaned up a lot to remove all the SuiteCRM 7 related code since it's not officially supported anymore by bitnami


### Benefits

`SKIP_BOOTSTRAP` flag functional again.

### Possible drawbacks

* Haven't had time to test the other ways (without SKIP_BOOTSTRAP), but in general my changes should not affect.
* Not really sure why `public/legacy/.htaccess` was included in the first place, but it was also something that did not work properly when running SuiteCRM 7, as it blocks resoruces like images and icons behind 403. Please let me know if this is maybe introducing any security holes

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->


### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
