### PR TITLE
[bitnami/discourse] added missing env variables to readme.md

### DIFF
--- a/bitnami/discourse/README.md
+++ b/bitnami/discourse/README.md
@@ -307,6 +307,9 @@ The set of default standard configuration files may be found [here](https://gith
 | `DISCOURSE_REDIS_PASSWORD`             | Redis(R) user password.                                                                                                         | `nil`                                   |
 | `DISCOURSE_REDIS_USE_SSL`              | Whether to enable SSL for Redis(R).                                                                                             | `no`                                    |
 | `DISCOURSE_REDIS_DB`                   | Redis(R) database number.                                                                                                       | `0`                                     |
+| `POSTGRESQL_DATABASE`                  | PostgreSQL database name.                                                                                                       | `nil`/set in compose file               |
+| `POSTGRESQL_USERNAME`                  | PostgreSQL database user.                                                                                                       | `nil`/set in compose file               |
+| `POSTGRESQL_PASSWORD`                  | PostgreSQL database user's password.                                                                                            | `nil`/set in compose file               |
 
 #### Read-only environment variables
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Discourse: Added postgresql-related env variables used in the docker compose file to the readme.md

### Benefits

Better explanation - I was looking for the variable postgresql_password but found it in neither the readme.md nor the exemplary compose file.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
