### PR TITLE
[bitnami/dcgm-exporter] Add dcgm-exporter marketing readme

### DIFF
--- a/bitnami/dcgm-exporter/README.md
+++ b/bitnami/dcgm-exporter/README.md
@@ -1,0 +1,9 @@
+# Bitnami Secure Image for DCGM Exporter
+
+## What is DCGM Exporter?
+
+> DCGM Exporter is a Prometheus exporter that exposes NVIDIA GPU telemetry, health, and profiling metrics collected via NVIDIA DCGM.
+
+[Overview of DCGM Exporter](https://github.com/NVIDIA/dcgm-exporter)
+
+This container image is only available under the [Bitnami Secure Images initiative](https://news.broadcom.com/app-dev/broadcom-introduces-bitnami-secure-images-for-production-ready-containerized-applications).


### PR DESCRIPTION
## Summary
- Adds the public marketing README for the new `dcgm-exporter` container (NVIDIA GPU metrics exporter for Prometheus), matching the standard short-form structure used across the catalog (e.g. `bitnami/headlamp`, `bitnami/headlamp-pluginctl`).

## Test plan
- [ ] Docs-only change, no build required