### PR TITLE
[bitnami/jaeger] Fix tests for v1/v2 compatibility

### DIFF
--- a/.vib/jaeger/goss/goss.yaml
+++ b/.vib/jaeger/goss/goss.yaml
@@ -5,7 +5,8 @@ gossfile:
   # Goss tests exclusive to the current container
   ../../jaeger/goss/jaeger.yaml: {}
   # Load scripts from .vib/common/goss/templates
-  ../../common/goss/templates/check-binaries.yaml: {}
+  # check-binaries tests moved to jaeger.yaml until v1 is deprecated
+  # ../../common/goss/templates/check-binaries.yaml: {}
   ../../common/goss/templates/check-broken-symlinks.yaml: {}
   ../../common/goss/templates/check-ca-certs.yaml: {}
   ../../common/goss/templates/check-directories.yaml: {}

--- a/.vib/jaeger/goss/jaeger.yaml
+++ b/.vib/jaeger/goss/jaeger.yaml
@@ -7,10 +7,20 @@ command:
     exit-status: 0
     stderr:
       - "Server created"
+  # HACK: Temporary fix for Jaeger v1 and v2 binaries
+  # Once v1 is deprecated, use regular check-app-version.yaml and check-binaries.yaml tests
   check-app-version:
-    # HACK: Temporary fix for Jaeger 1.68.0 and 2.5.0 as they do not show the version
-    # https://github.com/jaegertracing/jaeger/pull/6990
-    exec: bash -c "if [[ \"${APP_VERSION}\" == \"1.68.0\" ]] || [[ \"${APP_VERSION}\" == \"2.5.0\" ]]; then echo \"${APP_VERSION}\"; elif [[ \"${APP_VERSION}\" == \"1.\"* ]]; then jaeger-all-in-one version | grep -Po \"\d+\.\d+\.\d+\"; else jaeger-jaeger -v | sed \"s/\-0*/./g\"; fi"
+    exec: bash -c "if [[ \"${APP_VERSION}\" == \"1.\"* ]]; then jaeger-all-in-one version; else jaeger-jaeger version; fi"
     exit-status: 0
     stdout:
       - "{{ .Env.APP_VERSION }}"
+  # Jaeger v1
+  {{- range $binary := .Vars.binaries }} 
+  check-{{ $binary }}-binary-v1:
+    exec: bash -c "if [[ \"${APP_VERSION}\" == \"1.\"* ]]; then which {{ $binary }}; else exit 0; fi"
+    exit-status: 0
+  {{- end }}
+  # Jaeger v2
+  check-jaeger-binary:
+    exec: bash -c "if [[ \"${APP_VERSION}\" != \"1.\"* ]]; then which jaeger; else exit 0; fi"
+    exit-status: 0

--- a/.vib/jaeger/goss/vars.yaml
+++ b/.vib/jaeger/goss/vars.yaml
@@ -1,8 +1,11 @@
+# Jaeger v1 and v2 have different binaries.
+# check-binaries test moved to jaeger.yaml until v1 is deprecated
 binaries:
   - jaeger-ingester
   - jaeger-query
   - jaeger-all-in-one
   - jaeger-collector
+#  - jaeger # v2
 directories:
   - paths:
       - /opt/bitnami/jaeger/cassandra-schema


### PR DESCRIPTION
### Description of the change

New jaeger binary tests for jaeger v1 and v2.

### Benefits

The new tests will identify v1 and v2 images and check the correct binaries.

### Possible drawbacks

Replaces check-binaries.yaml and check-app-version.yaml common tests with tests especific for jaeger.

Needs to be reverted to common tests once v1 is deprecated.

### Additional information

Binaries in jaeger v1:
  - /opt/bitnami/jaeger/bin/jaeger-ingester
  - /opt/bitnami/jaeger/bin/jaeger-query
  - /opt/bitnami/jaeger/bin/jaeger-all-in-one
  - /opt/bitnami/jaeger/bin/jaeger-collector

Binaries in jaeger v2:
- /opt/bitnami/jaeger/bin/jaeger

We have been accidentally including both v1 and v2 binaries in both versions of the container. This will be fixed in the next release.
