### PR TITLE
[bitnami/headlamp] Add headlamp marketing readme

### DIFF
--- a/bitnami/headlamp-pluginctl/README.md
+++ b/bitnami/headlamp-pluginctl/README.md
@@ -1,0 +1,9 @@
+# Bitnami Secure Image for Headlamp PluginCtl
+
+## What is Headlamp PluginCtl?
+
+> Headlamp PluginCtl is a CLI tool for managing Headlamp plugins. It reconciles plugin installations from a configuration file against the ArtifactHub catalog.
+
+[Overview of Headlamp PluginCtl](https://headlamp.dev/)
+
+This container image is only available under the [Bitnami Secure Images initiative](https://news.broadcom.com/app-dev/broadcom-introduces-bitnami-secure-images-for-production-ready-containerized-applications).

--- a/bitnami/headlamp/README.md
+++ b/bitnami/headlamp/README.md
@@ -1,0 +1,9 @@
+# Bitnami Secure Image for Headlamp
+
+## What is Headlamp?
+
+> Headlamp is a user-friendly, extensible Kubernetes web UI that lets you monitor and manage cluster resources with plugin support.
+
+[Overview of Headlamp](https://headlamp.dev/)
+
+This container image is only available under the [Bitnami Secure Images initiative](https://news.broadcom.com/app-dev/broadcom-introduces-bitnami-secure-images-for-production-ready-containerized-applications).


### PR DESCRIPTION
Add marketing README for the Headlamp and Headlamp PluginCtl Bitnami Secure Images.

- `bitnami/headlamp/README.md`: Kubernetes web UI container
- `bitnami/headlamp-pluginctl/README.md`: plugin manager CLI container

Both images are BSI-only (not published to Docker Hub).
