### PR TITLE
[bitnami/airflow] Allow multiple executors with CeleryExecutor

### DIFF
--- a/bitnami/airflow/3/debian-12/rootfs/opt/bitnami/scripts/libairflow.sh
+++ b/bitnami/airflow/3/debian-12/rootfs/opt/bitnami/scripts/libairflow.sh
@@ -111,7 +111,7 @@ airflow_validate() {
     check_resolved_hostname "$AIRFLOW_DATABASE_HOST"
     check_positive_value AIRFLOW_DATABASE_PORT_NUMBER
     check_positive_value REDIS_PORT_NUMBER
-    if [[ "$AIRFLOW_EXECUTOR" == "CeleryExecutor" || "$AIRFLOW_EXECUTOR" == "CeleryKubernetesExecutor"  ]]; then
+    if [[ "$AIRFLOW_EXECUTOR" =~ "CeleryExecutor" || "$AIRFLOW_EXECUTOR" == "CeleryKubernetesExecutor"  ]]; then
         check_empty_value "REDIS_HOST"
         check_resolved_hostname "$REDIS_HOST"
     fi
@@ -227,7 +227,7 @@ airflow_initialize() {
         airflow_wait_for_db_migrations
         info "Waiting for admin user to be created"
         airflow_wait_for_admin_user
-        if [[ "$AIRFLOW_EXECUTOR" == "CeleryExecutor" || "$AIRFLOW_EXECUTOR" == "CeleryKubernetesExecutor"  ]]; then
+        if [[ "$AIRFLOW_EXECUTOR" =~ "CeleryExecutor" || "$AIRFLOW_EXECUTOR" == "CeleryKubernetesExecutor"  ]]; then
             wait-for-port --host "$REDIS_HOST" "$REDIS_PORT_NUMBER"
         fi
         ;;
@@ -347,7 +347,7 @@ airflow_generate_config() {
 
     # Configure Airflow executor
     airflow_conf_set "core" "executor" "$AIRFLOW_EXECUTOR"
-    [[ "$AIRFLOW_EXECUTOR" == "CeleryExecutor" || "$AIRFLOW_EXECUTOR" == "CeleryKubernetesExecutor" ]] && airflow_configure_celery_executor
+    [[ "$AIRFLOW_EXECUTOR" =~ "CeleryExecutor" || "$AIRFLOW_EXECUTOR" == "CeleryKubernetesExecutor" ]] && airflow_configure_celery_executor
     true # Avoid the function to fail due to the check above
 }
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Allow use of multiple executors as available since [Airflow 2.10.0](https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/executor/index.html#using-multiple-executors-concurrently)

Related [Helm Chart PR](https://github.com/bitnami/charts/pull/35423)

This is a follow up to #71461

### Benefits

Airflow 3.x does not allow hybrid executors to be used anymore in favor of the multiple executor syntax.

The current Bitnami chart for 3.0.3 will not spawn a celery worker when using the new multiple executor syntax because it is checking for an exact match on `CeleryExecutor`.

Making effectively impossible to deploy a hybrid Celery/k8s environment with 3.0.3.

### Possible drawbacks

The condition change preserves backwards compatibility so I don't see any.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

References

- https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/executor/index.html#using-multiple-executors-concurrently
- Helm Chart PR https://github.com/bitnami/charts/pull/35423
- Previous PR: #71461