### PR TITLE
[bitnami/valkey-cluster] Migrate legacy nodes.sh format in valkey_cluster_update_ips

### DIFF
--- a/bitnami/valkey-cluster/9.1/debian-12/rootfs/opt/bitnami/scripts/libvalkeycluster.sh
+++ b/bitnami/valkey-cluster/9.1/debian-12/rootfs/opt/bitnami/scripts/libvalkeycluster.sh
@@ -218,6 +218,18 @@ valkey_cluster_update_ips() {
             printf "%s=\"%s\"\n" "$key" "${host_2_ip_array[$key]}" >> "${VALKEY_DATA_DIR}/nodes.sh"
         done
     else
+        info "Updating Valkey cluster IPs"
+        # Safeguard to detect old format on nodes.sh
+        if grep -q "declare -A host_2_ip_array=" "${VALKEY_DATA_DIR}/nodes.sh"; then
+            # Transform the old format to the new format in a sub-shell
+            (
+                source "${VALKEY_DATA_DIR}/nodes.sh"
+                for host in "${!host_2_ip_array[@]}"; do
+                    echo "${host}=\"${host_2_ip_array[$host]}\""
+                done
+            ) > "${VALKEY_DATA_DIR}/nodes.sh.new"
+            mv "${VALKEY_DATA_DIR}/nodes.sh.new" "${VALKEY_DATA_DIR}/nodes.sh"
+        fi
         # The cluster was already started, let's read hosts and IPs from the nodes.sh file
         while IFS= read -r line || [[ -n "$line" ]]; do
             # Skip blank lines and shell comments


### PR DESCRIPTION
### Description of the change

`valkey_cluster_update_ips()` exits with an error when `${VALKEY_DATA_DIR}/nodes.sh` was persisted by a previous image revision in the legacy single-line `declare -A host_2_ip_array=(...)` format. The current reader only accepts the line-based `HOST="IP"` format:

```
valkey-cluster ERROR ==> Invalid line format in nodes.sh: declare -A host_2_ip_array=([valkey-cluster-0.valkey-cluster-headless]="10.42.1.20" ...)
```

Nodes with an existing data volume then crash-loop on startup after upgrading the image.

This ports the safeguard already shipped in `bitnami/redis-cluster` `8.8.0-debian-12-r3` (41a5b7dda59c4382b93c6f119875919eb0a4c351) to `valkey-cluster`: detect the legacy format and rewrite the file to the line-based format before reading it. The code is identical to the redis-cluster fix apart from the `REDIS_`→`VALKEY_` naming.

### Benefits

Existing clusters with a persisted `nodes.sh` in the legacy format can restart and upgrade without manual intervention, matching the behavior of `bitnami/redis-cluster`.

### Possible drawbacks

None known. Volumes already using the line-based format are unaffected (the safeguard is a no-op for them).

### Additional information

Reproduction: run `valkey-cluster` with dynamic IPs (the default) on an image revision that persisted `nodes.sh` via `declare -p`, then upgrade to `9.1.0-debian-12`. The node crash-loops with the error above. Same root cause as #94313, which covered `redis-cluster` only.