### PR TITLE
[bitnami/pgbouncer] Remove "Loading custom scripts" log line because it can be misleading

### DIFF
--- a/bitnami/pgbouncer/1/debian-12/rootfs/opt/bitnami/scripts/libpgbouncer.sh
+++ b/bitnami/pgbouncer/1/debian-12/rootfs/opt/bitnami/scripts/libpgbouncer.sh
@@ -358,7 +358,6 @@ pgbouncer_initialize() {
 #   None
 #########################
 pgbouncer_custom_init_scripts() {
-    info "Loading custom scripts..."
     if [[ -d "$PGBOUNCER_INITSCRIPTS_DIR" ]] && [[ -n $(find "$PGBOUNCER_INITSCRIPTS_DIR/" -type f -regex ".*\.sh") ]] && [[ ! -f "$PGBOUNCER_VOLUME_DIR/.user_scripts_initialized" || "$PGBOUNCER_FORCE_INITSCRIPTS" == "true" ]]; then
         info "Loading user's custom files from $PGBOUNCER_INITSCRIPTS_DIR ..."
         find "$PGBOUNCER_INITSCRIPTS_DIR/" -type f -regex ".*\.sh" | sort | while read -r f; do


### PR DESCRIPTION
### Description of the change

The function `pgbouncer_custom_init_scripts()` starts with the log `Loading custom scripts...`. Unfortunately though, There are many use cases where nothing will get loaded or if you call it again (which was in out case), it will already have dropped the `.user_scripts_initialized` file and will refuse to load the init scripts again.

My suggestion here is to just leave the `info "Loading user's custom files from $PGBOUNCER_INITSCRIPTS_DIR ..."` as the message when it actually is loading the custom init scripts.

### Benefits

Less confusing log on subsequent runs of the method.

### Possible drawbacks

If you call the function and it does not run the init scripts, you do not get any log messages.

### Applicable issues

It is misleading to the user using the container and building on top of its logic.

### Additional information

The other option here will be to log in the else of the `if` case so we log that init scripts were in fact skipped or not found so that both the positive and negative case get logs.
