### PR TITLE
[bitnami/mongodb, bitnami/mongodb-sharded] Fix secondary voting-rights check always returning true

### DIFF
--- a/bitnami/mongodb-sharded/8.3/debian-12/rootfs/opt/bitnami/scripts/libmongodb.sh
+++ b/bitnami/mongodb-sharded/8.3/debian-12/rootfs/opt/bitnami/scripts/libmongodb.sh
@@ -957,14 +957,17 @@ mongodb_secondary_node_has_voting_rights() {
     local result
 
     debug "Checking voting rights of the node"
+    # mongosh prints a connection banner containing 'directConnection=true', so a
+    # plain 'true' match always succeeds. Match an explicit sentinel instead, built
+    # at runtime so the positive value never appears verbatim in the sent script.
     result=$(
         mongodb_execute_print_output "$MONGODB_INITIAL_PRIMARY_ROOT_USER" "$MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD" "admin" "$MONGODB_INITIAL_PRIMARY_HOST" "$MONGODB_INITIAL_PRIMARY_PORT_NUMBER" <<EOF
-rs.conf().members.filter(m => m.host === '$node:$port' && m.votes > 0 && m.priority > 0).length === 1
+print("HAS_VOTES_" + (rs.conf().members.some(m => m.host === '$node:$port' && m.votes > 0 && m.priority > 0) ? "YES" : "NO"))
 EOF
     )
     debug "$result"
 
-    grep -q "true" <<<"$result"
+    grep -q "HAS_VOTES_YES" <<<"$result"
 }
 
 ########################

--- a/bitnami/mongodb/8.3/debian-12/rootfs/opt/bitnami/scripts/libmongodb.sh
+++ b/bitnami/mongodb/8.3/debian-12/rootfs/opt/bitnami/scripts/libmongodb.sh
@@ -957,14 +957,17 @@ mongodb_secondary_node_has_voting_rights() {
     local result
 
     debug "Checking voting rights of the node"
+    # mongosh prints a connection banner containing 'directConnection=true', so a
+    # plain 'true' match always succeeds. Match an explicit sentinel instead, built
+    # at runtime so the positive value never appears verbatim in the sent script.
     result=$(
         mongodb_execute_print_output "$MONGODB_INITIAL_PRIMARY_ROOT_USER" "$MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD" "admin" "$MONGODB_INITIAL_PRIMARY_HOST" "$MONGODB_INITIAL_PRIMARY_PORT_NUMBER" <<EOF
-rs.conf().members.filter(m => m.host === '$node:$port' && m.votes > 0 && m.priority > 0).length === 1
+print("HAS_VOTES_" + (rs.conf().members.some(m => m.host === '$node:$port' && m.votes > 0 && m.priority > 0) ? "YES" : "NO"))
 EOF
     )
     debug "$result"
 
-    grep -q "true" <<<"$result"
+    grep -q "HAS_VOTES_YES" <<<"$result"
 }
 
 ########################


### PR DESCRIPTION
### Description of the change

`mongodb_secondary_node_has_voting_rights()`, introduced in #95156, matches the mongosh output with `grep -q "true"`:

```bash
result=$(
    mongodb_execute_print_output ... <<EOF
rs.conf().members.filter(m => m.host === '$node:$port' && m.votes > 0 && m.priority > 0).length === 1
EOF
)
grep -q "true" <<<"$result"
```

mongosh always prints a connection banner on **stdout** containing `directConnection=true`, so the grep matches unconditionally and the function can never return false.

Reproduced with mongosh 2.9.2 — the version pinned in the 8.3 Dockerfiles (`mongodb-shell-2.9.2-0-linux-${OS_ARCH}-debian-12`) — reading stdout only and feeding the script on stdin, exactly as `mongodb_execute_print_output` does:

```console
$ mongosh --host nohost.invalid --port 27017 admin 2>/dev/null <<< 'print("x")'
Current Mongosh Log ID: 6a7ddf270f5d3c6ed07e2c0c
Connecting to:          mongodb://nohost.invalid:27017/admin?directConnection=true&appName=mongosh+2.9.2
```

The banner is printed even when the connection fails, so the match does not depend on reaching the server.

As a result `mongodb_configure_secondary()` always takes the `Node already has voting rights` branch and `mongodb_configure_secondary_node_voting()` is never called. Secondaries are added by `rs.add({votes: 0, priority: 0})` and stay there permanently, so only the node that ran `rs.initiate()` ends up holding a vote.

This prints an explicit `HAS_VOTES_YES` / `HAS_VOTES_NO` sentinel and matches on that. The sentinel is concatenated at runtime so the positive value never appears verbatim in the script sent to mongosh. It also uses `.some()` rather than `.filter().length === 1`.

The change is applied to both `bitnami/mongodb` and `bitnami/mongodb-sharded`: their `libmongodb.sh` are byte-identical and both contain the affected function and its call site.

### Benefits

Restores the behaviour #95156 intended but never actually executed — secondaries are granted `votes: 1` / `priority: 1` again instead of remaining at `votes: 0` / `priority: 0` indefinitely.

Verified on a 9-member sharded replica set: with the current code a new secondary joining while a voter slot was free stayed at `votes: 0` (9 members / 6 voters); with this change it is granted `votes: 1` / `priority: 1` (9 members / 7 voters). A member that already has voting rights is still correctly detected and left untouched.

### Possible drawbacks

The grant becomes reachable again, so on a set that has been running with the broken check, members sitting at `votes: 0` will be promoted the next time they go through `mongodb_configure_secondary()` — which only happens when the data directory is empty (fresh volume), not on an ordinary restart.

If the replica set already has MongoDB's maximum of 7 voting members, the reconfiguration is rejected and the script exits, as it did before #95156. That behaviour is pre-existing and deliberately not changed here.

### Applicable issues

None — this is a regression introduced by #95156.

### Additional information

`mongodb_is_secondary_node_ready()`, a few lines above, uses the same `grep -q "true"` pattern and is therefore also always true. It predates #95156, so it is left untouched here to keep this fix focused. It can be addressed separately; note that fixing it is a genuine behaviour change, since the "wait until the node is SECONDARY before granting voting rights" guard would start taking effect.
