### PR TITLE
[bitnami/kaniko] #82649 - Added /bin/sh via busybox like googlecontainers-kaniko had to support…

### DIFF
--- a/bitnami/kaniko/1/debian-12/Dockerfile
+++ b/bitnami/kaniko/1/debian-12/Dockerfile
@@ -35,6 +35,9 @@ RUN mkdir -p /out/kaniko/.docker /out/etc && cp /opt/bitnami/kaniko/bin/* /out/k
 
 ######
 
+FROM busybox:musl AS busybox
+
+
 FROM scratch
 
 ARG DOWNLOADS_URL="downloads.bitnami.com/files/stacksmith"
@@ -55,12 +58,17 @@ COPY rootfs /
 COPY --from=builder /opt/bitnami/kaniko/.spdx-kaniko.spdx /opt/bitnami/kaniko/.spdx-kaniko.spdx
 COPY --from=builder /opt/bitnami/kaniko/licenses /opt/bitnami/kaniko/licenses
 COPY --from=builder /out /
+COPY --from=busybox /bin /busybox
+# Declare /busybox as a volume to get it automatically in the path to ignore
+VOLUME /busybox
+RUN ["/busybox/mkdir", "-p", "/bin"]
+RUN ["/busybox/ln", "-s", "/busybox/sh", "/bin/sh"]
 
 ENV APP_VERSION="1.25.0" \
     BITNAMI_APP_NAME="kaniko" \
     DOCKER_CONFIG="/kaniko/.docker" \
     DOCKER_CREDENTIAL_GCR_CONFIG="/kaniko/.config/gcloud/docker_credential_gcr_config.json" \
-    PATH="/kaniko" \
+    PATH="/usr/local/bin:/kaniko" \
     SSL_CERT_DIR="/etc/ssl/certs/" \
     USER="root"
 

--- a/bitnami/rust/1/debian-12/Dockerfile
+++ b/bitnami/rust/1/debian-12/Dockerfile
@@ -8,14 +8,13 @@ ARG TARGETARCH
 
 LABEL com.vmware.cp.artifact.flavor="sha256:c50c90cfd9d12b445b011e6ad529f1ad3daea45c26d20b00732fae3cd71f6a83" \
       org.opencontainers.image.base.name="docker.io/bitnami/minideb:bookworm" \
-      org.opencontainers.image.created="2025-05-30T15:59:11Z" \
+      org.opencontainers.image.created="2025-06-26T23:19:17Z" \
       org.opencontainers.image.description="Application packaged by Broadcom, Inc." \
       org.opencontainers.image.documentation="https://github.com/bitnami/containers/tree/main/bitnami/rust/README.md" \
-      org.opencontainers.image.ref.name="1.87.0-debian-12-r3" \
       org.opencontainers.image.source="https://github.com/bitnami/containers/tree/main/bitnami/rust" \
       org.opencontainers.image.title="rust" \
       org.opencontainers.image.vendor="Broadcom, Inc." \
-      org.opencontainers.image.version="1.87.0"
+      org.opencontainers.image.version="1.88.0"
 
 ENV OS_ARCH="${TARGETARCH:-amd64}" \
     OS_FLAVOUR="debian-12" \
@@ -25,9 +24,11 @@ COPY prebuildfs /
 SHELL ["/bin/bash", "-o", "errexit", "-o", "nounset", "-o", "pipefail", "-c"]
 # Install required system packages and dependencies
 RUN install_packages build-essential ca-certificates curl git libgcc-s1 libsqlite3-dev libssl-dev libssl3 libstdc++6 pkg-config procps unzip wget zlib1g
-RUN mkdir -p /tmp/bitnami/pkg/cache/ ; cd /tmp/bitnami/pkg/cache/ || exit 1 ; \
+RUN --mount=type=secret,id=downloads_url,env=SECRET_DOWNLOADS_URL \
+    DOWNLOADS_URL=${SECRET_DOWNLOADS_URL:-${DOWNLOADS_URL}} ; \
+    mkdir -p /tmp/bitnami/pkg/cache/ ; cd /tmp/bitnami/pkg/cache/ || exit 1 ; \
     COMPONENTS=( \
-      "rust-1.87.0-0-linux-${OS_ARCH}-debian-12" \
+      "rust-1.88.0-0-linux-${OS_ARCH}-debian-12" \
     ) ; \
     for COMPONENT in "${COMPONENTS[@]}"; do \
       if [ ! -f "${COMPONENT}.tar.gz" ]; then \
@@ -44,8 +45,9 @@ RUN find / -perm /6000 -type f -exec chmod a-s {} \; || true
 RUN sed -i 's/^PASS_MAX_DAYS.*/PASS_MAX_DAYS    90/' /etc/login.defs && \
     sed -i 's/^PASS_MIN_DAYS.*/PASS_MIN_DAYS    0/' /etc/login.defs && \
     sed -i 's/sha512/sha512 minlen=8/' /etc/pam.d/common-password
+RUN uninstall_packages curl
 
-ENV APP_VERSION="1.87.0" \
+ENV APP_VERSION="1.88.0" \
     BITNAMI_APP_NAME="rust" \
     PATH="/opt/bitnami/rust/bin:$PATH"
 

--- a/bitnami/rust/1/debian-12/prebuildfs/opt/bitnami/.bitnami_components.json
+++ b/bitnami/rust/1/debian-12/prebuildfs/opt/bitnami/.bitnami_components.json
@@ -3,6 +3,6 @@
         "arch": "amd64",
         "distro": "debian-12",
         "type": "NAMI",
-        "version": "1.87.0-0"
+        "version": "1.88.0-0"
     }
 }

--- a/bitnami/rust/1/debian-12/prebuildfs/usr/sbin/uninstall_packages
+++ b/bitnami/rust/1/debian-12/prebuildfs/usr/sbin/uninstall_packages
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+set -eu
+
+n=0
+max=2
+export DEBIAN_FRONTEND=noninteractive
+
+until [ $n -gt $max ]; do
+    set +e
+    (
+        apt-get autoremove --purge -y "$@"
+    )
+    CODE=$?
+    set -e
+    if [ $CODE -eq 0 ]; then
+        break
+    fi
+    if [ $n -eq $max ]; then
+        exit $CODE
+    fi
+    echo "apt failed, retrying"
+    n=$(($n + 1))
+done
+apt-get clean && rm -rf /var/lib/apt/lists /var/cache/apt/archives

--- a/bitnami/rust/1/debian-12/tags-info.yaml
+++ b/bitnami/rust/1/debian-12/tags-info.yaml
@@ -1,5 +1,5 @@
 rolling-tags:
-- "1"
-- 1-debian-12
-- 1.87.0
-- latest
+  - "1"
+  - 1-debian-12
+  - 1.88.0
+  - latest


### PR DESCRIPTION
… gitlab-cicd workflows. Signed-off-by: Sebastian Schmidt <2270806+jammsen@users.noreply.github.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Added /bin/sh for GitLab CI/CD usage

### Benefits

Now users can use GitLabs before_script to login to custom docker-registries

### Possible drawbacks

I dont really now if theese changes will introduce a possible drawback

### Applicable issues

- fixes #82649


### Additional information

Please refer to the issue i already created and described the problem im facing - See: #82649