### PR TITLE
[bitnami/reloader] Add reloader marketing readme

### DIFF
--- a/bitnami/reloader/README.md
+++ b/bitnami/reloader/README.md
@@ -1,0 +1,9 @@
+# Bitnami Secure Image for Reloader
+
+## What is Reloader?
+
+> Reloader is a Kubernetes controller that watches for ConfigMap and Secret changes and triggers rolling upgrades on the workloads that reference them
+
+[Overview of Reloader](https://github.com/stakater/Reloader)
+
+This container image is only available under the [Bitnami Secure Images initiative](https://news.broadcom.com/app-dev/broadcom-introduces-bitnami-secure-images-for-production-ready-containerized-applications).


### PR DESCRIPTION
## Summary

- Add a short marketing README for `reloader`, following the pattern used for other Bitnami Secure Images-only assets (e.g. `versitygw`)
- The Reloader container image is only available under the Bitnami Secure Images initiative

## Jira

[TNZ-119576](https://vmw-jira.broadcom.net/browse/TNZ-119576)

ai-assisted=yes