### PR TITLE
[bitnami/nginx] Fix include order for context.d/http ConfigMaps

### DIFF
--- a/bitnami/nginx/1.29/debian-12/rootfs/opt/bitnami/nginx/conf/nginx.conf
+++ b/bitnami/nginx/1.29/debian-12/rootfs/opt/bitnami/nginx/conf/nginx.conf
@@ -44,8 +44,8 @@ http {
     absolute_redirect  off;
     port_in_redirect   off;
 
-    include  "/opt/bitnami/nginx/conf/server_blocks/*.conf";
     include  "/opt/bitnami/nginx/conf/context.d/http/*.conf";
+    include  "/opt/bitnami/nginx/conf/server_blocks/*.conf";
 
     # HTTP Server
     server {


### PR DESCRIPTION
## Description

When using the Bitnami nginx Helm chart with `existingContextHttpConfigmaps` to define `log_format` or `map` directives, nginx fails to start because server_blocks are included before context.d/http files.

## Problem

The current `nginx.conf` includes files in this order:
```nginx
include  "/opt/bitnami/nginx/conf/server_blocks/*.conf";    # First - uses directives
include  "/opt/bitnami/nginx/conf/context.d/http/*.conf";   # After - defines directives
```

This causes nginx to fail with errors like:
```
nginx: [emerg] unknown log format "main_with_upstream"
```

## Solution

This PR swaps the include order so that:
1. `context.d/http/*.conf` loads **first** (defines log_format, map, upstream, geo)
2. `server_blocks/*.conf` loads **after** (uses those definitions)

## Backward Compatibility

✅ This fix is **backward compatible** because:
- Definitional directives (`log_format`, `map`, `upstream`, `geo`) don't depend on server blocks
- Users not using `context.d/http` ConfigMaps will see no difference
- Semantically, context should be loaded before blocks that consume it

## Testing

Discovered and tested while using the Bitnami nginx Helm chart in production.

Fixes: bitnami/charts#36460