### PR TITLE
[bitnami/nginx] Deprecate branch 1.27

### DIFF
--- a/bitnami/nginx/1.27/README.md
+++ b/bitnami/nginx/1.27/README.md
@@ -1,5 +1,0 @@
-# Only the latest stable branch maintained in the free Bitnami catalog
-
-Starting December 10th, 2024, only the latest stable branch of each container image will receive updates in the free Bitnami catalog. To access up-to-date releases for all upstream-supported branches (e.g., LTS), consider upgrading to Bitnami Premium. Previously released versions will not be deleted and will remain available for pulling from DockerHub.
-
-Please check the Bitnami Premium page in our partner [Arrow Electronics](https://www.arrow.com/globalecs/na/vendors/bitnami?utm_source=GitHub&utm_medium=containers) for more information.


### PR DESCRIPTION
This branch reached the upstream EOL