### PR TITLE
fix(ci-pipeline): Add condition to license check

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -60,6 +60,9 @@ jobs:
       contents: read
       pull-requests: write
     needs: get-containers
+    if: |
+      needs.get-containers.outputs.result == 'ok' &&
+      github.event.pull_request.user.login != 'bitnami-bot'
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         name: Checkout Repository


### PR DESCRIPTION
### Description of the change

Add condition to license check. Label `verify` is required to run the license checks.

### Benefits

First review is required to run the license checks. 

### Possible drawbacks

None

### Applicable issues

- fixes https://github.com/bitnami/containers/security/code-scanning/17

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
