### PR TITLE
[bitnami/mongodb, bitnami/mongodb-sharded] Fix secondary readiness check always returning true

### DIFF
--- a/bitnami/mongodb-sharded/8.3/debian-12/rootfs/opt/bitnami/scripts/libmongodb.sh
+++ b/bitnami/mongodb-sharded/8.3/debian-12/rootfs/opt/bitnami/scripts/libmongodb.sh
@@ -902,12 +902,12 @@ mongodb_is_secondary_node_ready() {
     debug "Waiting for the node to be marked as secondary"
     result=$(
         mongodb_execute_print_output "$MONGODB_INITIAL_PRIMARY_ROOT_USER" "$MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD" "admin" "$MONGODB_INITIAL_PRIMARY_HOST" "$MONGODB_INITIAL_PRIMARY_PORT_NUMBER" <<EOF
-rs.status().members.filter(m => m.name === '$node:$port' && m.stateStr === 'SECONDARY').length === 1
+print("IS_SECONDARY_" + (rs.status().members.some(m => m.name === '$node:$port' && m.stateStr === 'SECONDARY') ? "YES" : "NO"))
 EOF
     )
     debug "$result"
 
-    grep -q "true" <<<"$result"
+    grep -q "IS_SECONDARY_YES" <<<"$result"
 }
 
 ########################

--- a/bitnami/mongodb/8.3/debian-12/rootfs/opt/bitnami/scripts/libmongodb.sh
+++ b/bitnami/mongodb/8.3/debian-12/rootfs/opt/bitnami/scripts/libmongodb.sh
@@ -902,12 +902,12 @@ mongodb_is_secondary_node_ready() {
     debug "Waiting for the node to be marked as secondary"
     result=$(
         mongodb_execute_print_output "$MONGODB_INITIAL_PRIMARY_ROOT_USER" "$MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD" "admin" "$MONGODB_INITIAL_PRIMARY_HOST" "$MONGODB_INITIAL_PRIMARY_PORT_NUMBER" <<EOF
-rs.status().members.filter(m => m.name === '$node:$port' && m.stateStr === 'SECONDARY').length === 1
+print("IS_SECONDARY_" + (rs.status().members.some(m => m.name === '$node:$port' && m.stateStr === 'SECONDARY') ? "YES" : "NO"))
 EOF
     )
     debug "$result"
 
-    grep -q "true" <<<"$result"
+    grep -q "IS_SECONDARY_YES" <<<"$result"
 }
 
 ########################


### PR DESCRIPTION
### Description of the change

`mongodb_is_secondary_node_ready()` greps the `mongosh` output for `"true"`, but `mongosh` always prints a connection banner holding `directConnection=true`, so the grep matches unconditionally and the function can never return `false`.

This is the same defect fixed in #96305 for the neighbouring `mongodb_secondary_node_has_voting_rights()`, and the last `grep -q "true"` left in the file.

`mongodb_configure_secondary()` uses this check to wait for a new node to finish its initial sync before granting it voting rights, so today that wait is a no-op and the node is promoted to `votes: 1, priority: 1` while it may still be in `STARTUP2`.

The fix mirrors #96305: print an explicit `IS_SECONDARY_YES` / `IS_SECONDARY_NO` sentinel and match on that.

### Benefits

A joining member is only granted voting rights once `rs.status()` really reports it as `SECONDARY`, as `mongodb_configure_secondary()` intends.

### Possible drawbacks

Secondary bootstrap now actually waits for initial sync, so it can take longer on a node with a large dataset to copy. That is the intended behaviour, bounded by `MONGODB_INIT_RETRY_ATTEMPTS` / `MONGODB_INIT_RETRY_DELAY`.

### Applicable issues

_None._

### Additional information

Follow-up to #95156 and #96305. `bitnami/mongodb` and `bitnami/mongodb-sharded` 8.3 carry an identical `libmongodb.sh`, so the change is applied to both. 7.0, 8.0 and 8.2 no longer ship a `debian-12` tree.
