### PR TITLE
Restore kaniko support

### DIFF
--- a/.vib/kaniko/goss/goss.yaml
+++ b/.vib/kaniko/goss/goss.yaml
@@ -1,0 +1,10 @@
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+gossfile:
+  # Goss tests exclusive to the current container
+  ../../kaniko/goss/kaniko.yaml: {}
+  # Load scripts from .vib/common/goss/templates
+  ../../common/goss/templates/check-app-version-no-shell-stdout.yaml: {}
+  ../../common/goss/templates/check-ca-certs.yaml: {}
+  ../../common/goss/templates/check-files.yaml: {}

--- a/.vib/kaniko/goss/kaniko.yaml
+++ b/.vib/kaniko/goss/kaniko.yaml
@@ -1,0 +1,17 @@
+command:
+  check-executor-help:
+    exec:
+    - /kaniko/executor
+    - --help
+    exit-status: 0
+    stdout:
+    - "Usage:"
+    - "executor [command]"
+  check-warmer-help:
+    exec:
+    - /kaniko/warmer
+    - --help
+    exit-status: 0
+    stdout:
+    - "Usage:"
+    - "cache warmer [flags]"

--- a/.vib/kaniko/goss/vars.yaml
+++ b/.vib/kaniko/goss/vars.yaml
@@ -1,0 +1,14 @@
+files:
+  - mode: "0644"
+    paths:
+      - /opt/bitnami/kaniko/.spdx-kaniko.spdx
+  - mode: "0755"
+    paths:
+      - /kaniko/docker-credential-acr-env
+      - /kaniko/docker-credential-ecr-login
+      - /kaniko/docker-credential-gcr
+      - /kaniko/executor
+      - /kaniko/warmer
+version:
+  bin_name: /kaniko/executor
+  flag: version

--- a/.vib/kaniko/vib-verify.json
+++ b/.vib/kaniko/vib-verify.json
@@ -1,0 +1,73 @@
+{
+  "context": {
+    "resources": {
+      "url": "{SHA_ARCHIVE}",
+      "path": "{VIB_ENV_PATH}"
+    },
+    "runtime_parameters": "Y29tbWFuZDogWyIvc2hhcmVkL2J1c3lib3giLCAic2xlZXAiLCAiMzYwMCJdCg=="
+  },
+  "phases": {
+    "package": {
+      "actions": [
+        {
+          "action_id": "container-image-package",
+          "params": {
+            "application": {
+              "details": {
+                "name": "{VIB_ENV_CONTAINER}",
+                "tag": "{VIB_ENV_TAG}"
+              }
+            },
+            "architectures": [
+              "linux/amd64",
+              "linux/arm64"
+            ]
+          }
+        },
+        {
+          "action_id": "container-image-lint",
+          "params": {
+            "threshold": "error"
+          }
+        }
+      ]
+    },
+    "verify": {
+      "actions": [
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib"
+            },
+            "tests_file": "kaniko/goss/goss.yaml",
+            "vars_file": "kaniko/goss/vars.yaml",
+            "remote": {
+              "pod": {
+                "workload": "deploy-kaniko"
+              }
+            }
+          }
+        },
+        {
+          "action_id": "trivy",
+          "params": {
+            "threshold": "LOW",
+            "vuln_type": [
+              "OS"
+            ]
+          }
+        },
+        {
+          "action_id": "grype",
+          "params": {
+            "threshold": "CRITICAL",
+            "package_type": [
+              "OS"
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/bitnami/kaniko/README.md
+++ b/bitnami/kaniko/README.md
@@ -1,0 +1,129 @@
+# Bitnami package for Kaniko
+
+## What is Kaniko?
+
+> Kaniko is a tool that builds and pushes container images directly in userspace. This allows securely building container images in environments like a standard Kubernetes cluster.
+
+[Overview of Kaniko](https://github.com/GoogleContainerTools/kaniko)
+Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
+
+## TL;DR
+
+```console
+docker run -it --name kaniko bitnami/kaniko
+```
+
+## Why use Bitnami Images?
+
+* Bitnami closely tracks upstream source changes and promptly publishes new versions of this image using our automated systems.
+* With Bitnami images the latest bug fixes and features are available as soon as possible.
+* Bitnami containers, virtual machines and cloud images use the same components and configuration approach - making it easy to switch between formats based on your project needs.
+* All our images are based on [**minideb**](https://github.com/bitnami/minideb) -a minimalist Debian based container image that gives you a small base container image and the familiarity of a leading Linux distribution- or **scratch** -an explicitly empty image-.
+* All Bitnami images available in Docker Hub are signed with [Notation](https://notaryproject.dev/). [Check this post](https://blog.bitnami.com/2024/03/bitnami-packaged-containers-and-helm.html) to know how to verify the integrity of the images.
+* Bitnami container images are released on a regular basis with the latest distribution packages available.
+
+Looking to use Kaniko in production? Try [VMware Tanzu Application Catalog](https://bitnami.com/enterprise), the commercial edition of the Bitnami catalog.
+
+## Only the latest stable branch maintained in the free Bitnami catalog
+
+Starting December 10th, 2024, only the latest stable branch of each container image will receive updates in the free Bitnami catalog. To access up-to-date releases for all upstream-supported branches (e.g., LTS), consider upgrading to Bitnami Premium. Previously released versions will not be deleted and will remain available for pulling from DockerHub.
+
+Please check the Bitnami Premium page in our partner [Arrow Electronics](https://www.arrow.com/globalecs/na/vendors/bitnami?utm_source=GitHub&utm_medium=containers) for more information.
+
+## Supported tags and respective `Dockerfile` links
+
+Learn more about the Bitnami tagging policy and the difference between rolling tags and immutable tags [in our documentation page](https://techdocs.broadcom.com/us/en/vmware-tanzu/application-catalog/tanzu-application-catalog/services/tac-doc/apps-tutorials-understand-rolling-tags-containers-index.html).
+
+You can see the equivalence between the different tags by taking a look at the `tags-info.yaml` file present in the branch folder, i.e `bitnami/ASSET/BRANCH/DISTRO/tags-info.yaml`.
+
+Subscribe to project updates by watching the [bitnami/containers GitHub repo](https://github.com/bitnami/containers).
+
+## Get this image
+
+The recommended way to get the Bitnami Kaniko Docker Image is to pull the prebuilt image from the [Docker Hub Registry](https://hub.docker.com/r/bitnami/kaniko).
+
+```console
+docker pull bitnami/kaniko:latest
+```
+
+To use a specific version, you can pull a versioned tag. You can view the [list of available versions](https://hub.docker.com/r/bitnami/kaniko/tags/) in the Docker Hub Registry.
+
+```console
+docker pull bitnami/kaniko:[TAG]
+```
+
+If you wish, you can also build the image yourself by cloning the repository, changing to the directory containing the Dockerfile and executing the `docker build` command. Remember to replace the `APP`, `VERSION` and `OPERATING-SYSTEM` path placeholders in the example command below with the correct values.
+
+```console
+git clone https://github.com/bitnami/containers.git
+cd bitnami/APP/VERSION/OPERATING-SYSTEM
+docker build -t bitnami/APP:latest .
+```
+
+## Maintenance
+
+### Upgrade this image
+
+Bitnami provides up-to-date versions of Kaniko, including security patches, soon after they are made upstream. We recommend that you follow these steps to upgrade your container.
+
+#### Step 1: Get the updated image
+
+```console
+docker pull bitnami/kaniko:latest
+```
+
+#### Step 2: Remove the currently running container
+
+```console
+docker rm -v kaniko
+```
+
+#### Step 3: Run the new image
+
+Re-create your container from the new image.
+
+```console
+docker run --name kaniko bitnami/kaniko:latest
+```
+
+## Configuration
+
+### Running commands
+
+To run commands inside this container you can use `docker run`, for example to execute `kaniko --help` you can follow the example below:
+
+```console
+docker run --rm --name kaniko bitnami/kaniko:latest --help
+```
+
+Check the [official Kaniko documentation](https://github.com/GoogleContainerTools/kanikodocs/) for more information about how to use Kaniko.
+
+## Notable Changes
+
+### Starting January 16, 2024
+
+* The `docker-compose.yaml` file has been removed, as it was solely intended for internal testing purposes.
+
+## Contributing
+
+We'd love for you to contribute to this Docker image. You can request new features by creating an [issue](https://github.com/bitnami/containers/issues) or submitting a [pull request](https://github.com/bitnami/containers/pulls) with your contribution.
+
+## Issues
+
+If you encountered a problem running this container, you can file an [issue](https://github.com/bitnami/containers/issues/new/choose). For us to provide better support, be sure to fill the issue template.
+
+## License
+
+Copyright &copy; 2025 Broadcom. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+<http://www.apache.org/licenses/LICENSE-2.0>
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
We'll restore the deprecated Kaniko using a new [maintained fork](https://github.com/chainguard-dev/kaniko).
Partially revert #82427