### PR TITLE
[bitnami/nginx] Add support for context-based configuration includes

### DIFF
--- a/bitnami/nginx/1.29/debian-12/rootfs/opt/bitnami/nginx/conf/nginx.conf
+++ b/bitnami/nginx/1.29/debian-12/rootfs/opt/bitnami/nginx/conf/nginx.conf
@@ -5,11 +5,11 @@ worker_processes  auto;
 error_log         "/opt/bitnami/nginx/logs/error.log";
 pid               "/opt/bitnami/nginx/tmp/nginx.pid";
 
-include  "/opt/bitnami/nginx/conf/by_context/main/*.conf";
+include  "/opt/bitnami/nginx/conf/context.d/main/*.conf";
 
 events {
     worker_connections  1024;
-    include  "/opt/bitnami/nginx/conf/by_context/events/*.conf";
+    include  "/opt/bitnami/nginx/conf/context.d/events/*.conf";
 }
 
 http {
@@ -45,7 +45,7 @@ http {
     port_in_redirect   off;
 
     include  "/opt/bitnami/nginx/conf/server_blocks/*.conf";
-    include  "/opt/bitnami/nginx/conf/by_context/http/*.conf";
+    include  "/opt/bitnami/nginx/conf/context.d/http/*.conf";
 
     # HTTP Server
     server {

--- a/bitnami/nginx/1.29/debian-12/rootfs/opt/bitnami/nginx/conf/nginx.conf
+++ b/bitnami/nginx/1.29/debian-12/rootfs/opt/bitnami/nginx/conf/nginx.conf
@@ -5,8 +5,11 @@ worker_processes  auto;
 error_log         "/opt/bitnami/nginx/logs/error.log";
 pid               "/opt/bitnami/nginx/tmp/nginx.pid";
 
+include  "/opt/bitnami/nginx/conf/by_context/main/*.conf";
+
 events {
     worker_connections  1024;
+    include  "/opt/bitnami/nginx/conf/by_context/events/*.conf";
 }
 
 http {
@@ -42,6 +45,7 @@ http {
     port_in_redirect   off;
 
     include  "/opt/bitnami/nginx/conf/server_blocks/*.conf";
+    include  "/opt/bitnami/nginx/conf/by_context/http/*.conf";
 
     # HTTP Server
     server {

--- a/bitnami/nginx/1.29/debian-12/rootfs/opt/bitnami/scripts/nginx/postunpack.sh
+++ b/bitnami/nginx/1.29/debian-12/rootfs/opt/bitnami/scripts/nginx/postunpack.sh
@@ -37,11 +37,26 @@ nginx_patch_httpoxy_vulnerability() {
 # Remove unnecessary directories that come with the tarball
 rm -rf "${BITNAMI_ROOT_DIR}/certs" "${BITNAMI_ROOT_DIR}/server_blocks"
 
+# Context include directories
+NGINX_CONTEXT_INCLUDES=(
+    "main"
+    "events"
+    "http"
+)
+
 # Ensure non-root user has write permissions on a set of directories
 chmod g+w "$NGINX_BASE_DIR"
 for dir in "$NGINX_VOLUME_DIR" "$NGINX_CONF_DIR" "$NGINX_INITSCRIPTS_DIR" "$NGINX_SERVER_BLOCKS_DIR" "$NGINX_STREAM_SERVER_BLOCKS_DIR" "${NGINX_CONF_DIR}/bitnami" "${NGINX_CONF_DIR}/bitnami/certs" "$NGINX_LOGS_DIR" "$NGINX_TMP_DIR" "$NGINX_DEFAULT_CONF_DIR"; do
     ensure_dir_exists "$dir"
     chmod -R g+rwX "$dir"
+done
+
+# Create by_context directory and context include directories
+ensure_dir_exists "${NGINX_CONF_DIR}/by_context"
+chmod -R g+rwX "${NGINX_CONF_DIR}/by_context"
+for context in "${NGINX_CONTEXT_INCLUDES[@]}"; do
+    ensure_dir_exists "${NGINX_CONF_DIR}/by_context/${context}"
+    chmod -R g+rwX "${NGINX_CONF_DIR}/by_context/${context}"
 done
 
 # Unset HTTP_PROXY header to protect vs HTTPPOXY vulnerability

--- a/bitnami/nginx/1.29/debian-12/rootfs/opt/bitnami/scripts/nginx/postunpack.sh
+++ b/bitnami/nginx/1.29/debian-12/rootfs/opt/bitnami/scripts/nginx/postunpack.sh
@@ -51,12 +51,12 @@ for dir in "$NGINX_VOLUME_DIR" "$NGINX_CONF_DIR" "$NGINX_INITSCRIPTS_DIR" "$NGIN
     chmod -R g+rwX "$dir"
 done
 
-# Create by_context directory and context include directories
-ensure_dir_exists "${NGINX_CONF_DIR}/by_context"
-chmod -R g+rwX "${NGINX_CONF_DIR}/by_context"
+# Create context.d directory and context include directories
+ensure_dir_exists "${NGINX_CONF_DIR}/context.d"
+chmod -R g+rwX "${NGINX_CONF_DIR}/context.d"
 for context in "${NGINX_CONTEXT_INCLUDES[@]}"; do
-    ensure_dir_exists "${NGINX_CONF_DIR}/by_context/${context}"
-    chmod -R g+rwX "${NGINX_CONF_DIR}/by_context/${context}"
+    ensure_dir_exists "${NGINX_CONF_DIR}/context.d/${context}"
+    chmod -R g+rwX "${NGINX_CONF_DIR}/context.d/${context}"
 done
 
 # Unset HTTP_PROXY header to protect vs HTTPPOXY vulnerability

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -159,9 +159,9 @@ services:
 
 The default `nginx.conf` supports custom configuration files organized by NGINX context. You can mount configuration files into the appropriate context directories:
 
-- `/opt/bitnami/nginx/conf/by_context/main/` - For main context directives (e.g., module loading, worker processes)
-- `/opt/bitnami/nginx/conf/by_context/events/` - For events context directives (e.g., worker_connections)
-- `/opt/bitnami/nginx/conf/by_context/http/` - For http context directives (equivalent to server_blocks)
+- `/opt/bitnami/nginx/conf/context.d/main/` - For main context directives (e.g., module loading, worker processes)
+- `/opt/bitnami/nginx/conf/context.d/events/` - For events context directives (e.g., worker_connections)
+- `/opt/bitnami/nginx/conf/context.d/http/` - For http context directives (equivalent to server_blocks)
 
 For example, to enable the WebDAV module, create a `webdav.conf` file with the following content:
 
@@ -173,7 +173,7 @@ Mount it to the main context directory:
 
 ```console
 docker run --name nginx \
-  -v /path/to/webdav.conf:/opt/bitnami/nginx/conf/by_context/main/webdav.conf:ro \
+  -v /path/to/webdav.conf:/opt/bitnami/nginx/conf/context.d/main/webdav.conf:ro \
   bitnami/nginx:latest
 ```
 
@@ -184,7 +184,7 @@ services:
   nginx:
   ...
     volumes:
-      - /path/to/webdav.conf:/opt/bitnami/nginx/conf/by_context/main/webdav.conf:ro
+      - /path/to/webdav.conf:/opt/bitnami/nginx/conf/context.d/main/webdav.conf:ro
   ...
 ```
 
@@ -192,7 +192,7 @@ Similarly, you can add custom server blocks to the http context:
 
 ```console
 docker run --name nginx \
-  -v /path/to/my_server_block.conf:/opt/bitnami/nginx/conf/by_context/http/my_server_block.conf:ro \
+  -v /path/to/my_server_block.conf:/opt/bitnami/nginx/conf/context.d/http/my_server_block.conf:ro \
   bitnami/nginx:latest
 ```
 

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -155,6 +155,47 @@ services:
   ...
 ```
 
+### Adding custom configuration by context
+
+The default `nginx.conf` supports custom configuration files organized by NGINX context. You can mount configuration files into the appropriate context directories:
+
+- `/opt/bitnami/nginx/conf/by_context/main/` - For main context directives (e.g., module loading, worker processes)
+- `/opt/bitnami/nginx/conf/by_context/events/` - For events context directives (e.g., worker_connections)
+- `/opt/bitnami/nginx/conf/by_context/http/` - For http context directives (equivalent to server_blocks)
+
+For example, to enable the WebDAV module, create a `webdav.conf` file with the following content:
+
+```nginx
+load_module /opt/bitnami/nginx/modules/ngx_http_dav_module.so;
+```
+
+Mount it to the main context directory:
+
+```console
+docker run --name nginx \
+  -v /path/to/webdav.conf:/opt/bitnami/nginx/conf/by_context/main/webdav.conf:ro \
+  bitnami/nginx:latest
+```
+
+or by modifying the [`docker-compose.yml`](https://github.com/bitnami/containers/blob/main/bitnami/nginx/docker-compose.yml) file:
+
+```yaml
+services:
+  nginx:
+  ...
+    volumes:
+      - /path/to/webdav.conf:/opt/bitnami/nginx/conf/by_context/main/webdav.conf:ro
+  ...
+```
+
+Similarly, you can add custom server blocks to the http context:
+
+```console
+docker run --name nginx \
+  -v /path/to/my_server_block.conf:/opt/bitnami/nginx/conf/by_context/http/my_server_block.conf:ro \
+  bitnami/nginx:latest
+```
+
 ### Adding custom stream server blocks
 
 Similar to server blocks, you can include server blocks for the [NGINX Stream Core Module](https://nginx.org/en/docs/stream/ngx_stream_core_module.html) mounting them at `/opt/bitnami/nginx/conf/stream_server_blocks/`. In order to do so, it's also necessary to set the `NGINX_ENABLE_STREAM` environment variable to `yes`.


### PR DESCRIPTION
This is the first part of the changes needed for: https://github.com/bitnami/charts/issues/35313

> I propose to introduce includes for each context, instead of server_block, call them by the name of the context. So I can provide particular snippet that is going to be included in existing config of main/events/http/... or any other contexts.


What has been done:
- Add by_context directory structure for organized configuration includes
- Support main, events, and http context directories
- Enable easy module loading in main context (e.g., WebDAV module)
- Maintain backward compatibility with existing server_blocks (I don't know what deprecation policies you have, so I haven't removed it yet).
- Update documentation with examples for all context types