### PR TITLE
[bitnami/argo-rollouts] Add marketing README for argo-rollouts and kubectl-argo-rollouts

### DIFF
--- a/bitnami/argo-rollouts/README.md
+++ b/bitnami/argo-rollouts/README.md
@@ -1,0 +1,73 @@
+# Bitnami Secure Image for Argo Rollouts
+
+> Argo Rollouts is a Kubernetes controller and set of CRDs for progressive delivery strategies such as canary and blue-green deployments.
+
+[Overview of Argo Rollouts](https://argoproj.github.io/rollouts/)
+Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
+
+## TL;DR
+
+```console
+docker run -it --name argo-rollouts bitnami/argo-rollouts:latest
+```
+
+## Why use Bitnami Secure Images?
+
+Those are hardened, minimal CVE images built and maintained by Bitnami. Bitnami Secure Images are based on the cloud-optimized, security-hardened enterprise [OS Photon Linux](https://vmware.github.io/photon/). Why choose BSI images?
+
+- Hardened secure images of popular open source software with Near-Zero Vulnerabilities
+- Vulnerability Triage & Prioritization with VEX Statements, KEV and EPSS Scores
+- Compliance focus with FIPS, STIG, and air-gap options, including secure bill of materials (SBOM)
+- Software supply chain provenance attestation through in-toto
+- First class support for the internet's favorite Helm charts
+
+Each image comes with valuable security metadata. You can view the metadata in [our public catalog here](https://app-catalog.vmware.com/bitnami/apps). Note: Some data is only available with [commercial subscriptions to BSI](https://bitnami.com/).
+
+![Alt text](https://github.com/bitnami/containers/blob/main/BSI%20UI%201.png?raw=true "Application details")
+![Alt text](https://github.com/bitnami/containers/blob/main/BSI%20UI%202.png?raw=true "Packaging report")
+
+If you are looking for our previous generation of images based on Debian Linux, please see the [Bitnami Legacy registry](https://hub.docker.com/u/bitnamilegacy).
+
+## Supported tags and respective `Dockerfile` links
+
+Learn more about the Bitnami tagging policy and the difference between rolling tags and immutable tags [in our documentation page](https://techdocs.broadcom.com/us/en/vmware-tanzu/application-catalog/tanzu-application-catalog/services/tac-doc/apps-tutorials-understand-rolling-tags-containers-index.html).
+
+## Get this image
+
+The Bitnami Argo Rollouts Docker image is only available to [Bitnami Secure Images](https://bitnami.com) customers.
+
+## Configuration
+
+The following section describes how to run commands
+
+### Running commands
+
+To run commands inside this container you can use `docker run`, for example to execute `rollouts-controller --help` you can follow the example below:
+
+```console
+docker run --rm --name argo-rollouts bitnami/argo-rollouts:latest --help
+```
+
+Check the [official Argo Rollouts documentation](https://argoproj.github.io/argo-rollouts/) for the list of the available parameters.
+
+### FIPS configuration in Bitnami Secure Images
+
+The Bitnami Argo Rollouts Docker image from the [Bitnami Secure Images](https://go-vmware.broadcom.com/contact-us) catalog includes extra features and settings to configure the container with FIPS capabilities. You can configure the next environment variables:
+
+- `GODEBUG`: controls Go FIPS mode. Use `fips140=only` (restricted), `fips140=on` (relaxed), or `fips140=off` (disabled).
+
+## License
+
+Copyright &copy; 2026 Broadcom. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+<http://www.apache.org/licenses/LICENSE-2.0>
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/bitnami/kubectl-argo-rollouts/README.md
+++ b/bitnami/kubectl-argo-rollouts/README.md
@@ -1,0 +1,77 @@
+# Bitnami Secure Image for kubectl Argo Rollouts
+
+> kubectl-argo-rollouts is a kubectl plugin and dashboard for managing and visualizing Argo Rollouts progressive delivery strategies.
+
+[Overview of kubectl Argo Rollouts](https://argoproj.github.io/rollouts/)
+Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
+
+## TL;DR
+
+```console
+docker run --name kubectl-argo-rollouts bitnami/kubectl-argo-rollouts:latest
+```
+
+## Why use Bitnami Secure Images?
+
+Those are hardened, minimal CVE images built and maintained by Bitnami. Bitnami Secure Images are based on the cloud-optimized, security-hardened enterprise [OS Photon Linux](https://vmware.github.io/photon/). Why choose BSI images?
+
+- Hardened secure images of popular open source software with Near-Zero Vulnerabilities
+- Vulnerability Triage & Prioritization with VEX Statements, KEV and EPSS Scores
+- Compliance focus with FIPS, STIG, and air-gap options, including secure bill of materials (SBOM)
+- Software supply chain provenance attestation through in-toto
+- First class support for the internet's favorite Helm charts
+
+Each image comes with valuable security metadata. You can view the metadata in [our public catalog here](https://app-catalog.vmware.com/bitnami/apps). Note: Some data is only available with [commercial subscriptions to BSI](https://bitnami.com/).
+
+![Alt text](https://github.com/bitnami/containers/blob/main/BSI%20UI%201.png?raw=true "Application details")
+![Alt text](https://github.com/bitnami/containers/blob/main/BSI%20UI%202.png?raw=true "Packaging report")
+
+If you are looking for our previous generation of images based on Debian Linux, please see the [Bitnami Legacy registry](https://hub.docker.com/u/bitnamilegacy).
+
+## Supported tags and respective `Dockerfile` links
+
+Learn more about the Bitnami tagging policy and the difference between rolling tags and immutable tags [in our documentation page](https://techdocs.broadcom.com/us/en/vmware-tanzu/application-catalog/tanzu-application-catalog/services/tac-doc/apps-tutorials-understand-rolling-tags-containers-index.html).
+
+## Get this image
+
+The Bitnami kubectl Argo Rollouts Docker image is only available to [Bitnami Secure Images](https://bitnami.com) customers.
+
+## Why use a non-root container?
+
+Non-root container images add an extra layer of security and are generally recommended for production environments. However, because they run as a non-root user, privileged tasks are typically off-limits. Learn more about non-root containers [in our docs](https://techdocs.broadcom.com/us/en/vmware-tanzu/application-catalog/tanzu-application-catalog/services/tac-doc/apps-tutorials-work-with-non-root-containers-index.html).
+
+## Configuration
+
+The following section describes how to configure the application.
+
+### Running commands
+
+To run commands inside this container you can use `docker run`, for example to execute `kubectl-argo-rollouts --help` you can follow the example below:
+
+```console
+docker run --rm --name kubectl-argo-rollouts bitnami/kubectl-argo-rollouts:latest -- --help
+```
+
+Check the [official kubectl Argo Rollouts documentation](https://argoproj.github.io/rollouts/) for more information.
+
+### FIPS configuration in Bitnami Secure Images
+
+The Bitnami kubectl Argo Rollouts Docker image from the [Bitnami Secure Images](https://go-vmware.broadcom.com/contact-us) catalog includes extra features and settings to configure the container with FIPS capabilities. You can configure the next environment variables:
+
+- `GODEBUG`: controls Go FIPS mode. Use `fips140=only` (restricted), `fips140=on` (relaxed), or `fips140=off` (disabled).
+
+## License
+
+Copyright &copy; 2026 Broadcom. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+<http://www.apache.org/licenses/LICENSE-2.0>
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
## Summary

- Add `bitnami/argo-rollouts/README.md` — new container image entry for the Argo Rollouts controller.
- Add `bitnami/kubectl-argo-rollouts/README.md` — new container image entry for the kubectl-argo-rollouts dashboard/plugin.

Both READMEs follow the same structure as existing BSI container READMEs (e.g. `argo-cd`).

FIPS section lists only `GODEBUG` (no `OPENSSL_FIPS`) since both images are scratch-based Go binaries with no OpenSSL layer.

ai-assisted=yes