### PR TITLE
fix(ci-pipeline): check license headers in automated PRs

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -61,8 +61,7 @@ jobs:
       pull-requests: write
     needs: get-containers
     if: |
-      needs.get-containers.outputs.result == 'ok' &&
-      github.event.pull_request.user.login != 'bitnami-bot'
+      needs.get-containers.outputs.result == 'ok'
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         name: Checkout Repository


### PR DESCRIPTION
### Description of the change

Follow up: #86100

Run `license-headers-linter` in automated PRs.

### Benefits

Automated PRs can be merged.

### Possible drawbacks

None

