### PR TITLE
Update README.md to use correct locations when adding API support to SuiteCRM image

### DIFF
--- a/bitnami/suitecrm/README.md
+++ b/bitnami/suitecrm/README.md
@@ -465,10 +465,10 @@ Based on the extended image, you can update the [`docker-compose.yml`](https://g
 ```Dockerfile
 FROM bitnami/suitecrm
 ## Install keys
-RUN openssl genrsa -out /opt/bitnami/suitecrm/Api/V8/OAuth2/private.key 2048 && \
-    openssl rsa -in /opt/bitnami/suitecrm/Api/V8/OAuth2/private.key -pubout -out /opt/bitnami/suitecrm/Api/V8/OAuth2/public.key && \
-    chmod 640 /opt/bitnami/suitecrm/Api/V8/OAuth2/private.key && \
-    chgrp daemon /opt/bitnami/suitecrm/Api/V8/OAuth2/private.key /opt/bitnami/suitecrm/Api/V8/OAuth2/public.key
+RUN openssl genrsa -out /opt/bitnami/suitecrm/public/legacy/Api/V8/OAuth2/private.key 2048 && \
+    openssl rsa -in /opt/bitnami/suitecrm/public/legacy/Api/V8/OAuth2/private.key -pubout -out /opt/bitnami/suitecrm/public/legacy/Api/V8/OAuth2/public.key && \
+    chmod 640 /opt/bitnami/suitecrm/public/legacy/Api/V8/OAuth2/private.key && \
+    chgrp daemon /opt/bitnami/suitecrm/public/legacy/Api/V8/OAuth2/private.key /opt/bitnami/suitecrm/public/legacy/Api/V8/OAuth2/public.key
 ```
 
 ## Notable Changes


### PR DESCRIPTION
Update of documentation only.

Edited the path for creation of keys under "Example 2: Add SuiteCRM API support".

Previous path: /opt/bitnami/suitecrm/Api/V8/OAuth2/
New path: /opt/bitnami/suitecrm/public/legacyApi/V8/OAuth2/

Without this change, keys are not generated as the specified locations do not exist.

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
