### PR TITLE
[bitnami/valkey-cluster] Fix valkey_conf_set stripping dashes from values

### DIFF
--- a/bitnami/valkey-cluster/9.1/debian-12/rootfs/opt/bitnami/scripts/libvalkey.sh
+++ b/bitnami/valkey-cluster/9.1/debian-12/rootfs/opt/bitnami/scripts/libvalkey.sh
@@ -54,9 +54,11 @@ valkey_conf_set() {
     value="${value//\\/\\\\}"
     value="${value//&/\\&}"
     value="${value//\?/\\?}"
-    # 2. \000-\037 strips all ASCII control characters (0-31)
+    # 2. \001-\037 strips all ASCII control characters (1-31)
+    #    NUL is excluded: Bash cannot store it, so including it turns the range
+    #    into a literal '-' that would strip dashes from the value
     # 3. \177 strips DEL (delete) character (127)
-    value="${value//[$'\000'-$'\037'$'\177']}"
+    value="${value//[$'\001'-$'\037'$'\177']}"
     # 4. If the value is empty, set it to an empty string
     [[ "$value" = "" ]] && value="\"$value\""
 


### PR DESCRIPTION
### Description of the change

The sanitization step in `valkey_conf_set()` intends to strip ASCII control characters:

```bash
value="${value//[$'\000'-$'\037'$'\177']}"
```

However, Bash cannot store NUL (`\000`) in a string, so the lower bound of the range is silently dropped and the bracket expression begins with a literal `-`. As a result the substitution removes every dash from the value, in addition to the control characters:

```console
$ value="my-announce-hostname.example-ns.svc"
$ echo "${value//[$'\000'-$'\037'$'\177']}"
myannouncehostname.examplens.svc
```

Any dash-containing value written through `valkey_conf_set` is corrupted. For example `cluster-announce-hostname` set via `VALKEY_CLUSTER_ANNOUNCE_HOSTNAME` ends up mangled in `valkey.conf`, and clients using hostname-based cluster topology (`cluster-preferred-endpoint-type hostname`) cannot resolve the announced names.

Starting the range at `\001` restores the intended behavior. Nothing is lost by excluding NUL, since it can never occur in a shell variable.

### Benefits

Values containing dashes (FQDNs, etc.) survive sanitization intact; control characters (1-31) and DEL (127) are still stripped:

```console
$ value="my-announce-hostname.example-ns.svc"
$ echo "${value//[$'\001'-$'\037'$'\177']}"
my-announce-hostname.example-ns.svc
```

### Possible drawbacks

None known. The effective sanitized set is unchanged (NUL cannot appear in a Bash string).

### Additional information

The same pattern is present in other containers sharing this helper, e.g. `redis_conf_set()` in `bitnami/redis-cluster`'s `libredis.sh`, which would benefit from the same one-character fix.