### PR TITLE
[bitnami/mongodb-sharded] Ensure secondary keeps votes and priority after restart

### DIFF
--- a/bitnami/mongodb-sharded/8.3/debian-12/rootfs/opt/bitnami/scripts/libmongodb.sh
+++ b/bitnami/mongodb-sharded/8.3/debian-12/rootfs/opt/bitnami/scripts/libmongodb.sh
@@ -942,6 +942,32 @@ EOF
 }
 
 ########################
+# Get if secondary node already has voting rights
+# Globals:
+#   MONGODB_*
+# Arguments:
+#   $1 - node
+#   $2 - port
+# Returns:
+#   Boolean
+#########################
+mongodb_secondary_node_has_voting_rights() {
+    local -r node="${1:?node is required}"
+    local -r port="${2:?port is required}"
+    local result
+
+    debug "Checking voting rights of the node"
+    result=$(
+        mongodb_execute_print_output "$MONGODB_INITIAL_PRIMARY_ROOT_USER" "$MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD" "admin" "$MONGODB_INITIAL_PRIMARY_HOST" "$MONGODB_INITIAL_PRIMARY_PORT_NUMBER" <<EOF
+rs.conf().members.filter(m => m.host === '$node:$port' && m.votes > 0 && m.priority > 0).length === 1
+EOF
+    )
+    debug "$result"
+
+    grep -q "true" <<<"$result"
+}
+
+########################
 # Get if hidden node is pending
 # Globals:
 #   MONGODB_*
@@ -1177,7 +1203,15 @@ mongodb_configure_secondary() {
             exit 1
         fi
         mongodb_wait_confirmation "$node" "$port"
+    fi
 
+    # Grant voting rights to the node if it does not have them yet. This must be
+    # done even when the node is already in the cluster: a previous attempt may
+    # have added it with votes/priority 0 and failed (or been restarted) before
+    # granting voting rights, leaving the node stuck without them.
+    if mongodb_secondary_node_has_voting_rights "$node" "$port"; then
+        info "Node already has voting rights"
+    else
         # Ensure that secondary nodes do not count as voting members until they are fully initialized
         # https://docs.mongodb.com/manual/reference/method/rs.add/#behavior
         if ! retry_while "mongodb_is_secondary_node_ready $node $port" "$MONGODB_INIT_RETRY_ATTEMPTS" "$MONGODB_INIT_RETRY_DELAY"; then
@@ -1188,17 +1222,16 @@ mongodb_configure_secondary() {
         # Grant voting rights to node
         # https://docs.mongodb.com/manual/tutorial/modify-psa-replica-set-safely/
         if ! retry_while "mongodb_configure_secondary_node_voting $node $port" "$MONGODB_INIT_RETRY_ATTEMPTS" "$MONGODB_INIT_RETRY_DELAY"; then
-            error "Secondary node did not get marked as secondary"
+            error "Secondary node did not get granted voting rights"
             exit 1
         fi
+    fi
 
-        # Mark node as readable. This is necessary in cases where the PVC is lost
-        if is_boolean_yes "$MONGODB_SET_SECONDARY_OK"; then
-            mongodb_execute_print_output "$MONGODB_INITIAL_PRIMARY_ROOT_USER" "$MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD" "admin" <<EOF
+    # Mark node as readable. This is necessary in cases where the PVC is lost
+    if is_boolean_yes "$MONGODB_SET_SECONDARY_OK"; then
+        mongodb_execute_print_output "$MONGODB_INITIAL_PRIMARY_ROOT_USER" "$MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD" "admin" <<EOF
 rs.secondaryOk()
 EOF
-        fi
-
     fi
 }
 


### PR DESCRIPTION
### Description of the change

When a secondary first joins a replica set, `mongodb_configure_secondary()` adds it with `votes: 0, priority: 0` (MongoDB's [recommended safe procedure](https://docs.mongodb.com/manual/reference/method/rs.add/#behavior)) and only grants voting rights on the freshly-added code path (inside the `else` branch of the "node currently in the cluster" check).

The problem is that the promotion to `votes: 1, priority: 1` happens only on the boot that first adds the node. If a previous attempt added the node but the container failed or was restarted *before* the voting-rights step ran, the next boot takes the **"Node currently in the cluster"** branch and skips promotion entirely. The member is then left stranded at `votes: 0, priority: 0` forever.

This change makes the voting-rights grant idempotent and re-runnable:

- adds `mongodb_secondary_node_has_voting_rights()`, which checks via `rs.conf()` whether a member already has `votes > 0 && priority > 0`;
- moves the voting-rights grant out of the "freshly added" branch so it runs **whenever voting rights are missing** — even for a node already in the cluster — letting an interrupted bootstrap converge to `votes: 1, priority: 1` on the next run;
- fixes the misleading error message printed for the voting step (`"did not get marked as secondary"` -> `"did not get granted voting rights"`).

### Benefits

Prevents a replica set from being silently left with a single voting member. With a 3-node set, a node stranded at `votes: 0, priority: 0` reduces the set to one voter — a single point of failure: if that node goes down, the set can no longer elect a primary and goes read-only. After this change, a member that is already present but under-privileged is repaired on the next bootstrap instead of remaining non-voting.

### Possible drawbacks

- The "mark node as readable" (`rs.secondaryOk()`) step now also runs on the already-in-cluster path when `MONGODB_SET_SECONDARY_OK` is enabled. This is idempotent and consistent with the intent of that flag.
- Already-broken clusters that boot from persisted data will not self-heal from the image alone, since that path skips replica-set (re)configuration entirely; those still need a one-time manual `rs.reconfig()`. This change guarantees correct behavior for new bootstraps and any path where `mongodb_configure_secondary` runs against an under-privileged member.

### Applicable issues

_None._

### Additional information

This was discovered and validated downstream in Scality's Zenko project, where two clusters on the same MongoDB version diverged (one healthy with 3 voters, one broken with 1 voter). The same fix has been applied there; this PR proposes it upstream against the latest `mongodb-sharded` version (8.3). The change is identical for the 8.0/8.2 script variants.
