### PR TITLE
[bitnami/keycloak] Fix Keycloak 26.5.0 startup failure with empty HTTPS env vars

### DIFF
--- a/bitnami/keycloak/26/debian-12/rootfs/opt/bitnami/scripts/keycloak/run.sh
+++ b/bitnami/keycloak/26/debian-12/rootfs/opt/bitnami/scripts/keycloak/run.sh
@@ -15,6 +15,17 @@ set -o pipefail
 # Load Keycloak environment variables
 . /opt/bitnami/scripts/keycloak-env.sh
 
+# Keycloak 26.5.0 introduced stricter validation for certain configuration options
+for env_var in \
+    "KC_HTTPS_TRUST_STORE_FILE" \
+    "KC_HTTPS_TRUST_STORE_PASSWORD" \
+    "KC_HTTPS_KEY_STORE_FILE" \
+    "KC_HTTPS_KEY_STORE_PASSWORD" \
+    "KC_HTTPS_CERTIFICATE_FILE" \
+    "KC_HTTPS_CERTIFICATE_KEY_FILE"; do
+    [[ -z "${!env_var:-}" ]] && unset "$env_var"
+done
+
 start_command=("${KEYCLOAK_BIN_DIR}/kc.sh" "-cf" "${KEYCLOAK_CONF_DIR}/${KEYCLOAK_CONF_FILE}")
 # Prepend extra args
 if [[ -n "$KEYCLOAK_EXTRA_ARGS_PREPENDED" ]]; then

--- a/bitnami/keycloak/26/debian-12/rootfs/opt/bitnami/scripts/keycloak/setup.sh
+++ b/bitnami/keycloak/26/debian-12/rootfs/opt/bitnami/scripts/keycloak/setup.sh
@@ -15,6 +15,17 @@ set -o pipefail
 # Load Keycloak environment variables
 . /opt/bitnami/scripts/keycloak-env.sh
 
+# Keycloak 26.5.0 introduced stricter validation for certain configuration options
+for env_var in \
+    "KC_HTTPS_TRUST_STORE_FILE" \
+    "KC_HTTPS_TRUST_STORE_PASSWORD" \
+    "KC_HTTPS_KEY_STORE_FILE" \
+    "KC_HTTPS_KEY_STORE_PASSWORD" \
+    "KC_HTTPS_CERTIFICATE_FILE" \
+    "KC_HTTPS_CERTIFICATE_KEY_FILE"; do
+    [[ -z "${!env_var:-}" ]] && unset "$env_var"
+done
+
 # Ensure Keycloak environment variables are valid
 keycloak_validate
 


### PR DESCRIPTION
Keycloak 26.5.0 introduced stricter validation for configuration options. Empty string values are now rejected with the error:
```
Invalid empty value for option 'KC_HTTPS_CERTIFICATE_KEY_FILE'
```

The current `keycloak-env.sh` exports HTTPS-related environment variables with empty string defaults:
```bash
export KC_HTTPS_CERTIFICATE_KEY_FILE="${KC_HTTPS_CERTIFICATE_KEY_FILE:-}"
```

This causes Keycloak 26.5.0+ to fail on startup when TLS is disabled (common in edge-terminated reverse proxy setups).

This PR adds a loop to `run.sh` and `setup.sh` that unsets these environment variables if they are empty, after loading `keycloak-env.sh`:
```bash
for env_var in \
    "KC_HTTPS_TRUST_STORE_FILE" \
    "KC_HTTPS_TRUST_STORE_PASSWORD" \
    "KC_HTTPS_KEY_STORE_FILE" \
    "KC_HTTPS_KEY_STORE_PASSWORD" \
    "KC_HTTPS_CERTIFICATE_FILE" \
    "KC_HTTPS_CERTIFICATE_KEY_FILE"; do
    [[ -z "${!env_var:-}" ]] && unset "$env_var"
done
```

**Affected variables:**
- `KC_HTTPS_TRUST_STORE_FILE`
- `KC_HTTPS_TRUST_STORE_PASSWORD`
- `KC_HTTPS_KEY_STORE_FILE`
- `KC_HTTPS_KEY_STORE_PASSWORD`
- `KC_HTTPS_CERTIFICATE_FILE`
- `KC_HTTPS_CERTIFICATE_KEY_FILE`

### Benefits

- Fixes compatibility with Keycloak 26.5.0+
- Allows users to run Keycloak behind edge-terminated reverse proxies (e.g., AWS ALB, nginx) without TLS configuration
- No breaking changes for existing setups that use TLS - variables with values continue to work as before

### Possible drawbacks

None identified. This change only affects the behavior when the variables are empty/unset, which was causing failures anyway in Keycloak 26.5.0+.

### Applicable issues

- fixes #89326

### Additional information

**Tested with:**
- Keycloak 26.5.0 behind AWS ALB with edge-terminated TLS
- Configuration:
  - `KEYCLOAK_PRODUCTION=true`
  - `KC_HTTP_ENABLED=true`
  - `KC_PROXY_HEADERS=xforwarded`
  - `KEYCLOAK_ENABLE_HTTPS=false` (default)

**References:**
- Keycloak 26.5.0 Release: https://www.keycloak.org/2026/01/keycloak-2650-released
- Keycloak Reverse Proxy Guide: https://www.keycloak.org/server/reverseproxy

**Error before fix:**
```
INFO  ==> ** keycloak setup finished! **
INFO  ==> ** Starting Keycloak **
Appending additional Java properties to JAVA_OPTS
Changes detected in configuration. Updating the server image.
Invalid empty value for option 'KC_HTTPS_CERTIFICATE_KEY_FILE'
```