### PR TITLE
Update JRE version for Jenkins and Jenkins Agent images

### DIFF
--- a/bitnami/jenkins-agent/0/debian-12/Dockerfile
+++ b/bitnami/jenkins-agent/0/debian-12/Dockerfile
@@ -30,7 +30,7 @@ RUN --mount=type=secret,id=downloads_url,env=SECRET_DOWNLOADS_URL \
     DOWNLOADS_URL=${SECRET_DOWNLOADS_URL:-${DOWNLOADS_URL}} ; \
     mkdir -p /tmp/bitnami/pkg/cache/ ; cd /tmp/bitnami/pkg/cache/ || exit 1 ; \
     COMPONENTS=( \
-      "jre-17.0.16-12-0-linux-${OS_ARCH}-debian-12" \
+      "jre-21.0.8-12-0-linux-${OS_ARCH}-debian-12" \
       "jenkins-agent-0.3327.0-0-linux-${OS_ARCH}-debian-12" \
     ) ; \
     for COMPONENT in "${COMPONENTS[@]}"; do \

--- a/bitnami/jenkins-agent/0/debian-12/prebuildfs/opt/bitnami/.bitnami_components.json
+++ b/bitnami/jenkins-agent/0/debian-12/prebuildfs/opt/bitnami/.bitnami_components.json
@@ -9,6 +9,6 @@
         "arch": "amd64",
         "distro": "debian-12",
         "type": "NAMI",
-        "version": "17.0.16-12-0"
+        "version": "21.0.8-12-0"
     }
 }

--- a/bitnami/jenkins/2/debian-12/Dockerfile
+++ b/bitnami/jenkins/2/debian-12/Dockerfile
@@ -31,7 +31,7 @@ RUN --mount=type=secret,id=downloads_url,env=SECRET_DOWNLOADS_URL \
     mkdir -p /tmp/bitnami/pkg/cache/ ; cd /tmp/bitnami/pkg/cache/ || exit 1 ; \
     COMPONENTS=( \
       "render-template-1.0.8-1-linux-${OS_ARCH}-debian-12" \
-      "jre-17.0.16-12-0-linux-${OS_ARCH}-debian-12" \
+      "jre-21.0.8-12-0-linux-${OS_ARCH}-debian-12" \
       "jenkins-2.516.1-0-linux-${OS_ARCH}-debian-12" \
     ) ; \
     for COMPONENT in "${COMPONENTS[@]}"; do \

--- a/bitnami/jenkins/2/debian-12/prebuildfs/opt/bitnami/.bitnami_components.json
+++ b/bitnami/jenkins/2/debian-12/prebuildfs/opt/bitnami/.bitnami_components.json
@@ -9,7 +9,7 @@
         "arch": "amd64",
         "distro": "debian-12",
         "type": "NAMI",
-        "version": "17.0.16-12-0"
+        "version": "21.0.8-12-0"
     },
     "render-template": {
         "arch": "amd64",


### PR DESCRIPTION
### Description of the change

Update the Java version to 21 for the `jenkins` and `jenkins-agent` images.

### Benefits

While recent Jenkins versions still work fine with Java 17, there are already annoying warning messages indicating that Java 17's end-of-life support will occur on or after March 31, 2026. Additionally, the official Jenkins images starting from version 2.509 already use Java 21.

<img width="2736" height="270" alt="CleanShot 2025-07-28 at 17 08 23@2x" src="https://github.com/user-attachments/assets/9c78b996-abfb-45cc-b5a7-a9ede9a61512" />

### Possible drawbacks

You need to consider the [Java 17 to 21 upgrade guidelines](https://www.jenkins.io/doc/book/platform-information/upgrade-java-to-21/) when upgrading an existing Jenkins setup to a newer version.

### Additional information

- https://www.jenkins.io/doc/book/platform-information/support-policy-java/
- https://www.jenkins.io/changelog/2.509/
