### PR TITLE
[bitnami/scylladb] Deprecate branches 6.0, 6.1 and 6.2

### DIFF
--- a/bitnami/scylladb/6.0/README.md
+++ b/bitnami/scylladb/6.0/README.md
@@ -1,5 +1,0 @@
-# Only the latest stable branch maintained in the free Bitnami catalog
-
-Starting December 10th, 2024, only the latest stable branch of each container image will receive updates in the free Bitnami catalog. To access up-to-date releases for all upstream-supported branches (e.g., LTS), consider upgrading to Bitnami Premium. Previously released versions will not be deleted and will remain available for pulling from DockerHub.
-
-Please check the Bitnami Premium page in our partner [Arrow Electronics](https://www.arrow.com/globalecs/na/vendors/bitnami?utm_source=GitHub&utm_medium=containers) for more information.

--- a/bitnami/scylladb/6.1/README.md
+++ b/bitnami/scylladb/6.1/README.md
@@ -1,5 +1,0 @@
-# Only the latest stable branch maintained in the free Bitnami catalog
-
-Starting December 10th, 2024, only the latest stable branch of each container image will receive updates in the free Bitnami catalog. To access up-to-date releases for all upstream-supported branches (e.g., LTS), consider upgrading to Bitnami Premium. Previously released versions will not be deleted and will remain available for pulling from DockerHub.
-
-Please check the Bitnami Premium page in our partner [Arrow Electronics](https://www.arrow.com/globalecs/na/vendors/bitnami?utm_source=GitHub&utm_medium=containers) for more information.

--- a/bitnami/scylladb/6.2/README.md
+++ b/bitnami/scylladb/6.2/README.md
@@ -1,5 +1,0 @@
-# Only the latest stable branch maintained in the free Bitnami catalog
-
-Starting December 10th, 2024, only the latest stable branch of each container image will receive updates in the free Bitnami catalog. To access up-to-date releases for all upstream-supported branches (e.g., LTS), consider upgrading to Bitnami Premium. Previously released versions will not be deleted and will remain available for pulling from DockerHub.
-
-Please check the Bitnami Premium page in our partner [Arrow Electronics](https://www.arrow.com/globalecs/na/vendors/bitnami?utm_source=GitHub&utm_medium=containers) for more information.


### PR DESCRIPTION
Those branches are not supported anymore in favor of 2025.1 and 2025.2, see https://docs.scylladb.com/stable/versioning/version-support.html