### PR TITLE
[bitnami/csi-addons-controller] Add csi-addons-controller marketing readme

### DIFF
--- a/bitnami/csi-addons-controller/README.md
+++ b/bitnami/csi-addons-controller/README.md
@@ -1,0 +1,7 @@
+# Bitnami Secure Image for CSI-Addons Controller
+
+## What is CSI-Addons Controller?
+
+> CSI-Addons Controller is a Kubernetes controller that extends CSI drivers with extra storage operations such as network fencing, volume replication, and reclaim space.
+
+This container image is only available under the [Bitnami Secure Images initiative](https://news.broadcom.com/app-dev/broadcom-introduces-bitnami-secure-images-for-production-ready-containerized-applications).


### PR DESCRIPTION
## Summary
- Add a short BSI-only marketing README for `csi-addons-controller`, matching the pattern used for sibling CSI sidecar/controller assets (`csi-external-attacher`, `ceph-csi-operator`).
- Part of the container-only onboarding tracked in https://vmw-jira.broadcom.net/browse/TNZ-144862.

ai-assisted=yes